### PR TITLE
parse_access_log.py: take relation edit activity into account

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ pylint==2.6.0
 python-dateutil==2.8.1
 pytz==2020.1
 pyyaml==5.3.1
+unidecode==1.1.1
 yamllint==1.25.0
 yattag==1.14.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ license_file = LICENSE
 max-line-length = 120
 # W504 is the newer, W503 is the older style.
 ignore = W503
+
+[mypy-unidecode.*]
+ignore_missing_imports = True

--- a/stats.py
+++ b/stats.py
@@ -53,10 +53,9 @@ def handle_topusers(src_root: str, j: Dict[str, Any]) -> None:
     j["topusers"] = ret
 
 
-def handle_topcities(src_root: str, j: Dict[str, Any]) -> None:
+def get_topcities(src_root: str) -> List[Tuple[str, int]]:
     """
-    Generates stats for top cities.
-    This lists the top 20 cities which got lots of new house numbers in the past 30 days.
+    Generates a list of cities, sorted by how many new hours numbers they got recently.
     """
     ret = []
     new_day = datetime.date.today().strftime("%Y-%m-%d")
@@ -81,6 +80,15 @@ def handle_topcities(src_root: str, j: Dict[str, Any]) -> None:
             if count and city in old_counts:
                 counts.append((city, int(count) - old_counts[city]))
     ret = sorted(counts, key=lambda x: x[1], reverse=True)
+    return ret
+
+
+def handle_topcities(src_root: str, j: Dict[str, Any]) -> None:
+    """
+    Generates stats for top cities.
+    This lists the top 20 cities which got lots of new house numbers in the past 30 days.
+    """
+    ret = get_topcities(src_root)
     ret = ret[:20]
     j["topcities"] = ret
 


### PR DESCRIPTION
1) Top 5 (most edited) relations are frequent, even without visitors.

2) If a relation got less than 5 new house numbers in the last 30 days,
then the relation is not frequent, even with lots of visitors.

Change-Id: I8b46268f9cb9ca98855e6af8aa794051dbf40ae4
