### PR TITLE
invalid refstreets: document what is an invalid osm/ref name

### DIFF
--- a/util.py
+++ b/util.py
@@ -563,6 +563,9 @@ def invalid_refstreets_to_html(invalids: Tuple[List[str], List[str]]) -> yattag.
                 for ref_invalid in ref_invalids:
                     with doc.tag("li"):
                         doc.text(ref_invalid)
+    doc.stag("br")
+    doc.text(_("Note: an OSM name is invalid if it's not in the OSM database."))
+    doc.text(_("A reference name is invalid if it's in the OSM database."))
     return doc
 
 


### PR DESCRIPTION
A ref name is invalid based on only the OSM database, for now.

Related to
<https://github.com/vmiklos/osm-gimmisn/issues/1025#issuecomment-784018959>.

Change-Id: I0e747ad38a93b72d5da9011bff5921aae195f9e9
