### PR TITLE
wsgi: use the /missing-streets/.../update-result.json endpoint

### DIFF
--- a/osm.ts
+++ b/osm.ts
@@ -200,6 +200,31 @@ async function initRedirects()
         }
         return;
     }
+
+    const noRefStreets = document.querySelector("#no-ref-streets");
+    if (noRefStreets)
+    {
+        noRefStreets.removeChild(noRefStreets.childNodes[0]);
+        noRefStreets.textContent += " " + getOsmString("str-reference-wait")
+        const relationName = tokens[tokens.length - 2];
+        const link = config.uriPrefix + "/missing-streets/" + relationName + "/update-result.json";
+        const request = new Request(link);
+        try
+        {
+            const response = await window.fetch(request);
+            const refStreets = await response.json();
+            if (refStreets.error != "")
+            {
+                throw refStreets.error;
+            }
+            window.location.reload();
+        }
+        catch (reason)
+        {
+            noRefStreets.textContent += " " + getOsmString("str-reference-error") + reason;
+        }
+        return;
+    }
 }
 
 /**

--- a/webframe.py
+++ b/webframe.py
@@ -556,4 +556,26 @@ def handle_no_ref_housenumbers(prefix: str, relation_name: str, label: str) -> y
                 pass
     return doc
 
+
+def handle_no_ref_streets(prefix: str, relation_name: str, label: str) -> yattag.doc.Doc:
+    """Handles the no-ref-streets error on a page using JS."""
+    doc = yattag.doc.Doc()
+    link = prefix + "/missing-streets/" + relation_name + "/update-result"
+    with doc.tag("noscript"):
+        with doc.tag("a", href=link):
+            doc.text(_("Create from reference") + "...")
+    # Emit localized strings for JS purposes.
+    with doc.tag("div", style="display: none;"):
+        string_pairs = [
+            ("str-reference-wait", label),
+            ("str-reference-error", _("Error from reference: ")),
+        ]
+        for key, value in string_pairs:
+            kwargs: Dict[str, str] = {}
+            kwargs["id"] = key
+            kwargs["data-value"] = value
+            with doc.tag("div", **kwargs):
+                pass
+    return doc
+
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/wsgi.py
+++ b/wsgi.py
@@ -201,8 +201,8 @@ def missing_streets_view_result(relations: areas.Relations, request_uri: str) ->
     if not os.path.exists(relation.get_files().get_ref_streets_path()):
         with doc.tag("div", id="no-ref-streets"):
             doc.text(_("No street list: "))
-            with doc.tag("a", href=prefix + "/missing-streets/" + relation_name + "/update-result"):
-                doc.text(_("Create from reference"))
+        label = _("No reference streets: creating from reference...")
+        doc.asis(webframe.handle_no_ref_streets(prefix, relation_name, label).getvalue())
         return doc
 
     ret = relation.write_missing_streets()


### PR DESCRIPTION
With this, missing-streets never leaves the page when doing the initial
osm/ref request or when updating from osm.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/765>.

Change-Id: I106a91dddb239a1d16cb2f7e893feeee5ac14b24
