### PR TITLE
Update relation-budapest_06.yaml

### DIFF
--- a/data/relation-budapest_06.yaml
+++ b/data/relation-budapest_06.yaml
@@ -20,6 +20,9 @@ filters:
   Lehel utca:
     ranges:
       - {start: '1', end: '5'}
+  Munkácsy Mihály utca:
+    # 31-37-ig üres telek (Star Park Podmaniczky utcai parkolója van rajta)
+    invalid: ['31', '33', '35', '37']    
   Váci út:
     ranges:
       - {start: '1', end: '3'}

--- a/data/relation-budapest_06.yaml
+++ b/data/relation-budapest_06.yaml
@@ -22,7 +22,7 @@ filters:
       - {start: '1', end: '5'}
   Munkácsy Mihály utca:
     # 31-37-ig üres telek (Star Park Podmaniczky utcai parkolója van rajta)
-    invalid: ['31', '33', '35', '37']    
+    invalid: ['31', '33', '35', '37']
   Váci út:
     ranges:
       - {start: '1', end: '3'}


### PR DESCRIPTION
Budapest 6., Munkácsi Mihály utcában nem fellelhető házszámok kizárása.