### PR TITLE
webframe: drop support for serving js from git

### DIFF
--- a/tests/static/sorttable.js
+++ b/tests/static/sorttable.js
@@ -1,3 +1,0 @@
-/*
-  SortTable
-*/

--- a/tests/test_webframe.py
+++ b/tests/test_webframe.py
@@ -37,13 +37,6 @@ class TestHandleStatic(test_config.TestCase):
         self.assertTrue(len(content))
         self.assertEqual(content_type, "text/css")
 
-    def test_javascript(self) -> None:
-        """Tests the javascript case."""
-        prefix = config.Config.get_uri_prefix()
-        content, content_type = webframe.handle_static(prefix + "/static/sorttable.js")
-        self.assertTrue(len(content))
-        self.assertEqual(content_type, "application/x-javascript")
-
     def test_generated_javascript(self) -> None:
         """Tests the generated javascript case."""
         prefix = config.Config.get_uri_prefix()

--- a/webframe.py
+++ b/webframe.py
@@ -215,18 +215,14 @@ def handle_static(request_uri: str) -> Tuple[str, str]:
 
     if request_uri.endswith(".js"):
         content_type = "application/x-javascript"
-    elif request_uri.endswith(".css"):
-        content_type = "text/css"
-    elif request_uri.endswith(".json"):
-        content_type = "application/json"
-
-    if path.endswith(".js") or path.endswith(".css"):
-        if os.path.exists(os.path.join(config.get_abspath("static"), path)):
-            content = util.get_content(config.get_abspath("static"), path)
-        else:
-            content = util.get_content(config.Config.get_workdir(), path)
+        content = util.get_content(config.Config.get_workdir(), path)
         return content, content_type
-    if path.endswith(".json"):
+    if request_uri.endswith(".css"):
+        content_type = "text/css"
+        content = util.get_content(config.get_abspath("static"), path)
+        return content, content_type
+    if request_uri.endswith(".json"):
+        content_type = "application/json"
         return util.get_content(os.path.join(config.Config.get_workdir(), "stats"), path), content_type
 
     return "", ""


### PR DESCRIPTION
All js is bundled and served from workdir, so the serve-from-git code is
no longer needed, reducing complexity.

Change-Id: I6c9d136306a0070e3a0556a6c2bb8ec78e7e1f38
