### PR TITLE
additional streets: add initial web endpoint

### DIFF
--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -560,6 +560,47 @@ class TestMissingStreets(TestWsgi):
         self.assertNotIn("OSM Name 2", cast(Container[Any], results[0].text))
 
 
+class TestAdditionalStreets(TestWsgi):
+    """Tests the additional streets page."""
+    def test_well_formed(self) -> None:
+        """Tests if the output is well-formed."""
+        root = self.get_dom_for_path("/additional-streets/gazdagret/view-result")
+        results = root.findall("body/table")
+        self.assertEqual(len(results), 1)
+
+    def test_no_osm_streets_well_formed(self) -> None:
+        """Tests if the output is well-formed, no osm streets case."""
+        relations = get_relations()
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_streets_path()
+        real_exists = os.path.exists
+
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/additional-streets/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-osm-streets']")
+            self.assertEqual(len(results), 1)
+
+    def test_no_ref_streets_well_formed(self) -> None:
+        """Tests if the output is well-formed, no ref streets case."""
+        relations = get_relations()
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_ref_streets_path()
+        real_exists = os.path.exists
+
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/additional-streets/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-ref-streets']")
+            self.assertEqual(len(results), 1)
+
+
 class TestMain(TestWsgi):
     """Tests handle_main()."""
     def test_well_formed(self) -> None:

--- a/webframe.py
+++ b/webframe.py
@@ -70,7 +70,7 @@ def fill_header_function(function: str, relation_name: str, items: List[yattag.d
         with doc.tag("a", href=prefix + "/missing-housenumbers/" + relation_name + "/update-result"):
             doc.text(_("Update from reference"))
         items.append(doc)
-    elif function == "missing-streets":
+    elif function in ("missing-streets", "additional-streets"):
         # The OSM data source changes much more frequently than the ref one, so add a dedicated link
         # to update OSM streets first.
         doc = yattag.doc.Doc()
@@ -467,6 +467,7 @@ def check_existing_relation(relations: areas.Relations, request_uri: str) -> yat
     prefix = config.Config.get_uri_prefix()
     if not request_uri.startswith(prefix + "/streets/") \
             and not request_uri.startswith(prefix + "/missing-streets/") \
+            and not request_uri.startswith(prefix + "/additional-streets/") \
             and not request_uri.startswith(prefix + "/street-housenumbers/") \
             and not request_uri.startswith(prefix + "/missing-housenumbers/"):
         return doc


### PR DESCRIPTION
So that manually visiting e.g.
/osm/additional-streets/budapest_12/view-result gives the result.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/611>.

Change-Id: Ib4cfe5f6bd98c7aee2ced6814a9237e759163e15
