### PR TITLE
gen_link: no need to redirect anymore

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -206,7 +206,6 @@ class TestGenLink(unittest.TestCase):
         """Tests the happy path."""
         doc = util.gen_link("http://www.example.com", "label")
         expected = '<a href="http://www.example.com">label...</a>'
-        expected += '<script type="text/javascript">window.location.href = "http://www.example.com";</script>'
         self.assertEqual(doc.getvalue(), expected)
 
 

--- a/util.py
+++ b/util.py
@@ -476,10 +476,6 @@ def gen_link(url: str, label: str) -> yattag.doc.Doc:
     with doc.tag("a", href=url):
         doc.text(label + "...")
 
-    # Always auto-visit the link for now.
-    with doc.tag("script", type="text/javascript"):
-        doc.text("window.location.href = \"%s\";" % url)
-
     return doc
 
 


### PR DESCRIPTION
If a street update is done, we no longer know what was the original
context, better to not redirect automatically. These pages are no not
visited with JS enabled, we use the .json variant in the JS case which
never looses the context.

Change-Id: I6f21014eeeb77a072bf8d205857bd39f9197ea18
