### PR TITLE
wsgi: add a /streets/.../update-result.json endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ PYTHON_TEST_OBJECTS = \
 	tests/test_validator.py \
 	tests/test_webframe.py \
 	tests/test_wsgi.py \
+	tests/test_wsgi_json.py \
 
 # These have good coverage.
 PYTHON_SAFE_OBJECTS = \
@@ -41,6 +42,7 @@ PYTHON_SAFE_OBJECTS = \
 	version.py \
 	webframe.py \
 	wsgi.py \
+	wsgi_json.py \
 
 # These have bad coverage.
 PYTHON_UNSAFE_OBJECTS = \

--- a/tests/test_wsgi_json.py
+++ b/tests/test_wsgi_json.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2020 Miklos Vajna and contributors.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""The test_wsgi_json module covers the wsgi_json module."""
+
+from typing import Any
+from typing import BinaryIO
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import TYPE_CHECKING
+from typing import Tuple
+from typing import cast
+import io
+import json
+import os
+import unittest
+import unittest.mock
+import urllib.error
+
+import test_config
+
+import areas
+import config
+import wsgi
+
+if TYPE_CHECKING:
+    # pylint: disable=no-name-in-module,import-error,unused-import
+    from wsgiref.types import StartResponse
+
+
+def get_relations() -> areas.Relations:
+    """Returns a Relations object that uses the test data and workdir."""
+    workdir = os.path.join(os.path.dirname(__file__), "workdir")
+    return areas.Relations(workdir)
+
+
+class TestWsgiJson(test_config.TestCase):
+    """Base class for wsgi_json tests."""
+
+    def get_json_for_path(self, path: str) -> Dict[str, Any]:
+        """Generates an json dict for a given wsgi path."""
+        def start_response(status: str, response_headers: List[Tuple[str, str]]) -> None:
+            # Make sure the built-in exception catcher is not kicking in.
+            self.assertEqual(status, "200 OK")
+            header_dict = dict(response_headers)
+            self.assertEqual(header_dict["Content-type"], "application/json; charset=utf-8")
+
+        prefix = config.Config.get_uri_prefix()
+        environ = {
+            "PATH_INFO": prefix + path
+        }
+        callback = cast('StartResponse', start_response)
+        output_iterable = wsgi.application(environ, callback)
+        output_list = cast(List[bytes], output_iterable)
+        self.assertTrue(output_list)
+        output = output_list[0].decode('utf-8')
+        return cast(Dict[str, Any], json.loads(output))
+
+
+class TestJsonStreets(TestWsgiJson):
+    """Tests streets_update_result_json()."""
+    def test_update_result_json(self) -> None:
+        """Tests if the update-result json output is well-formed."""
+        result_from_overpass = "@id\tname\n1\tTűzkő utca\n2\tTörökugrató utca\n3\tOSM Name 1\n4\tHamzsabégi út\n"
+
+        def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
+            buf = io.BytesIO()
+            buf.write(result_from_overpass.encode('utf-8'))
+            buf.seek(0)
+            return buf
+        with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
+            root = self.get_json_for_path("/streets/gazdagret/update-result.json")
+            self.assertEqual(root["error"], "")
+
+    def test_update_result_json_error(self) -> None:
+        """Tests if the update-result json output on error is well-formed."""
+
+        def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
+            raise urllib.error.HTTPError(url="", code=0, msg="", hdrs={}, fp=io.BytesIO())
+        with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
+            root = self.get_json_for_path("/streets/gazdagret/update-result.json")
+            self.assertEqual(root["error"], "HTTP Error 0: ")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wsgi.py
+++ b/wsgi.py
@@ -31,6 +31,7 @@ import config
 import overpass_query
 import util
 import webframe
+import wsgi_json
 
 if TYPE_CHECKING:
     # pylint: disable=no-name-in-module,import-error,unused-import
@@ -932,6 +933,9 @@ def our_application(
     if request_uri.startswith(prefix + "/static/"):
         output, content_type = webframe.handle_static(request_uri)
         return webframe.send_response(start_response, content_type, "200 OK", output, [])
+
+    if ext == "json":
+        return wsgi_json.our_application_json(start_response, relations, request_uri)
 
     doc = yattag.doc.Doc()
     util.write_html_header(doc)

--- a/wsgi_json.py
+++ b/wsgi_json.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+#
+# Copyright 2020 Miklos Vajna. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+
+"""The wsgi module contains functionality specific to the json part of the web interface."""
+
+import json
+import urllib.parse
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import TYPE_CHECKING
+from typing import Tuple
+
+import areas
+import overpass_query
+import webframe
+
+if TYPE_CHECKING:
+    # pylint: disable=no-name-in-module,import-error,unused-import
+    from wsgiref.types import StartResponse
+
+
+def streets_update_result_json(relations: areas.Relations, request_uri: str) -> str:
+    """Expected request_uri: e.g. /osm/streets/ormezo/update-result.json."""
+    tokens = request_uri.split("/")
+    relation_name = tokens[-2]
+    relation = relations.get_relation(relation_name)
+    query = relation.get_osm_streets_query()
+    ret: Dict[str, str] = {}
+    try:
+        relation.get_files().write_osm_streets(overpass_query.overpass_query(query))
+        ret["error"] = ""
+    except urllib.error.HTTPError as http_error:
+        ret["error"] = str(http_error)
+    return json.dumps(ret)
+
+
+def our_application_json(
+        start_response: 'StartResponse',
+        relations: areas.Relations,
+        request_uri: str
+) -> Iterable[bytes]:
+    """Dispatches json requests based on their URIs."""
+    content_type = "application/json"
+    extra_headers: List[Tuple[str, str]] = []
+    # Assume that request_uri starts with prefix + "/streets/".
+    output = streets_update_result_json(relations, request_uri)
+    return webframe.send_response(start_response, content_type, "200 OK", output, extra_headers)
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab:


### PR DESCRIPTION
So that js can call it in the future, without an actual redirect.
Introduce a wsgi_json module for this, before wsgi grows too large.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/765>.

Change-Id: Icad722dffebc75bb8683b966963fe3ab1651d530
