### PR TITLE
Add initial reverse street compare

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,14 @@ PYTHON_SAFE_OBJECTS = \
 	webframe.py \
 	wsgi.py \
 
+# These have bad coverage.
+PYTHON_UNSAFE_OBJECTS = \
+	additional_streets.py \
+
 PYTHON_OBJECTS = \
 	$(PYTHON_TEST_OBJECTS) \
 	$(PYTHON_SAFE_OBJECTS) \
+	$(PYTHON_UNSAFE_OBJECTS) \
 
 # These are valid.
 YAML_SAFE_OBJECTS = \

--- a/additional_streets.py
+++ b/additional_streets.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+#
+# Copyright 2020 Miklos Vajna. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+
+"""Compares OSM streets with reference ones and shows the diff."""
+
+import sys
+
+import areas
+import config
+
+
+def main() -> None:
+    """Commandline interface."""
+    workdir = config.Config.get_workdir()
+
+    relation_name = sys.argv[1]
+
+    relations = areas.Relations(workdir)
+    relation = relations.get_relation(relation_name)
+    only_in_osm, _ = relation.get_additional_streets()
+
+    for street in only_in_osm:
+        print(street)
+
+
+if __name__ == '__main__':
+    main()
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -535,6 +535,20 @@ class TestRelationGetMissingStreets(test_config.TestCase):
         self.assertEqual(in_both, ['Hamzsabégi út', 'Ref Name 1', 'Törökugrató utca', 'Tűzkő utca'])
 
 
+class TestRelationGetAdditionalStreets(test_config.TestCase):
+    """Tests Relation.get_additional_streets()."""
+    def test_happy(self) -> None:
+        """Tests the happy path."""
+        relations = get_relations()
+        relation_name = "gazdagret"
+        relation = relations.get_relation(relation_name)
+        only_in_osm, in_both = relation.get_additional_streets()
+
+        self.assertEqual(only_in_osm, ['OSM Name 1', 'Only In OSM utca'])
+
+        self.assertEqual(in_both, ['Hamzsabégi út', 'Törökugrató utca', 'Tűzkő utca'])
+
+
 def table_doc_to_string(table: List[List[yattag.doc.Doc]]) -> List[List[str]]:
     """Unwraps an escaped matrix of yattag documents into a string matrix."""
     table_content = []
@@ -680,7 +694,7 @@ class TestRelationBuildRefStreets(unittest.TestCase):
         relation_name = "gazdagret"
         relations = get_relations()
         relation = relations.get_relation(relation_name)
-        ret = relation.build_ref_streets(memory_cache)
+        ret = relation.get_config().build_ref_streets(memory_cache)
         self.assertEqual(ret, ['Törökugrató utca',
                                'Tűzkő utca',
                                'Ref Name 1',


### PR DESCRIPTION
Just a cmdline tool so far, and not yet possible to silence false alarms.

Also move build_ref_streets() to RelationConfig before Relation grows
too large.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/611>.

Change-Id: I7a424b90d44dd85ac0c688ff2017975e11b30ee3
