### PR TITLE
Drop unused sort_housenumbers_csv

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -452,15 +452,6 @@ class TestSortHousenumbers(unittest.TestCase):
         self.assertEqual(util.sort_housenumbers(unsorted), expected)
 
 
-class TestSortHouseNumbersCsv(unittest.TestCase):
-    """Tests sort_housenumbers_csv()."""
-    def test_happy(self) -> None:
-        """Tests the happy path."""
-        unsorted = 'head\n2\n1'
-        expected = 'head\n1\n2'
-        self.assertEqual(util.sort_housenumbers_csv(unsorted), expected)
-
-
 class TestOnlyInFirst(unittest.TestCase):
     """Tests get_only_in_first()."""
     def test_happy(self) -> None:

--- a/util.py
+++ b/util.py
@@ -752,15 +752,6 @@ def sort_housenumbers(lines: Iterable[str]) -> List[str]:
     return sorted(lines, key=split_housenumber_line)
 
 
-def sort_housenumbers_csv(data: str) -> str:
-    """
-    Sorts TSV Overpass house numbers result with visual partitioning.
-
-    See split_housenumber_line for sorting rules.
-    """
-    return process_csv_body(sort_housenumbers, data)
-
-
 def get_only_in_first(first: List[Any], second: List[Any]) -> List[Any]:
     """
     Returns items which are in first, but not in second.


### PR DESCRIPTION
This was only useful when the CSV only had 3 cols.

Change-Id: Ib3c1b64d8cb2181449e1a0c203bb05740df8f4ae
