### PR TITLE
get_osm_housenumbers: consider addr:place when addr:street is empty

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -47,6 +47,14 @@ make TSDEBUG=1
 
 produces output that is for debugging.
 
+== Python debugging
+
+To run a single test:
+
+----
+env PYTHONPATH=.:tests python3 -m unittest tests.test_areas.TestRelationGetOsmHouseNumbers.test_happy
+----
+
 == Checklist
 
 Ideally CI checks everything before a commit hits master, but here are a few

--- a/areas.py
+++ b/areas.py
@@ -384,14 +384,19 @@ class Relation:
             house_numbers: Dict[str, List[util.HouseNumber]] = {}
             with self.get_files().get_osm_housenumbers_csv_stream() as sock:
                 first = True
+                columns: Dict[str, int] = {}
                 for row in sock.get_rows():
                     if first:
                         first = False
+                        for index, label in enumerate(row):
+                            columns[label] = index
                         continue
-                    if len(row) < 3:
+                    if not row:
                         continue
-                    street = row[1]
-                    for house_number in row[2].split(';'):
+                    street = row[columns["addr:street"]]
+                    if not street and "addr:place" in columns:
+                        street = row[columns["addr:place"]]
+                    for house_number in row[columns["addr:housenumber"]].split(';'):
                         if street not in house_numbers:
                             house_numbers[street] = []
                         house_numbers[street] += normalize(self, house_number, street, self.get_street_ranges())

--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -386,7 +386,7 @@ class TestRelationGetRefStreets(unittest.TestCase):
 
 
 class TestRelationGetOsmHouseNumbers(unittest.TestCase):
-    """Tests Relation.get_osm_house_numbers()."""
+    """Tests Relation.get_osm_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
         relation_name = "gazdagret"
@@ -395,6 +395,15 @@ class TestRelationGetOsmHouseNumbers(unittest.TestCase):
         relation = relations.get_relation(relation_name)
         house_numbers = relation.get_osm_housenumbers(street_name)
         self.assertEqual([i.get_number() for i in house_numbers], ["1", "2"])
+
+    def test_addr_place(self) -> None:
+        """Tests the case when addr:place is used instead of addr:street."""
+        relation_name = "gh964"
+        relations = get_relations()
+        relation = relations.get_relation(relation_name)
+        street_name = "Tolvajos tanya"
+        house_numbers = relation.get_osm_housenumbers(street_name)
+        self.assertEqual([i.get_number() for i in house_numbers], ["52"])
 
 
 class TestRelationGetMissingHousenumbers(test_config.TestCase):


### PR DESCRIPTION
This is for housenumbers, street were working already.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/964>.

Change-Id: I0cbb6ad1c1467fc5ad9200bc51352b68408cbb73
