### PR TITLE
filter-based-on-position: avoid 'TypeError: gps is null'

### DIFF
--- a/static/osm.js
+++ b/static/osm.js
@@ -101,6 +101,11 @@ async function onGpsClick()
 // eslint-disable-next-line no-unused-vars
 document.addEventListener("DOMContentLoaded", async function(event) {
     let gps = document.querySelector("#filter-based-on-position");
+    if (!gps)
+    {
+        return;
+    }
+
     let gpsLink = gps.childNodes[0];
     gpsLink.onclick = onGpsClick;
 });


### PR DESCRIPTION
When this is not the main page.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/690>.

Change-Id: Ie0cdbbda115e4746bdac9465ce7a143b4c3ab905
