### PR TITLE
missing streets: add a JS way to update from OSM

### DIFF
--- a/osm.ts
+++ b/osm.ts
@@ -203,6 +203,35 @@ async function initRedirects()
 }
 
 /**
+ * Updates an outdated OSM street list for a relation.
+ */
+async function onUpdateOsmStreets()
+{
+    const tokens = window.location.pathname.split('/');
+
+    const streets = document.querySelector("#trigger-streets-update");
+    streets.removeChild(streets.childNodes[0]);
+    streets.textContent += " " + getOsmString("str-toolbar-overpass-wait")
+    const relationName = tokens[tokens.length - 2];
+    const link = config.uriPrefix + "/streets/" + relationName + "/update-result.json";
+    const request = new Request(link);
+    try
+    {
+        const response = await window.fetch(request);
+        const osmStreets = await response.json();
+        if (osmStreets.error != "")
+        {
+            throw osmStreets.error;
+        }
+        window.location.reload();
+    }
+    catch (reason)
+    {
+        streets.textContent += " " + getOsmString("str-toolbar-overpass-error") + reason;
+    }
+}
+
+/**
  * Updates an outdated OSM house number list for a relation.
  */
 async function onUpdateOsmHousenumbers()
@@ -242,6 +271,15 @@ async function initTriggerUpdate()
         const streetHousenumbersLink = <HTMLLinkElement>streetHousenumbers.childNodes[0];
         streetHousenumbersLink.onclick = onUpdateOsmHousenumbers;
         streetHousenumbersLink.href = "#";
+        return;
+    }
+
+    const streets = document.querySelector("#trigger-streets-update");
+    if (streets)
+    {
+        const streetsLink = <HTMLLinkElement>streets.childNodes[0];
+        streetsLink.onclick = onUpdateOsmStreets;
+        streetsLink.href = "#";
     }
 }
 

--- a/webframe.py
+++ b/webframe.py
@@ -75,8 +75,9 @@ def fill_header_function(function: str, relation_name: str, items: List[yattag.d
         # The OSM data source changes much more frequently than the ref one, so add a dedicated link
         # to update OSM streets first.
         doc = yattag.doc.Doc()
-        with doc.tag("a", href=prefix + "/streets/" + relation_name + "/update-result"):
-            doc.text(_("Update from OSM"))
+        with doc.tag("span", id="trigger-streets-update"):
+            with doc.tag("a", href=prefix + "/streets/" + relation_name + "/update-result"):
+                doc.text(_("Update from OSM"))
         items.append(doc)
 
         doc = yattag.doc.Doc()


### PR DESCRIPTION
Missing streets is now almost JS-ready, just the no-ref-streets case
remains.

Change-Id: Ib5ca08adeb163758276840db9ed04851813d3b2f
