### PR TITLE
cron: build missing housenumbers html cache

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -23,6 +23,7 @@ import traceback
 import urllib.error
 
 import areas
+import cache
 import config
 import overpass_query
 import stats
@@ -147,6 +148,7 @@ def update_missing_housenumbers(relations: areas.Relations, update: bool) -> Non
             continue
 
         relation.write_missing_housenumbers()
+        cache.get_missing_housenumbers_html(relation)
     info("update_missing_housenumbers: end")
 
 


### PR DESCRIPTION
So the typical user gets the cached version even the first time the page
is visited.

Change-Id: I6012d9b6e2324da10ae598bc6898f52be9140d64
