### PR TITLE
Drop remaining "not enough columns" checks

### DIFF
--- a/tests/workdir/street-housenumbers-budafok.csv
+++ b/tests/workdir/street-housenumbers-budafok.csv
@@ -1,0 +1,2 @@
+@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
+

--- a/tests/workdir/street-housenumbers-empty.csv
+++ b/tests/workdir/street-housenumbers-empty.csv
@@ -1,2 +1,2 @@
-@id	addr:street	addr:housenumber
+@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
 

--- a/tests/workdir/street-housenumbers-gh611.csv
+++ b/tests/workdir/street-housenumbers-gh611.csv
@@ -1,2 +1,3 @@
-@id	addr:street	addr:housenumber
-6852648009	Albert utca	42
+@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
+
+6852648009	Albert utca	42									node

--- a/tests/workdir/street-housenumbers-test.csv
+++ b/tests/workdir/street-housenumbers-test.csv
@@ -1,7 +1,6 @@
-HA3	HB3	HC3
-HA2	HB2	HC2
-HA1	HB1	HC1
-HA0		HC0
-Bogus1
-Bogus	2
-Bogus	3	
+@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
+
+HA2	HB2	HC2									node
+HA1	HB1	HC1									node
+HA0		HC0									node
+no-hnum-no-cnum											node

--- a/util.py
+++ b/util.py
@@ -618,18 +618,16 @@ def get_street_from_housenumber(
         if not row:
             continue
 
-        has_housenumber = housenumber_column < len(row) and row[housenumber_column]
-        has_conscriptionnumber = conscriptionnumber_column < len(row) and row[conscriptionnumber_column]
-        if len(row) < street_column + 1 or ((not has_housenumber) and (not has_conscriptionnumber)):
+        has_housenumber = row[housenumber_column]
+        has_conscriptionnumber = row[conscriptionnumber_column]
+        if (not has_housenumber) and (not has_conscriptionnumber):
             continue
         street_name = row[street_column]
         if not street_name:
             continue
 
-        osm_type = "way"
         osm_type_column = 11
-        if osm_type_column < len(row):
-            osm_type = row[osm_type_column]
+        osm_type = row[osm_type_column]
         try:
             osm_id = int(row[0])
         except ValueError:


### PR DESCRIPTION
All this error handling is only needed for the test data, real data
always has enough columns.

Towards parsing street-housenumber CSVs by header name.

Change-Id: Ic79f45a3923f8ec2017f7256cb0300ee9b84e7b4
