### PR TITLE
get_osm_streets: ignore empty street name from house number list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ check-filters-schema: $(patsubst %.yaml,%.validyaml,$(YAML_SAFE_OBJECTS))
 
 # Make sure that the current directory is *not* the repo root but something else to catch
 # non-absolute paths.
-server:
+run:
 	cd $(HOME) && $(PWD)/wsgi.py
 
 deploy:

--- a/areas.py
+++ b/areas.py
@@ -354,7 +354,8 @@ class Relation:
                 ret.append(util.Street(osm_id=int(row[0]), osm_name=row[1]))
         if os.path.exists(self.get_files().get_osm_housenumbers_path()):
             with self.get_files().get_osm_housenumbers_csv_stream() as sock:
-                ret += [util.Street(i) for i in util.get_nth_column(sock, 1)]
+                # Street name of house numbers without street name is not interesting.
+                ret += [util.Street(i) for i in util.get_nth_column(sock, 1) if i]
         return sorted(set(ret))
 
     def get_osm_streets_query(self) -> str:


### PR DESCRIPTION
Overpass already filters out empty street name from streets, this does
the same for house numbers.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/611>.

Change-Id: If85925e9bc7b6167b134029e2be41089f1950b97
