### PR TITLE
get_osm_streets: ignore house-number-less house numbers

### DIFF
--- a/areas.py
+++ b/areas.py
@@ -363,7 +363,7 @@ class Relation:
         if os.path.exists(self.get_files().get_osm_housenumbers_path()):
             with self.get_files().get_osm_housenumbers_csv_stream() as sock:
                 # Street name of house numbers without street name is not interesting.
-                ret += [util.Street(i) for i in util.get_nth_column(sock, 1) if i]
+                ret += [util.Street(i) for i in util.get_nth_column(sock, 1, 2) if i]
         return sorted(set(ret))
 
     def get_osm_streets_query(self) -> str:

--- a/tests/workdir/street-housenumbers-test.csv
+++ b/tests/workdir/street-housenumbers-test.csv
@@ -1,4 +1,6 @@
-HA3	HB3
-HA2	HB2
-HA1	HB1
-Bogus
+HA3	HB3	HC3
+HA2	HB2	HC2
+HA1	HB1	HC1
+Bogus1
+Bogus	2
+Bogus	3	

--- a/util.py
+++ b/util.py
@@ -559,7 +559,7 @@ def tsv_to_list(stream: CsvIO) -> List[List[yattag.doc.Doc]]:
     return table
 
 
-def get_nth_column(sock: CsvIO, column: int) -> List[str]:
+def get_nth_column(sock: CsvIO, street_column: int, housenumber_column: int) -> List[str]:
     """Reads the content from sock, interprets its content as tab-separated values, finally returns
     the values of the nth column. If a row has less columns, that's silently ignored."""
     ret = []
@@ -570,10 +570,10 @@ def get_nth_column(sock: CsvIO, column: int) -> List[str]:
             first = False
             continue
 
-        if len(row) < column + 1:
+        if len(row) < street_column + 1 or len(row) < housenumber_column + 1 or not row[housenumber_column]:
             continue
 
-        ret.append(row[column])
+        ret.append(row[street_column])
 
     return ret
 


### PR DESCRIPTION
Normally we take osm streets, then also check osm housenumbers, in case
a house number would mention some street name which has no matching way.

Disable this mechanism for house numbers where there is only a street,
but no actual house number.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/754>.

Change-Id: I3c5237075389d698831c068bffff0a070dcaa084
