### PR TITLE
additional streets, view turbo: don't uniq sort on street name

### DIFF
--- a/wsgi_additional.py
+++ b/wsgi_additional.py
@@ -99,7 +99,7 @@ def additional_streets_view_turbo(relations: areas.Relations, request_uri: str) 
 
     doc = yattag.doc.Doc()
     relation = relations.get_relation(relation_name)
-    streets = relation.get_additional_streets()
+    streets = relation.get_additional_streets(sorted_result=False)
     query = areas.make_turbo_query_for_street_objs(relation, streets)
 
     with doc.tag("pre"):


### PR DESCRIPTION
One street can have multiple ids, let's uniq sort the type+id pairs
only.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/861>.

Change-Id: I25fb0510ffad49c318d00136a76ce27911ec9f51
