### PR TITLE
Cache missing-housenumbers HTML output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PYTHON_TEST_OBJECTS = \
 	tests/test_accept_language.py \
 	tests/test_areas.py \
+	tests/test_cache.py \
 	tests/test_cache_yamls.py \
 	tests/test_cherry.py \
 	tests/test_config.py \
@@ -25,6 +26,7 @@ PYTHON_TEST_OBJECTS = \
 PYTHON_SAFE_OBJECTS = \
 	accept_language.py \
 	areas.py \
+	cache.py \
 	cache_yamls.py \
 	cherry.py \
 	config.py \

--- a/areas.py
+++ b/areas.py
@@ -19,6 +19,7 @@ import yattag
 
 from i18n import translate as _
 import config
+import i18n
 import ranges
 import util
 
@@ -90,6 +91,14 @@ class RelationFiles:
     def get_housenumbers_percent_stream(self, mode: str) -> TextIO:
         """Opens the house number percent file of a relation."""
         return cast(TextIO, open(self.get_housenumbers_percent_path(), mode=mode))
+
+    def get_housenumbers_htmlcache_path(self) -> str:
+        """Builds the file name of the house number HTML cache file of a relation."""
+        return os.path.join(self.__workdir, "%s.htmlcache.%s" % (self.__name, i18n.get_language()))
+
+    def get_housenumbers_htmlcache_stream(self, mode: str) -> TextIO:
+        """Opens the house number HTML cache file of a relation."""
+        return cast(TextIO, open(self.get_housenumbers_htmlcache_path(), mode=mode))
 
     def get_streets_percent_path(self) -> str:
         """Builds the file name of the street percent file of a relation."""

