### PR TITLE
invalid refstreets: add to missing/additional streets as well

### DIFF
--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -174,8 +174,10 @@ class TestMissingHousenumbers(TestWsgi):
         """Tests if the output is well-formed."""
         root = self.get_dom_for_path("/missing-housenumbers/gazdagret/view-result")
         results = root.findall("body/table")
+        self.assertEqual(len(results), 1)
         # refstreets: >0 invalid osm name
         results = root.findall("body/div[@id='osm-invalids-container']")
+        self.assertEqual(len(results), 1)
         # refstreets: >0 invalid ref name
         results = root.findall("body/div[@id='ref-invalids-container']")
         self.assertEqual(len(results), 1)
@@ -469,6 +471,12 @@ class TestMissingStreets(TestWsgi):
         root = self.get_dom_for_path("/missing-streets/gazdagret/view-result")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
+        # refstreets: >0 invalid osm name
+        results = root.findall("body/div[@id='osm-invalids-container']")
+        self.assertEqual(len(results), 1)
+        # refstreets: >0 invalid ref name
+        results = root.findall("body/div[@id='ref-invalids-container']")
+        self.assertEqual(len(results), 1)
 
     def test_well_formed_compat(self) -> None:
         """Tests if the output is well-formed (URL rewrite)."""
@@ -576,6 +584,12 @@ class TestAdditionalStreets(TestWsgi):
         """Tests if the output is well-formed."""
         root = self.get_dom_for_path("/additional-streets/gazdagret/view-result")
         results = root.findall("body/table")
+        self.assertEqual(len(results), 1)
+        # refstreets: >0 invalid osm name
+        results = root.findall("body/div[@id='osm-invalids-container']")
+        self.assertEqual(len(results), 1)
+        # refstreets: >0 invalid ref name
+        results = root.findall("body/div[@id='ref-invalids-container']")
         self.assertEqual(len(results), 1)
 
     def test_street_from_housenr_well_formed(self) -> None:

--- a/wsgi.py
+++ b/wsgi.py
@@ -218,6 +218,7 @@ def missing_streets_view_result(relations: areas.Relations, request_uri: str) ->
             doc.text(_("Checklist format"))
 
     doc.asis(util.html_table_from_list(table).getvalue())
+    doc.asis(util.invalid_refstreets_to_html(areas.get_invalid_refstreets(relation)).getvalue())
     return doc
 
 

--- a/wsgi_additional.py
+++ b/wsgi_additional.py
@@ -89,6 +89,7 @@ def additional_streets_view_result(relations: areas.Relations, request_uri: str)
                 doc.text(_("Overpass turbo query for the below streets"))
 
         doc.asis(util.html_table_from_list(table).getvalue())
+        doc.asis(util.invalid_refstreets_to_html(areas.get_invalid_refstreets(relation)).getvalue())
     return doc
 
 


### PR DESCRIPTION
We have a list of invalid osm and ref names for the osm <-> ref street
name mapping. This was already visible at the bottom of the missing
housenumbers page. Do the same for the missing/additional streets pages,
as this is useful for relations where only streets are analyzed.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/1008>.

Change-Id: I657f7307fff21540f50e6e8be39cd4dd9bbe6435
