### PR TITLE
additional streets: add view-turbo action

### DIFF
--- a/areas.py
+++ b/areas.py
@@ -849,4 +849,19 @@ out skel qt;"""
     return query
 
 
+def make_turbo_query_for_street_objs(relation: Relation, streets: List[util.Street]) -> str:
+    """Creates an overpass query that shows all streets from a list."""
+    header = """[out:json][timeout:425];
+rel(@RELATION@)->.searchRelation;
+area(@AREA@)->.searchArea;
+("""
+    query = util.process_template(header, relation.get_config().get_osmrelation())
+    for street in streets:
+        query += street.get_osm_type() + "(" + str(street.get_osm_id()) + ");\n"
+    query += """);
+out body;
+>;
+out skel qt;"""
+    return query
+
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/wsgi.py
+++ b/wsgi.py
@@ -428,7 +428,7 @@ def handle_additional_streets(relations: areas.Relations, request_uri: str) -> y
     """Expected request_uri: e.g. /osm/additional-streets/ujbuda/view-[result|query]."""
     tokens = request_uri.split("/")
     relation_name = tokens[-2]
-    # tokens[-1] would be the action
+    action = tokens[-1]
 
     relation = relations.get_relation(relation_name)
     osmrelation = relation.get_config().get_osmrelation()
@@ -436,8 +436,11 @@ def handle_additional_streets(relations: areas.Relations, request_uri: str) -> y
     doc = yattag.doc.Doc()
     doc.asis(webframe.get_toolbar(relations, "additional-streets", relation_name, osmrelation).getvalue())
 
-    # assume view-result
-    doc.asis(wsgi_additional.additional_streets_view_result(relations, request_uri).getvalue())
+    if action == "view-turbo":
+        doc.asis(wsgi_additional.additional_streets_view_turbo(relations, request_uri).getvalue())
+    else:
+        # assume view-result
+        doc.asis(wsgi_additional.additional_streets_view_result(relations, request_uri).getvalue())
 
     date = streets_diff_last_modified(relation)
     doc.asis(webframe.get_footer(date).getvalue())

--- a/wsgi_additional.py
+++ b/wsgi_additional.py
@@ -84,8 +84,26 @@ def additional_streets_view_result(relations: areas.Relations, request_uri: str)
             doc.stag("br")
             with doc.tag("a", href=prefix + "/additional-streets/" + relation_name + "/view-result.chkl"):
                 doc.text(_("Checklist format"))
+            doc.stag("br")
+            with doc.tag("a", href=prefix + "/additional-streets/{}/view-turbo".format(relation_name)):
+                doc.text(_("Overpass turbo query for the below streets"))
 
         doc.asis(util.html_table_from_list(table).getvalue())
+    return doc
+
+
+def additional_streets_view_turbo(relations: areas.Relations, request_uri: str) -> yattag.doc.Doc:
+    """Expected request_uri: e.g. /osm/additional-housenumbers/ormezo/view-turbo."""
+    tokens = request_uri.split("/")
+    relation_name = tokens[-2]
+
+    doc = yattag.doc.Doc()
+    relation = relations.get_relation(relation_name)
+    streets = relation.get_additional_streets()
+    query = areas.make_turbo_query_for_street_objs(relation, streets)
+
+    with doc.tag("pre"):
+        doc.text(query)
     return doc
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:


### PR DESCRIPTION
Similar to missing housenumbers -> view-turbo, but this work can work
with OSM IDs, so it's more precise.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/861>.

Change-Id: I47346c1b9b2e4a8a30371ba58deb2b7bc8a43a0b
