### PR TITLE
wsgi: use the /streets/.../update-result.json endpoint

### DIFF
--- a/osm.ts
+++ b/osm.ts
@@ -118,9 +118,44 @@ async function initGps()
     gpsLink.onclick = onGpsClick;
 }
 
+/**
+ * Starts various JSON requests in case some input of a ref vs osm diff is missing (or the other way
+ * around).
+ */
+async function initRedirects()
+{
+    const tokens = window.location.pathname.split('/');
+
+    const noOsmStreets = document.querySelector("#no-osm-streets");
+    if (noOsmStreets)
+    {
+        noOsmStreets.removeChild(noOsmStreets.childNodes[0]);
+        noOsmStreets.textContent += " " + getOsmString("str-overpass-wait")
+        const relationName = tokens[tokens.length - 2];
+        const link = config.uriPrefix + "/streets/" + relationName + "/update-result.json";
+        const request = new Request(link);
+        try
+        {
+            const response = await window.fetch(request);
+            const osmStreets = await response.json();
+            if (osmStreets.error != "")
+            {
+                throw osmStreets.error;
+            }
+            window.location.reload();
+        }
+        catch (reason)
+        {
+            noOsmStreets.textContent += " " + getOsmString("str-overpass-error") + reason;
+        }
+        return;
+    }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 document.addEventListener("DOMContentLoaded", async function(event) {
     initGps();
+    initRedirects();
     stats.initStats();
 });
 

--- a/webframe.py
+++ b/webframe.py
@@ -475,4 +475,25 @@ def check_existing_relation(relations: areas.Relations, request_uri: str) -> yat
     return doc
 
 
+def handle_no_osm_streets(prefix: str, relation_name: str, label: str) -> yattag.doc.Doc:
+    """Handles the no-osm-streets error on a page using JS."""
+    doc = yattag.doc.Doc()
+    link = prefix + "/streets/" + relation_name + "/update-result"
+    with doc.tag("noscript"):
+        with doc.tag("a", href=link):
+            doc.text(_("Call Overpass to create") + "...")
+    # Emit localized strings for JS purposes.
+    with doc.tag("div", style="display: none;"):
+        string_pairs = [
+            ("str-overpass-wait", label),
+            ("str-overpass-error", _("Error from Overpass: ")),
+        ]
+        for key, value in string_pairs:
+            kwargs: Dict[str, str] = {}
+            kwargs["id"] = key
+            kwargs["data-value"] = value
+            with doc.tag("div", **kwargs):
+                pass
+    return doc
+
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/wsgi.py
+++ b/wsgi.py
@@ -150,8 +150,8 @@ def missing_housenumbers_view_res(relations: areas.Relations, request_uri: str) 
     if not os.path.exists(relation.get_files().get_osm_streets_path()):
         with doc.tag("div", id="no-osm-streets"):
             doc.text(_("No existing streets: "))
-            link = prefix + "/streets/" + relation_name + "/update-result"
-            doc.asis(util.gen_link(link, _("Call Overpass to create")).getvalue())
+        label = _("No existing streets: waiting for Overpass...")
+        doc.asis(webframe.handle_no_osm_streets(prefix, relation_name, label).getvalue())
     elif not os.path.exists(relation.get_files().get_osm_housenumbers_path()):
         with doc.tag("div", id="no-osm-housenumbers"):
             doc.text(_("No existing house numbers: "))


### PR DESCRIPTION
... in the missing-housenumber case. The benefit is that this way the
original page is not left, so the user can't end up on a different page
after the overpass query completes.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/765>.

Change-Id: I96b784b45e073ed48c45ae22af6475043f17509d
