### PR TITLE
make deploy: support a custom deploy command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,12 @@ run:
 	cd $(HOME) && $(PWD)/wsgi.py
 
 deploy:
+ifeq (,$(wildcard ./deploy.sh))
 	git pull -r
 	make
+else
+	./deploy.sh
+endif
 
 update-pot: areas.py webframe.py wsgi.py util.py Makefile
 	xgettext --keyword=_ --language=Python --add-comments --sort-output --from-code=UTF-8 -o po/osm-gimmisn.pot $(filter %.py,$^)


### PR DESCRIPTION
If ./deploy.sh is there, use it; otherwise do the usual pull + make.

Change-Id: Icd2d48d631e680a1aab55a7f3039b0d9af75d7e3
