### PR TITLE
cache_yamls: create a json that contains all the osm relation IDs we track

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,11 +99,11 @@ version.py: .git/$(shell git symbolic-ref HEAD) Makefile
 	$(file > $@,"""The version module allows tracking the last reload of the app server.""")
 	$(file >> $@,VERSION = '$(shell git describe --tags)')
 
-data/yamls.pickle: $(YAML_OBJECTS)
-	./cache_yamls.py data
+data/yamls.pickle: cache_yamls.py $(YAML_OBJECTS)
+	./cache_yamls.py data workdir
 
-tests/data/yamls.pickle: $(YAML_TEST_OBJECTS)
-	./cache_yamls.py tests/data
+tests/data/yamls.pickle: cache_yamls.py $(YAML_TEST_OBJECTS)
+	./cache_yamls.py tests/data tests/workdir
 
 check-filters: check-filters-syntax check-filters-schema
 

--- a/cache_yamls.py
+++ b/cache_yamls.py
@@ -10,6 +10,7 @@
 from typing import Any
 from typing import Dict
 import glob
+import json
 import os
 import pickle
 import sys
@@ -31,6 +32,19 @@ def main() -> None:
     cache_path = os.path.join(datadir, "yamls.pickle")
     with open(cache_path, "wb") as cache_stream:
         pickle.dump(cache, cache_stream)
+
+    workdir = config.get_abspath(sys.argv[2])
+    yaml_path = os.path.join(datadir, "relations.yaml")
+    relation_ids = []
+    with open(yaml_path) as stream:
+        relations = yaml.safe_load(stream)
+        for _key, value in relations.items():
+            relation_ids.append(value["osmrelation"])
+    relation_ids = sorted(set(relation_ids))
+    statsdir = os.path.join(workdir, "stats")
+    os.makedirs(statsdir, exist_ok=True)
+    with open(os.path.join(statsdir, "relations.json"), "w") as stream:
+        json.dump(relation_ids, stream)
 
 
 if __name__ == "__main__":

--- a/tests/test_cache_yamls.py
+++ b/tests/test_cache_yamls.py
@@ -6,13 +6,16 @@
 
 """The test_cache_yamls module covers the cache_yamls module."""
 
+import json
 import os
 import unittest
 import unittest.mock
 
 import test_config
 
+import areas
 import cache_yamls
+import config
 
 
 class TestMain(test_config.TestCase):
@@ -22,12 +25,20 @@ class TestMain(test_config.TestCase):
         cache_path = "tests/data/yamls.pickle"
         if os.path.exists(cache_path):
             os.remove(cache_path)
-        argv = ["", "data"]
+        argv = ["", "data", "workdir"]
         with unittest.mock.patch('sys.argv', argv):
             cache_yamls.main()
         # Just assert that the result is created, the actual content is validated by the other
         # tests.
         self.assertTrue(os.path.exists(cache_path))
+
+        relation_ids_path = "tests/workdir/stats/relations.json"
+        relation_ids = []
+        with open(relation_ids_path) as stream:
+            relation_ids = json.load(stream)
+        relations = areas.Relations(config.Config.get_workdir())
+        osmids = sorted([relation.get_config().get_osmrelation() for relation in relations.get_relations()])
+        self.assertEqual(relation_ids, sorted(set(osmids)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Related to <https://github.com/vmiklos/osm-gimmisn/issues/690>.

Change-Id: Id43f686a4320f7d977e987e132821e91dc6b4bba
