### PR TITLE
missing-housenumbers html cache: handle missing relation yaml

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -41,8 +41,7 @@ def is_missing_housenumbers_html_cached(relation: areas.Relation) -> bool:
 
     datadir = config.get_abspath("data")
     relation_path = os.path.join(datadir, "relation-%s.yaml" % relation.get_name())
-    relation_mtime = os.path.getmtime(relation_path)
-    if relation_mtime > cache_mtime:
+    if os.path.exists(relation_path) and os.path.getmtime(relation_path) > cache_mtime:
         return False
 
     return True


### PR DESCRIPTION
It's valid to not have filters, which is common for new relations.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/1225>.

Change-Id: Icd03bee75e6362f2054dc060c442cd397dc70f6e
