### PR TITLE
wsgi: use the /missing-housenumbers/.../update-result.json endpoint

### DIFF
--- a/osm.ts
+++ b/osm.ts
@@ -175,6 +175,31 @@ async function initRedirects()
         }
         return;
     }
+
+    const noRefHousenumbers = document.querySelector("#no-ref-housenumbers");
+    if (noRefHousenumbers)
+    {
+        noRefHousenumbers.removeChild(noRefHousenumbers.childNodes[0]);
+        noRefHousenumbers.textContent += " " + getOsmString("str-reference-wait")
+        const relationName = tokens[tokens.length - 2];
+        const link = config.uriPrefix + "/missing-housenumbers/" + relationName + "/update-result.json";
+        const request = new Request(link);
+        try
+        {
+            const response = await window.fetch(request);
+            const refHousenumbers = await response.json();
+            if (refHousenumbers.error != "")
+            {
+                throw refHousenumbers.error;
+            }
+            window.location.reload();
+        }
+        catch (reason)
+        {
+            noRefHousenumbers.textContent += " " + getOsmString("str-reference-error") + reason;
+        }
+        return;
+    }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/webframe.py
+++ b/webframe.py
@@ -518,4 +518,26 @@ def handle_no_osm_housenumbers(prefix: str, relation_name: str, label: str) -> y
                 pass
     return doc
 
+
+def handle_no_ref_housenumbers(prefix: str, relation_name: str, label: str) -> yattag.doc.Doc:
+    """Handles the no-ref-housenumbers error on a page using JS."""
+    doc = yattag.doc.Doc()
+    link = prefix + "/missing-housenumbers/" + relation_name + "/update-result"
+    with doc.tag("noscript"):
+        with doc.tag("a", href=link):
+            doc.text(_("Create from reference") + "...")
+    # Emit localized strings for JS purposes.
+    with doc.tag("div", style="display: none;"):
+        string_pairs = [
+            ("str-reference-wait", label),
+            ("str-reference-error", _("Error from reference: ")),
+        ]
+        for key, value in string_pairs:
+            kwargs: Dict[str, str] = {}
+            kwargs["id"] = key
+            kwargs["data-value"] = value
+            with doc.tag("div", **kwargs):
+                pass
+    return doc
+
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/wsgi.py
+++ b/wsgi.py
@@ -160,8 +160,8 @@ def missing_housenumbers_view_res(relations: areas.Relations, request_uri: str) 
     elif not os.path.exists(relation.get_files().get_ref_housenumbers_path()):
         with doc.tag("div", id="no-ref-housenumbers"):
             doc.text(_("No missing house numbers: "))
-            link = prefix + "/missing-housenumbers/" + relation_name + "/update-result"
-            doc.asis(util.gen_link(link, _("Create from reference")).getvalue())
+        label = _("No reference house numbers: creating from reference...")
+        doc.asis(webframe.handle_no_ref_housenumbers(prefix, relation_name, label).getvalue())
     else:
         ret = relation.write_missing_housenumbers()
         todo_street_count, todo_count, done_count, percent, table = ret


### PR DESCRIPTION
... in the missing-housenumber case, in case of a new relation.

With this, all 3 redirects for a new relation is replaced by JSON API
calls.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/765>.

Change-Id: I0703beb386f2be8db869e362323abb4b47defc21
