### PR TITLE
handle_no_osm_streets: eliminate not needed noscript

### DIFF
--- a/webframe.py
+++ b/webframe.py
@@ -495,9 +495,9 @@ def handle_no_osm_streets(prefix: str, relation_name: str) -> yattag.doc.Doc:
     """Handles the no-osm-streets error on a page using JS."""
     doc = yattag.doc.Doc()
     link = prefix + "/streets/" + relation_name + "/update-result"
-    with doc.tag("noscript"):
+    with doc.tag("div", id="no-osm-streets"):
         with doc.tag("a", href=link):
-            doc.text(_("Call Overpass to create") + "...")
+            doc.text(_("No existing streets: call Overpass to create..."))
     # Emit localized strings for JS purposes.
     with doc.tag("div", style="display: none;"):
         string_pairs = [

--- a/wsgi.py
+++ b/wsgi.py
@@ -148,8 +148,6 @@ def missing_housenumbers_view_res(relations: areas.Relations, request_uri: str) 
     relation = relations.get_relation(relation_name)
     prefix = config.Config.get_uri_prefix()
     if not os.path.exists(relation.get_files().get_osm_streets_path()):
-        with doc.tag("div", id="no-osm-streets"):
-            doc.text(_("No existing streets: "))
         doc.asis(webframe.handle_no_osm_streets(prefix, relation_name).getvalue())
     elif not os.path.exists(relation.get_files().get_osm_housenumbers_path()):
         with doc.tag("div", id="no-osm-housenumbers"):
@@ -191,8 +189,6 @@ def missing_streets_view_result(relations: areas.Relations, request_uri: str) ->
     doc = yattag.doc.Doc()
     prefix = config.Config.get_uri_prefix()
     if not os.path.exists(relation.get_files().get_osm_streets_path()):
-        with doc.tag("div", id="no-osm-streets"):
-            doc.text(_("No existing streets: "))
         doc.asis(webframe.handle_no_osm_streets(prefix, relation_name).getvalue())
         return doc
 
@@ -450,8 +446,6 @@ def additional_streets_view_result(relations: areas.Relations, request_uri: str)
     doc = yattag.doc.Doc()
     prefix = config.Config.get_uri_prefix()
     if not os.path.exists(relation.get_files().get_osm_streets_path()):
-        with doc.tag("div", id="no-osm-streets"):
-            doc.text(_("No existing streets: "))
         doc.asis(webframe.handle_no_osm_streets(prefix, relation_name).getvalue())
     elif not os.path.exists(relation.get_files().get_ref_streets_path()):
         with doc.tag("div", id="no-ref-streets"):


### PR DESCRIPTION
The python side can just generate HTML which works without JS, then JS
code can remove the elements which are not needed for JS. This means no
need to mark anything as noscript explicitly.

Change-Id: I9810d1f9ef0b6c1ef0b8833395c94a87898d4363
