### PR TITLE
wsgi: optionally gzip-compress the output

### DIFF
--- a/webframe.py
+++ b/webframe.py
@@ -20,6 +20,7 @@ import locale
 import os
 import time
 import traceback
+import xmlrpc.client
 
 import pytz
 import yattag
@@ -245,19 +246,43 @@ def handle_static(request_uri: str) -> Tuple[bytes, str, List[Tuple[str, str]]]:
     return bytes(), "", extra_headers
 
 
+class ResponseProperties:
+    """Properties of a response, to be read by send_response()."""
+    def __init__(self, content_type: str, status: str) -> None:
+        self.__content_type: str = content_type
+        self.__status: str = status
+
+    def get_content_type(self) -> str:
+        """Gets the Content-type value."""
+        return self.__content_type
+
+    def get_status(self) -> str:
+        """Gets the HTTP status."""
+        return self.__status
+
+
 def send_response(
+        environ: Dict[str, Any],
         start_response: 'StartResponse',
-        content_type: str,
-        status: str,
+        response_properties: ResponseProperties,
         output_bytes: bytes,
         extra_headers: List[Tuple[str, str]]
 ) -> Iterable[bytes]:
     """Turns an output string into a byte array and sends it."""
+    content_type = response_properties.get_content_type()
     if content_type != "application/octet-stream":
         content_type += "; charset=utf-8"
+    accept_encodings = environ.get("HTTP_ACCEPT_ENCODING", "").split(",")
+    accepts_gzip = "gzip" in accept_encodings
+    if accepts_gzip:
+        output_bytes = xmlrpc.client.gzip_encode(output_bytes)
+    content_length = len(output_bytes)
     response_headers = [('Content-type', content_type),
-                        ('Content-Length', str(len(output_bytes)))]
+                        ('Content-Length', str(content_length))]
+    if accepts_gzip:
+        response_headers.append(("Content-Encoding", "gzip"))
     response_headers += extra_headers
+    status = response_properties.get_status()
     start_response(status, response_headers)
     return [output_bytes]
 
@@ -275,7 +300,8 @@ def handle_exception(
     with doc.tag("pre"):
         doc.text(_("Internal error when serving {0}").format(request_uri) + "\n")
         doc.text(traceback.format_exc())
-    return send_response(start_response, "text/html", status, doc.getvalue().encode("utf-8"), [])
+    response_properties = ResponseProperties("text/html", status)
+    return send_response(environ, start_response, response_properties, doc.getvalue().encode("utf-8"), [])
 
 
 def handle_404() -> yattag.doc.Doc:

--- a/wsgi_json.py
+++ b/wsgi_json.py
@@ -9,6 +9,7 @@
 
 import json
 import urllib.parse
+from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List
@@ -80,6 +81,7 @@ def missing_streets_update_result_json(relations: areas.Relations, request_uri: 
 
 
 def our_application_json(
+        environ: Dict[str, Any],
         start_response: 'StartResponse',
         relations: areas.Relations,
         request_uri: str
@@ -97,6 +99,8 @@ def our_application_json(
     else:
         # Assume that request_uri starts with prefix + "/missing-streets/".
         output = missing_streets_update_result_json(relations, request_uri)
-    return webframe.send_response(start_response, content_type, "200 OK", output.encode("utf-8"), extra_headers)
+    output_bytes = output.encode("utf-8")
+    response_properties = webframe.ResponseProperties(content_type, "200 OK")
+    return webframe.send_response(environ, start_response, response_properties, output_bytes, extra_headers)
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:


### PR DESCRIPTION
Works with cherry.py only, not with wsgiref, which doesn't bother
setting the HTTP_ACCEPT_ENCODING key. bundlej.js transfer size goes down
from 263.55 KB to 93.95 KB with this.

Fixes <https://github.com/vmiklos/osm-gimmisn/issues/1116>.

Change-Id: I4baa8735156f95843eed88a1bb0b9ed73921a50f
