### PR TITLE
invalid_refstreets: add a script to find errors in all relations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ PYTHON_SAFE_OBJECTS = \
 # These have bad coverage.
 PYTHON_UNSAFE_OBJECTS = \
 	additional_streets.py \
+	invalid_refstreets.py \
 
 PYTHON_OBJECTS = \
 	$(PYTHON_TEST_OBJECTS) \

--- a/invalid_refstreets.py
+++ b/invalid_refstreets.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021 Miklos Vajna. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+
+"""Prints invalid refstreets for all realtions."""
+
+import areas
+import config
+
+
+def main() -> None:
+    """Commandline interface."""
+    workdir = config.Config.get_workdir()
+    relations = areas.Relations(workdir)
+    for relation in relations.get_relations():
+        invalid_refstreets = areas.get_invalid_refstreets(relation)
+        osm_invalids, ref_invalids = invalid_refstreets
+        if not osm_invalids and not ref_invalids:
+            continue
+
+        print(relation.get_name() + ": " + str(invalid_refstreets))
+
+
+if __name__ == '__main__':
+    main()
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab:


### PR DESCRIPTION
Mostly because this way I can quickly find a relation with errors for
integration testing.

Change-Id: Ia4088e57f948190c1ddf8a32f5e703c81e8d23a4