--- a/cache.py
+++ b/cache.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+#
+# Copyright 2021 Miklos Vajna. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+
+"""The cache module accelerates some functions of the areas module."""
+
+import os
+
+import yattag
+
+from i18n import translate as _
+import areas
+import config
+import util
+
+
+def is_missing_housenumbers_html_cached(relation: areas.Relation) -> bool:
+    """Decides if we have an up to date cache entry or not."""
+    cache_path = relation.get_files().get_housenumbers_htmlcache_path()
+    if not os.path.exists(cache_path):
+        return False
+
+    cache_mtime = os.path.getmtime(cache_path)
+    osm_streets_path = relation.get_files().get_osm_streets_path()
+    osm_streets_mtime = os.path.getmtime(osm_streets_path)
+    if osm_streets_mtime > cache_mtime:
+        return False
+
+    osm_housenumbers_path = relation.get_files().get_osm_housenumbers_path()
+    osm_housenumbers_mtime = os.path.getmtime(osm_housenumbers_path)
+    if osm_housenumbers_mtime > cache_mtime:
+        return False
+
+    ref_housenumbers_path = relation.get_files().get_ref_housenumbers_path()
+    ref_housenumbers_mtime = os.path.getmtime(ref_housenumbers_path)
+    if ref_housenumbers_mtime > cache_mtime:
+        return False
+
+    datadir = config.get_abspath("data")
+    relation_path = os.path.join(datadir, "relation-%s.yaml" % relation.get_name())
+    relation_mtime = os.path.getmtime(relation_path)
+    if relation_mtime > cache_mtime:
+        return False
+
+    return True
+
+
+def get_missing_housenumbers_html(relation: areas.Relation) -> yattag.doc.Doc:
+    """Gets the cached HTML of the missing housenumbers for a relation."""
+    doc = yattag.doc.Doc()
+    if is_missing_housenumbers_html_cached(relation):
+        with relation.get_files().get_housenumbers_htmlcache_stream("r") as stream:
+            doc.asis(stream.read())
+        return doc
+
+    ret = relation.write_missing_housenumbers()
+    todo_street_count, todo_count, done_count, percent, table = ret
+
+    with doc.tag("p"):
+        prefix = config.Config.get_uri_prefix()
+        relation_name = relation.get_name()
+        doc.text(_("OpenStreetMap is possibly missing the below {0} house numbers for {1} streets.")
+                 .format(str(todo_count), str(todo_street_count)))
+        doc.text(_(" (existing: {0}, ready: {1}).").format(str(done_count), util.format_percent(str(percent))))
+        doc.stag("br")
+        with doc.tag("a", href="https://github.com/vmiklos/osm-gimmisn/tree/master/doc"):
+            doc.text(_("Filter incorrect information"))
+        doc.text(".")
+        doc.stag("br")
+        with doc.tag("a", href=prefix + "/missing-housenumbers/{}/view-turbo".format(relation_name)):
+            doc.text(_("Overpass turbo query for the below streets"))
+        doc.stag("br")
+        with doc.tag("a", href=prefix + "/missing-housenumbers/{}/view-result.txt".format(relation_name)):
+            doc.text(_("Plain text format"))
+        doc.stag("br")
+        with doc.tag("a", href=prefix + "/missing-housenumbers/{}/view-result.chkl".format(relation_name)):
+            doc.text(_("Checklist format"))
+
+    doc.asis(util.html_table_from_list(table).getvalue())
+    doc.asis(util.invalid_refstreets_to_html(areas.get_invalid_refstreets(relation)).getvalue())
+    doc.asis(util.invalid_filter_keys_to_html(areas.get_invalid_filter_keys(relation)).getvalue())
+
+    with relation.get_files().get_housenumbers_htmlcache_stream("w") as stream:
+        stream.write(doc.getvalue())
+
+    return doc
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Miklos Vajna and contributors.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""The test_cache module covers the cache module."""
+
+import os
+import unittest
+
+import test_config
+
+import areas
+import cache
+import config
+
+
+def get_relations() -> areas.Relations:
+    """Returns a Relations object that uses the test data and workdir."""
+    workdir = os.path.join(os.path.dirname(__file__), "workdir")
+    return areas.Relations(workdir)
+
+
+class TestIsMissingHousenumbersHtmlCached(test_config.TestCase):
+    """Tests is_missing_housenumbers_html_cached()."""
+    def test_happy(self) -> None:
+        """Tests the happy path."""
+        relations = get_relations()
+        relation = relations.get_relation("gazdagret")
+        cache.get_missing_housenumbers_html(relation)
+        self.assertTrue(cache.is_missing_housenumbers_html_cached(relation))
+
+    def test_no_cache(self) -> None:
+        """Tests the case when there is no cache."""
+        relations = get_relations()
+        relation = relations.get_relation("gazdagret")
+        cache.get_missing_housenumbers_html(relation)
+        cache_path = relation.get_files().get_housenumbers_htmlcache_path()
+        orig_exists = os.path.exists
+
+        def mock_exists(path: str) -> bool:
+            if path == cache_path:
+                return False
+            return orig_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            self.assertFalse(cache.is_missing_housenumbers_html_cached(relation))
+
+    def test_osm_housenumbers_new(self) -> None:
+        """Tests the case when osm_housenumbers is new, so the cache entry is old."""
+        relations = get_relations()
+        relation = relations.get_relation("gazdagret")
+        cache.get_missing_housenumbers_html(relation)
+        cache_path = relation.get_files().get_housenumbers_htmlcache_path()
+        osm_housenumbers_path = relation.get_files().get_osm_housenumbers_path()
+        orig_getmtime = os.path.getmtime
+
+        def mock_getmtime(path: str) -> float:
+            if path == osm_housenumbers_path:
+                return orig_getmtime(cache_path) + 1
+            return orig_getmtime(path)
+        with unittest.mock.patch('os.path.getmtime', mock_getmtime):
+            self.assertFalse(cache.is_missing_housenumbers_html_cached(relation))
+
+    def test_ref_housenumbers_new(self) -> None:
+        """Tests the case when ref_housenumbers is new, so the cache entry is old."""
+        relations = get_relations()
+        relation = relations.get_relation("gazdagret")
+        cache.get_missing_housenumbers_html(relation)
+        cache_path = relation.get_files().get_housenumbers_htmlcache_path()
+        ref_housenumbers_path = relation.get_files().get_ref_housenumbers_path()
+        orig_getmtime = os.path.getmtime
+
+        def mock_getmtime(path: str) -> float:
+            if path == ref_housenumbers_path:
+                return orig_getmtime(cache_path) + 1
+            return orig_getmtime(path)
+        with unittest.mock.patch('os.path.getmtime', mock_getmtime):
+            self.assertFalse(cache.is_missing_housenumbers_html_cached(relation))
+
+    def test_relation_new(self) -> None:
+        """Tests the case when relation is new, so the cache entry is old."""
+        relations = get_relations()
+        relation = relations.get_relation("gazdagret")
+        cache.get_missing_housenumbers_html(relation)
+        cache_path = relation.get_files().get_housenumbers_htmlcache_path()
+        datadir = config.get_abspath("data")
+        relation_path = os.path.join(datadir, "relation-%s.yaml" % relation.get_name())
+        orig_getmtime = os.path.getmtime
+
+        def mock_getmtime(path: str) -> float:
+            if path == relation_path:
+                return orig_getmtime(cache_path) + 1
+            return orig_getmtime(path)
+        with unittest.mock.patch('os.path.getmtime', mock_getmtime):
+            self.assertFalse(cache.is_missing_housenumbers_html_cached(relation))
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/wsgi.py
+++ b/wsgi.py
@@ -27,6 +27,7 @@ import yattag
 
 from i18n import translate as _
 import areas
+import cache
 import config
 import overpass_query
 import util
@@ -155,30 +156,7 @@ def missing_housenumbers_view_res(relations: areas.Relations, request_uri: str) 
     elif not os.path.exists(relation.get_files().get_ref_housenumbers_path()):
         doc.asis(webframe.handle_no_ref_housenumbers(prefix, relation_name).getvalue())
     else:
-        ret = relation.write_missing_housenumbers()
-        todo_street_count, todo_count, done_count, percent, table = ret
-
-        with doc.tag("p"):
-            doc.text(_("OpenStreetMap is possibly missing the below {0} house numbers for {1} streets.")
-                     .format(str(todo_count), str(todo_street_count)))
-            doc.text(_(" (existing: {0}, ready: {1}).").format(str(done_count), util.format_percent(str(percent))))
-            doc.stag("br")
-            with doc.tag("a", href="https://github.com/vmiklos/osm-gimmisn/tree/master/doc"):
-                doc.text(_("Filter incorrect information"))
-            doc.text(".")
-            doc.stag("br")
-            with doc.tag("a", href=prefix + "/missing-housenumbers/{}/view-turbo".format(relation_name)):
-                doc.text(_("Overpass turbo query for the below streets"))
-            doc.stag("br")
-            with doc.tag("a", href=prefix + "/missing-housenumbers/{}/view-result.txt".format(relation_name)):
-                doc.text(_("Plain text format"))
-            doc.stag("br")
-            with doc.tag("a", href=prefix + "/missing-housenumbers/{}/view-result.chkl".format(relation_name)):
-                doc.text(_("Checklist format"))
-
-        doc.asis(util.html_table_from_list(table).getvalue())
-        doc.asis(util.invalid_refstreets_to_html(areas.get_invalid_refstreets(relation)).getvalue())
-        doc.asis(util.invalid_filter_keys_to_html(areas.get_invalid_filter_keys(relation)).getvalue())
+        doc = cache.get_missing_housenumbers_html(relation)
     return doc
 
 


### PR DESCRIPTION
Old cost for budapest_11: 26.888 seconds

New cost: 0.054 seconds

I.e. once you hit the cached cache, the new cost is 0.2% of the baseline.

Note that the caches is not versioned, the path can be always extended
to contain a version number later if it's needed.

Also note that the cached content is localized, so the language is part
of the cache key.

Fixes <https://github.com/vmiklos/osm-gimmisn/issues/1119>.

Change-Id: Ia3d11833b247879b6452d47b93c43d7576902269
