### PR TITLE
CI: automerge: try to use the default retries/sleeps again

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -29,5 +29,3 @@ jobs:
           MERGE_METHOD: "rebase"
           UPDATE_METHOD: "rebase"
           MERGE_DELETE_BRANCH: true
-          MERGE_RETRIES: "360"
-          MERGE_RETRY_SLEEP: "10000"


### PR DESCRIPTION
My understanding is that a failing automerge is not a problem, it'll be
triggered again once the other checks finish (and then it can succeed).
However, a long-running automerge attempt has the problem of parallel
instances, which seems to be even worse.

Change-Id: I49a94329de9fd4f6110a7789383b8183cc98885b
