### PR TITLE
js: merge config.js, osm.js and stats.js into a single bundle.js

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,7 @@
     "env": {
         "browser": true,
         "es2017": true,
+        "node": true,
     },
     "extends": "eslint:recommended",
     "parserOptions": {

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -36,6 +36,17 @@ the tests mocking that single function.
 for i in *.py; do lines=$(wc -l < $i); if [ $lines -gt 800 ]; then echo "$i is too large: $lines lines"; fi; done
 ----
 
+== JS debugging
+
+Bundled JS can be minified (for production) and also source maps can be added (for debugging). The
+default output is for production, but touching a JS source file and invoking:
+
+----
+make JSDEBUG=1
+----
+
+produces output that is for debugging.
+
 == Checklist
 
 Ideally CI checks everything before a commit hits master, but here are a few

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -39,7 +39,6 @@ This makes sure that you will have exactly the same version of the depdendencies
 
 ----
 pip install -r requirements.txt
-npm install
 ----
 
 - Build the generated code and data:

--- a/osm.js
+++ b/osm.js
@@ -4,7 +4,7 @@
  * found in the LICENSE file.
  */
 
-/* global osmPrefix */
+var config = require("./config.js");
 
 function getOsmString(key) {
     return document.getElementById(key).getAttribute("data-value");
@@ -70,7 +70,7 @@ async function onGpsClick()
     }
 
     // Now fetch the list of relations we recognize.
-    url = osmPrefix + "/static/relations.json";
+    url = config.uriPrefix + "/static/relations.json";
     request = new Request(url);
     gps.textContent = getOsmString("str-relations-wait");
     var knownRelations = null;
@@ -100,7 +100,7 @@ async function onGpsClick()
 
     // Redirect.
     gps.textContent = getOsmString("str-redirect-wait");
-    url = osmPrefix + "/filter-for/relations/" + knownRelationIds.join(",");
+    url = config.uriPrefix + "/filter-for/relations/" + knownRelationIds.join(",");
     window.location.href = url;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "license": "MIT",
   "dependencies": {
-    "eslint": "7.14.0"
+    "browserify": "17.0.0",
+    "eslint": "7.14.0",
+    "tinyify": "3.0.0"
   },
   "repository": {
     "type": "git",

--- a/stats.js
+++ b/stats.js
@@ -4,7 +4,9 @@
  * found in the LICENSE file.
  */
 
-/* global osmPrefix Chart */
+/* global Chart */
+
+var config = require("./config.js");
 
 function getString(key) {
     return document.getElementById(key).getAttribute("data-value");
@@ -421,7 +423,12 @@ function addCharts(stats) {
 
 // eslint-disable-next-line no-unused-vars
 document.addEventListener("DOMContentLoaded", async function(event) {
-    var statsJSON = osmPrefix + "/static/stats.json";
+    if (!document.getElementById("daily")) {
+        // Not on the stats page.
+        return;
+    }
+
+    var statsJSON = config.uriPrefix + "/static/stats.json";
     var response = await window.fetch(statsJSON);
     var stats = await response.json();
     addCharts(stats);

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,1 +1,0 @@
-// config.js

--- a/tests/test_webframe.py
+++ b/tests/test_webframe.py
@@ -47,8 +47,8 @@ class TestHandleStatic(test_config.TestCase):
     def test_generated_javascript(self) -> None:
         """Tests the generated javascript case."""
         prefix = config.Config.get_uri_prefix()
-        content, content_type = webframe.handle_static(prefix + "/static/config.js")
-        self.assertEqual("// config.js\n", content)
+        content, content_type = webframe.handle_static(prefix + "/static/bundle.js")
+        self.assertEqual("// bundle.js\n", content)
         self.assertEqual(content_type, "application/x-javascript")
 
     def test_json(self) -> None:

--- a/tests/workdir/bundle.js
+++ b/tests/workdir/bundle.js
@@ -1,0 +1,1 @@
+// bundle.js

--- a/webframe.py
+++ b/webframe.py
@@ -224,7 +224,7 @@ def handle_static(request_uri: str) -> Tuple[str, str]:
         if os.path.exists(os.path.join(config.get_abspath("static"), path)):
             content = util.get_content(config.get_abspath("static"), path)
         else:
-            content = util.get_content(config.get_abspath(""), path)
+            content = util.get_content(config.Config.get_workdir(), path)
         return content, content_type
     if path.endswith(".json"):
         return util.get_content(os.path.join(config.Config.get_workdir(), "stats"), path), content_type
@@ -353,8 +353,6 @@ def handle_stats(relations: areas.Relations, request_uri: str) -> yattag.doc.Doc
     with doc.tag("script", src=prefix + "/static/chartjs-plugin-datalabels.min.js"):
         pass
     with doc.tag("script", src=prefix + "/static/chartjs-plugin-trendline.min.js"):
-        pass
-    with doc.tag("script", src=prefix + "/static/stats.js"):
         pass
 
     # Emit localized strings for JS purposes.

--- a/wsgi.py
+++ b/wsgi.py
@@ -844,9 +844,7 @@ def write_html_head(doc: yattag.doc.Doc, title: str) -> None:
             doc.text(_("Where to map?") + title)
         doc.stag("meta", charset="UTF-8")
         doc.stag("link", rel="stylesheet", type="text/css", href=prefix + "/static/osm.css")
-        with doc.tag("script", src=prefix + "/static/config.js"):
-            pass
-        with doc.tag("script", src=prefix + "/static/osm.js"):
+        with doc.tag("script", src=prefix + "/static/bundle.js"):
             pass
         with doc.tag("script", src=prefix + "/static/sorttable.js"):
             pass


### PR DESCRIPTION
So that the stats page only loads 5 .js files, not 7.

The end goal is to load just a single one, and then the ability to move
to typescript.

Change-Id: Id058516673c0b889038dd3c5b863dcec5f229b54
