### PR TITLE
stats: invalid-refstreets -> invalid-relations

### DIFF
--- a/po/hu/osm-gimmisn.po
+++ b/po/hu/osm-gimmisn.po
@@ -30,7 +30,7 @@ msgstr "(üres)"
 msgid "(invalid)"
 msgstr "(hibás)"
 
-#: util.py:568
+#: util.py:569
 msgid "A reference name is invalid if it's in the OSM database."
 msgstr "Egy referencia név érvénytelen ha szerepel az OSM adatbázisban."
 
@@ -177,8 +177,8 @@ msgid "Internal error when serving {0}"
 msgstr "Belső hiba a {0} kiszolgálása során"
 
 #: webframe.py:432
-msgid "Invalid street mappings"
-msgstr "Érvénytelen utca hozzárendelések"
+msgid "Invalid relation settings"
+msgstr "Érvénytelen területi beállítások"
 
 #: webframe.py:47
 msgid "Last update: "
@@ -273,9 +273,10 @@ msgstr "Nincs ilyen reláció: {0}"
 msgid "Note"
 msgstr "Megjegyzés"
 
-#: util.py:567
+#: util.py:568
 msgid "Note: an OSM name is invalid if it's not in the OSM database."
-msgstr "Megjegyzés: egy OSM név érvénytelen ha nem szerepel az OSM adatbázisban."
+msgstr ""
+"Megjegyzés: egy OSM név érvénytelen ha nem szerepel az OSM adatbázisban."
 
 #: util.py:464
 msgid "Note: wait for {} seconds"
@@ -507,7 +508,7 @@ msgstr "meglévő házszámok"
 msgid "existing streets"
 msgstr "meglévő utcák"
 
-#: util.py:640
+#: util.py:641
 msgid "housenumber"
 msgstr "házszám"
 

--- a/po/osm-gimmisn.pot
+++ b/po/osm-gimmisn.pot
@@ -30,7 +30,7 @@ msgstr ""
 msgid "(invalid)"
 msgstr ""
 
-#: util.py:568
+#: util.py:569
 msgid "A reference name is invalid if it's in the OSM database."
 msgstr ""
 
@@ -177,7 +177,7 @@ msgid "Internal error when serving {0}"
 msgstr ""
 
 #: webframe.py:432
-msgid "Invalid street mappings"
+msgid "Invalid relation settings"
 msgstr ""
 
 #: webframe.py:47
@@ -273,7 +273,7 @@ msgstr ""
 msgid "Note"
 msgstr ""
 
-#: util.py:567
+#: util.py:568
 msgid "Note: an OSM name is invalid if it's not in the OSM database."
 msgstr ""
 
@@ -493,7 +493,7 @@ msgstr ""
 msgid "existing streets"
 msgstr ""
 
-#: util.py:640
+#: util.py:641
 msgid "housenumber"
 msgstr ""
 

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -864,7 +864,7 @@ class TestInvalidRefstreets(TestWsgi):
     """Tests handle_invalid_refstreets()."""
     def test_well_formed(self) -> None:
         """Tests if the output is well-formed."""
-        root = self.get_dom_for_path("/housenumber-stats/hungary/invalid-refstreets")
+        root = self.get_dom_for_path("/housenumber-stats/hungary/invalid-relations")
         results = root.findall("body/h1/a")
         self.assertNotEqual(results, [])
 

--- a/webframe.py
+++ b/webframe.py
@@ -349,7 +349,7 @@ Only cities with house numbers in OSM are considered."""))
 
 
 def handle_invalid_refstreets(relations: areas.Relations) -> yattag.doc.Doc:
-    """Expected request_uri: e.g. /osm/housenumber-stats/hungary/invalid-refstreets."""
+    """Expected request_uri: e.g. /osm/housenumber-stats/hungary/invalid-relations."""
     doc = yattag.doc.Doc()
     doc.asis(get_toolbar(relations).getvalue())
 
@@ -374,7 +374,7 @@ def handle_stats(relations: areas.Relations, request_uri: str) -> yattag.doc.Doc
     if request_uri.endswith("/cityprogress"):
         return handle_stats_cityprogress(relations)
 
-    if request_uri.endswith("/invalid-refstreets"):
+    if request_uri.endswith("/invalid-relations"):
         return handle_invalid_refstreets(relations)
 
     doc = yattag.doc.Doc()
@@ -429,7 +429,7 @@ def handle_stats(relations: areas.Relations, request_uri: str) -> yattag.doc.Doc
         (_("All house number editors"), "usertotal"),
         (_("Coverage"), "progress"),
         (_("Per-city coverage"), "cityprogress"),
-        (_("Invalid street mappings"), "invalid-refstreets"),
+        (_("Invalid relation settings"), "invalid-relations"),
     ]
 
     with doc.tag("ul"):
@@ -439,15 +439,15 @@ def handle_stats(relations: areas.Relations, request_uri: str) -> yattag.doc.Doc
                     with doc.tag("a", href=prefix + "/housenumber-stats/hungary/cityprogress"):
                         doc.text(title)
                     continue
-                if identifier == "invalid-refstreets":
-                    with doc.tag("a", href=prefix + "/housenumber-stats/hungary/invalid-refstreets"):
+                if identifier == "invalid-relations":
+                    with doc.tag("a", href=prefix + "/housenumber-stats/hungary/invalid-relations"):
                         doc.text(title)
                     continue
                 with doc.tag("a", href="#_" + identifier):
                     doc.text(title)
 
     for title, identifier in title_ids:
-        if identifier in ("cityprogress", "invalid-refstreets"):
+        if identifier in ("cityprogress", "invalid-relations"):
             continue
         with doc.tag("h2", id="_" + identifier):
             doc.text(title)


### PR DESCRIPTION
So that we can search for more errors, like invalid street names in
filters.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/1048>.

Change-Id: I51d4abde33c442db80da4a1ca906849fe4c9391c
