### PR TITLE
Allow web-testing a relation without mentioning in tests/data/relations.yaml

### DIFF
--- a/tests/data/relations.yaml
+++ b/tests/data/relations.yaml
@@ -43,7 +43,3 @@ budafok:
     osmrelation: 42
     refcounty: "43"
     refsettlement: "44"
-gh611:
-    osmrelation: 2713748
-    refcounty: "01"
-    refsettlement: "011"

--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -777,7 +777,6 @@ class TestRelations(test_config.TestCase):
             "empty",
             "gazdagret",
             "gellerthegy",
-            "gh611",
             "inactiverelation",
             "nosuchrefcounty",
             "nosuchrefsettlement",
@@ -788,7 +787,7 @@ class TestRelations(test_config.TestCase):
         self.assertEqual(relations.get_names(), expected_relation_names)
         self.assertTrue("inactiverelation" not in relations.get_active_names())
         osmids = sorted([relation.get_config().get_osmrelation() for relation in relations.get_relations()])
-        self.assertEqual([13, 42, 42, 43, 44, 45, 66, 221998, 2702687, 2713748, 2713748], osmids)
+        self.assertEqual([13, 42, 42, 43, 44, 45, 66, 221998, 2702687, 2713748], osmids)
         self.assertEqual("only", relations.get_relation("ujbuda").get_config().should_check_missing_streets())
 
         relations.activate_all(True)

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -570,7 +570,10 @@ class TestAdditionalStreets(TestWsgi):
 
     def test_street_from_housenr_well_formed(self) -> None:
         """Tests if the output is well-formed when the street name comes from a housenr."""
-        root = self.get_dom_for_path("/additional-streets/gh611/view-result")
+        def mock_check_existing_relation(_relations: areas.Relations, _request_uri: str) -> yattag.doc.Doc:
+            return yattag.doc.Doc()
+        with unittest.mock.patch('webframe.check_existing_relation', mock_check_existing_relation):
+            root = self.get_dom_for_path("/additional-streets/gh611/view-result")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
 


### PR DESCRIPTION
So that adding a new relation has no effect on existing tests.

Change-Id: I73de2c1fc0a1b57e0c01c1706ebf666a878994c5
