### PR TITLE
webrame: refactor to stop preprocessing js files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ YAML_TEST_OBJECTS = \
 JS_OBJECTS = \
 	static/osm.js \
 	static/stats.js \
+	config.js \
 
 ifndef V
 	QUIET_FLAKE8 = @echo '   ' FLAKE8 $@;
@@ -83,10 +84,10 @@ ifndef V
 	QUIET_YAMLLINT = @echo '   ' YAMLLINT $@;
 endif
 
-all: version.py wsgi.ini data/yamls.pickle locale/hu/LC_MESSAGES/osm-gimmisn.mo
+all: version.py config.js wsgi.ini data/yamls.pickle locale/hu/LC_MESSAGES/osm-gimmisn.mo
 
 clean:
-	rm -f version.py
+	rm -f version.py config.js
 	rm -f $(patsubst %.yaml,%.yamllint,$(filter-out .github/workflows/tests.yml,$(YAML_OBJECTS)))
 	rm -f $(patsubst %.yaml,%.validyaml,$(YAML_SAFE_OBJECTS))
 	rm -f $(patsubst %.py,%.flake8,$(PYTHON_OBJECTS))
@@ -99,6 +100,9 @@ check: all check-filters check-flake8 check-mypy check-unit check-pylint check-e
 version.py: .git/$(shell git symbolic-ref HEAD) Makefile
 	$(file > $@,"""The version module allows tracking the last reload of the app server.""")
 	$(file >> $@,VERSION = '$(shell git describe --tags)')
+
+config.js: wsgi.ini Makefile
+	printf '// eslint-disable-next-line no-unused-vars\nvar osmPrefix = "%s";' $(shell grep prefix wsgi.ini |sed 's/uri_prefix = //') > $@
 
 # Intentionally don't update this when the source changes.
 wsgi.ini:

--- a/static/osm.js
+++ b/static/osm.js
@@ -4,6 +4,8 @@
  * found in the LICENSE file.
  */
 
+/* global osmPrefix */
+
 function getOsmString(key) {
     return document.getElementById(key).getAttribute("data-value");
 }
@@ -68,7 +70,7 @@ async function onGpsClick()
     }
 
     // Now fetch the list of relations we recognize.
-    url = "@PREFIX@/static/relations.json";
+    url = osmPrefix + "/static/relations.json";
     request = new Request(url);
     gps.textContent = getOsmString("str-relations-wait");
     var knownRelations = null;
@@ -98,7 +100,7 @@ async function onGpsClick()
 
     // Redirect.
     gps.textContent = getOsmString("str-redirect-wait");
-    url = "@PREFIX@/filter-for/relations/" + knownRelationIds.join(",");
+    url = osmPrefix + "/filter-for/relations/" + knownRelationIds.join(",");
     window.location.href = url;
 }
 

--- a/static/stats.js
+++ b/static/stats.js
@@ -4,7 +4,7 @@
  * found in the LICENSE file.
  */
 
-/* global Chart */
+/* global osmPrefix Chart */
 
 function getString(key) {
     return document.getElementById(key).getAttribute("data-value");
@@ -421,7 +421,7 @@ function addCharts(stats) {
 
 // eslint-disable-next-line no-unused-vars
 document.addEventListener("DOMContentLoaded", async function(event) {
-    var statsJSON = "@PREFIX@/static/stats.json";
+    var statsJSON = osmPrefix + "/static/stats.json";
     var response = await window.fetch(statsJSON);
     var stats = await response.json();
     addCharts(stats);

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,0 +1,1 @@
+// config.js

--- a/tests/test_webframe.py
+++ b/tests/test_webframe.py
@@ -44,6 +44,13 @@ class TestHandleStatic(test_config.TestCase):
         self.assertTrue(len(content))
         self.assertEqual(content_type, "application/x-javascript")
 
+    def test_generated_javascript(self) -> None:
+        """Tests the generated javascript case."""
+        prefix = config.Config.get_uri_prefix()
+        content, content_type = webframe.handle_static(prefix + "/static/config.js")
+        self.assertEqual("// config.js\n", content)
+        self.assertEqual(content_type, "application/x-javascript")
+
     def test_json(self) -> None:
         """Tests the json case."""
         prefix = config.Config.get_uri_prefix()

--- a/webframe.py
+++ b/webframe.py
@@ -221,9 +221,10 @@ def handle_static(request_uri: str) -> Tuple[str, str]:
         content_type = "application/json"
 
     if path.endswith(".js") or path.endswith(".css"):
-        prefix = config.Config.get_uri_prefix()
-        template = util.get_content(config.get_abspath("static"), path)
-        content = template.replace("@PREFIX@", prefix)
+        if os.path.exists(os.path.join(config.get_abspath("static"), path)):
+            content = util.get_content(config.get_abspath("static"), path)
+        else:
+            content = util.get_content(config.get_abspath(""), path)
         return content, content_type
     if path.endswith(".json"):
         return util.get_content(os.path.join(config.Config.get_workdir(), "stats"), path), content_type

--- a/wsgi.py
+++ b/wsgi.py
@@ -844,6 +844,8 @@ def write_html_head(doc: yattag.doc.Doc, title: str) -> None:
             doc.text(_("Where to map?") + title)
         doc.stag("meta", charset="UTF-8")
         doc.stag("link", rel="stylesheet", type="text/css", href=prefix + "/static/osm.css")
+        with doc.tag("script", src=prefix + "/static/config.js"):
+            pass
         with doc.tag("script", src=prefix + "/static/osm.js"):
             pass
         with doc.tag("script", src=prefix + "/static/sorttable.js"):


### PR DESCRIPTION
Provide a config.js instead, so the rest of the files can be served
as-is. Otherwise file offsets don't match in the filesystem and in the
browser which makes debugging harder than necessary.

Change-Id: Ie4778c8e8053b23412d6d5eaf8423c972cfc4239
