### PR TITLE
Zugló településrész határok pontosítása

### DIFF
--- a/data/relation-alsorakos.yaml
+++ b/data/relation-alsorakos.yaml
@@ -65,5 +65,8 @@ filters:
   Teleki Blanka utca:
     ranges:
       - {start: '1', end: '15'}
+  Zalán utca:
+    ranges:
+      - {start: '77', end: '81'}
 source: survey
 inactive: false

--- a/data/relation-kiszuglo.yaml
+++ b/data/relation-kiszuglo.yaml
@@ -12,6 +12,10 @@ filters:
     ranges:
       - {start: '1', end: '23'}
       - {start: '2', end: '30'}
+  Bölcsőde utca:
+    ranges: []
+  Emma köz:
+    ranges: []
   Egressy út:
     ranges:
       - {start: '92', end: '112'}
@@ -32,5 +36,9 @@ filters:
   Thököly út:
     ranges:
       - {start: '157', end: '999'}
+  Torontál utca:
+    ranges: []
+  Újvilág utca:
+    ranges: []
 source: survey
 inactive: false

--- a/data/relation-rakosfalva.yaml
+++ b/data/relation-rakosfalva.yaml
@@ -31,5 +31,9 @@ filters:
       - {start: '2', end: '32'}
   Vezér utca:
     ranges: []
+  Zalán utca:
+    ranges:
+      - {start: '1', end: '75'}
+      - {start: '2', end: '66'}
 source: survey
 inactive: false

--- a/data/relation-torokor.yaml
+++ b/data/relation-torokor.yaml
@@ -4,10 +4,14 @@ filters:
     ranges:
       - {start: '1', end: '25'}
       - {start: '2', end: '34'}
+  Bánki Donát utca:
+    ranges: []
   Besnyői utca:
     ranges:
       - {start: '7', end: '15'}
       - {start: '8', end: '12'}
+  Bolgárkertész utca:
+    ranges: []
   Columbus utca:
     ranges:
       - {start: '1', end: '23'}
@@ -30,9 +34,13 @@ filters:
     ranges:
       - {start: '23', end: '23'}
       - {start: '24', end: '26'}
+  Kelevéz utca:
+    ranges: []
   Kerepesi út:
     ranges:
       - {start: '24', end: '58'}
+  Kupa vezér útja:
+    ranges: []
   Mexikói út:
     ranges:
       - {start: '1', end: '47'}


### PR DESCRIPTION
Olyan utcákat is hoznak a kapcsolatok, amik legfeljebb minimálisan lóghatnak át. De az utca és az összes épület a szomszédos városrészhez tartozik.