### PR TITLE
data: add overpass query to get all settlements in Hungary

### DIFF
--- a/data/settlements-hungary.txt
+++ b/data/settlements-hungary.txt
@@ -1,0 +1,6 @@
+[out:csv(::type, ::id, name)] [timeout:425];
+area(3600021335)->.searchArea;
+(
+  relation["boundary"="administrative"]["admin_level"="8"](area.searchArea);
+);
+out;


### PR DESCRIPTION
It did not find anything missing on OSM, so let's stop here. Once it
would find something, we could have a page like
/osm/housenumber-stats/hungary/missing-settlements to list the missing
settlements.

Change-Id: Iade0b6d27ec81bab87f33e51d6e3209b6fd26fc5
