### PR TITLE
refstreets: enforce that this is a 1:1 mapping

### DIFF
--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -148,7 +148,9 @@ frequently:
 
 - `refstreets`: this key can be used in the root of a relation file, it's used to describe street
   name mappings, in case the OSM name and reference name differs and the OSM one is the correct
-  name.
+  name. The key is the OSM name and the value is the reference name. It's not valid to map multiple
+  OSM names to the same reference name, so this has to be a 1:1 mapping. This makes it possible to
+  map both ways using the same markup.
 
 - `refsettlement`: this key can be used for a street. In case the majority of a relation has a given
   `refsettlement` value, but there are a few exceptions, then you can use this markup to override the

--- a/tests/data/relation-gazdagret-refstreets-bad-map.yaml
+++ b/tests/data/relation-gazdagret-refstreets-bad-map.yaml
@@ -1,0 +1,4 @@
+refstreets:
+  'OSM Name 1': "Ref Name 1"
+  # maps to the same ref name
+  'OSM Name 2': "Ref Name 1"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -249,6 +249,12 @@ class TestValidatorMainFailureMsg2(TestValidatorMainFailureMsgBase):
         expected += ": expected value type for 'filters.Hamzsabégi út.show-refstreet' is bool\n"
         self.assert_failure_msg("tests/data/relation-gazdagret-filter-show-refstreet-bad.yaml", expected)
 
+    def test_relation_refstreets_bad_map_type(self) -> None:
+        """Tests the relation path: bad refstreets map, not 1:1."""
+        expected = "failed to validate tests/data/relation-gazdagret-refstreets-bad-map.yaml"
+        expected += ": osm and ref streets are not a 1:1 mapping in 'refstreets.'\n"
+        self.assert_failure_msg("tests/data/relation-gazdagret-refstreets-bad-map.yaml", expected)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/validator.py
+++ b/validator.py
@@ -133,6 +133,9 @@ def validate_refstreets(errors: List[str], parent: str, refstreets: Dict[str, An
             errors.append("expected no quotes in '%s%s'" % (context, key))
         if "'" in value or "\"" in value:
             errors.append("expected no quotes in value of '%s%s'" % (context, key))
+    reverse = {v: k for k, v in refstreets.items()}
+    if len(refstreets) != len(reverse):
+        errors.append("osm and ref streets are not a 1:1 mapping in '%s'" % context)
 
 
 def validate_street_filters(errors: List[str], parent: str, street_filters: List[Any]) -> None:


### PR DESCRIPTION
So it can be used for mapping ref names to osm names as well in the
future. The markup allowed mapping multiple osm names to the same ref
name in the past.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/611>.

Change-Id: I354ca286a17b5ea833dd4f9984793940be317530
