### PR TITLE
missing streets: use the /streets/.../update-result.json endpoint

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -194,8 +194,8 @@ def missing_streets_view_result(relations: areas.Relations, request_uri: str) ->
     if not os.path.exists(relation.get_files().get_osm_streets_path()):
         with doc.tag("div", id="no-osm-streets"):
             doc.text(_("No existing streets: "))
-            with doc.tag("a", href=prefix + "/streets/" + relation_name + "/update-result"):
-                doc.text(_("Call Overpass to create"))
+        label = _("No existing streets: waiting for Overpass...")
+        doc.asis(webframe.handle_no_osm_streets(prefix, relation_name, label).getvalue())
         return doc
 
     if not os.path.exists(relation.get_files().get_ref_streets_path()):


### PR DESCRIPTION
So there is only 1 reload, not 2 when osm streets are missing.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/765>.

Change-Id: I53d1c26fdfe19937e551f3f7ac1e4bed98f92a5b
