### PR TITLE
Cache missing-housenumbers plain text output

### DIFF
--- a/areas.py
+++ b/areas.py
@@ -100,6 +100,14 @@ class RelationFiles:
         """Opens the house number HTML cache file of a relation."""
         return cast(TextIO, open(self.get_housenumbers_htmlcache_path(), mode=mode))
 
+    def get_housenumbers_txtcache_path(self) -> str:
+        """Builds the file name of the house number plain text cache file of a relation."""
+        return os.path.join(self.__workdir, "%s.txtcache" % self.__name)
+
+    def get_housenumbers_txtcache_stream(self, mode: str) -> TextIO:
+        """Opens the house number plain text cache file of a relation."""
+        return cast(TextIO, open(self.get_housenumbers_txtcache_path(), mode=mode))
+
     def get_streets_percent_path(self) -> str:
         """Builds the file name of the street percent file of a relation."""
         return os.path.join(self.__workdir, "%s-streets.percent" % self.__name)

--- a/cache.py
+++ b/cache.py
@@ -7,6 +7,8 @@
 
 """The cache module accelerates some functions of the areas module."""
 
+from typing import List
+import locale
 import os
 
 import yattag
@@ -17,34 +19,32 @@ import config
 import util
 
 
-def is_missing_housenumbers_html_cached(relation: areas.Relation) -> bool:
+def is_cache_outdated(cache_path: str, dependencies: List[str]) -> bool:
     """Decides if we have an up to date cache entry or not."""
-    cache_path = relation.get_files().get_housenumbers_htmlcache_path()
     if not os.path.exists(cache_path):
         return False
 
     cache_mtime = os.path.getmtime(cache_path)
-    osm_streets_path = relation.get_files().get_osm_streets_path()
-    osm_streets_mtime = os.path.getmtime(osm_streets_path)
-    if osm_streets_mtime > cache_mtime:
-        return False
 
-    osm_housenumbers_path = relation.get_files().get_osm_housenumbers_path()
-    osm_housenumbers_mtime = os.path.getmtime(osm_housenumbers_path)
-    if osm_housenumbers_mtime > cache_mtime:
-        return False
-
-    ref_housenumbers_path = relation.get_files().get_ref_housenumbers_path()
-    ref_housenumbers_mtime = os.path.getmtime(ref_housenumbers_path)
-    if ref_housenumbers_mtime > cache_mtime:
-        return False
-
-    datadir = config.get_abspath("data")
-    relation_path = os.path.join(datadir, "relation-%s.yaml" % relation.get_name())
-    if os.path.exists(relation_path) and os.path.getmtime(relation_path) > cache_mtime:
-        return False
+    for dependency in dependencies:
+        if os.path.exists(dependency) and os.path.getmtime(dependency) > cache_mtime:
+            return False
 
     return True
+
+
+def is_missing_housenumbers_html_cached(relation: areas.Relation) -> bool:
+    """Decides if we have an up to date HTML cache entry or not."""
+    cache_path = relation.get_files().get_housenumbers_htmlcache_path()
+    datadir = config.get_abspath("data")
+    relation_path = os.path.join(datadir, "relation-%s.yaml" % relation.get_name())
+    dependencies = [
+        relation.get_files().get_osm_streets_path(),
+        relation.get_files().get_osm_housenumbers_path(),
+        relation.get_files().get_ref_housenumbers_path(),
+        relation_path
+    ]
+    return is_cache_outdated(cache_path, dependencies)
 
 
 def get_missing_housenumbers_html(relation: areas.Relation) -> yattag.doc.Doc:
@@ -86,5 +86,48 @@ def get_missing_housenumbers_html(relation: areas.Relation) -> yattag.doc.Doc:
         stream.write(doc.getvalue())
 
     return doc
+
+
+def is_missing_housenumbers_txt_cached(relation: areas.Relation) -> bool:
+    """Decides if we have an up to date plain text cache entry or not."""
+    cache_path = relation.get_files().get_housenumbers_txtcache_path()
+    datadir = config.get_abspath("data")
+    relation_path = os.path.join(datadir, "relation-%s.yaml" % relation.get_name())
+    dependencies = [
+        relation.get_files().get_osm_streets_path(),
+        relation.get_files().get_osm_housenumbers_path(),
+        relation.get_files().get_ref_housenumbers_path(),
+        relation_path
+    ]
+    return is_cache_outdated(cache_path, dependencies)
+
+
+def get_missing_housenumbers_txt(relation: areas.Relation) -> str:
+    """Gets the cached plain text of the missing housenumbers for a relation."""
+    output = ""
+    if is_missing_housenumbers_txt_cached(relation):
+        with relation.get_files().get_housenumbers_txtcache_stream("r") as stream:
+            output = stream.read()
+        return output
+
+    ongoing_streets, _ignore = relation.get_missing_housenumbers()
+    table = []
+    for result in ongoing_streets:
+        range_list = util.get_housenumber_ranges(result[1])
+        range_strings = [i.get_number() for i in range_list]
+        # Street name, only_in_reference items.
+        if not relation.get_config().get_street_is_even_odd(result[0].get_osm_name()):
+            result_sorted = sorted(range_strings, key=util.split_house_number)
+            row = result[0].get_osm_name() + "\t[" + ", ".join(result_sorted) + "]"
+        else:
+            elements = util.format_even_odd(range_list, doc=None)
+            row = result[0].get_osm_name() + "\t[" + "], [".join(elements) + "]"
+        table.append(row)
+    table.sort(key=locale.strxfrm)
+    output += "\n".join(table)
+
+    with relation.get_files().get_housenumbers_txtcache_stream("w") as stream:
+        stream.write(output)
+    return output
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/cron.py
+++ b/cron.py
@@ -154,6 +154,7 @@ def update_missing_housenumbers(relations: areas.Relations, update: bool) -> Non
             i18n.set_language(language)
             cache.get_missing_housenumbers_html(relation)
         i18n.set_language(orig_language)
+        cache.get_missing_housenumbers_txt(relation)
     info("update_missing_housenumbers: end")
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -95,4 +95,14 @@ class TestIsMissingHousenumbersHtmlCached(test_config.TestCase):
         with unittest.mock.patch('os.path.getmtime', mock_getmtime):
             self.assertFalse(cache.is_missing_housenumbers_html_cached(relation))
 
+
+class TestIsMissingHousenumbersTxtCached(test_config.TestCase):
+    """Tests is_missing_housenumbers_txt_cached()."""
+    def test_happy(self) -> None:
+        """Tests the happy path."""
+        relations = get_relations()
+        relation = relations.get_relation("gazdagret")
+        cache.get_missing_housenumbers_txt(relation)
+        self.assertTrue(cache.is_missing_housenumbers_txt_cached(relation))
+
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/wsgi.py
+++ b/wsgi.py
@@ -217,22 +217,7 @@ def missing_housenumbers_view_txt(relations: areas.Relations, request_uri: str) 
     elif not os.path.exists(relation.get_files().get_ref_housenumbers_path()):
         output += _("No reference house numbers")
     else:
-        ongoing_streets, _ignore = relation.get_missing_housenumbers()
-
-        table = []
-        for result in ongoing_streets:
-            range_list = util.get_housenumber_ranges(result[1])
-            range_strings = [i.get_number() for i in range_list]
-            # Street name, only_in_reference items.
-            if not relation.get_config().get_street_is_even_odd(result[0].get_osm_name()):
-                result_sorted = sorted(range_strings, key=util.split_house_number)
-                row = result[0].get_osm_name() + "\t[" + ", ".join(result_sorted) + "]"
-            else:
-                elements = util.format_even_odd(range_list, doc=None)
-                row = result[0].get_osm_name() + "\t[" + "], [".join(elements) + "]"
-            table.append(row)
-        table.sort(key=locale.strxfrm)
-        output += "\n".join(table)
+        output = cache.get_missing_housenumbers_txt(relation)
     return output
 
 


### PR DESCRIPTION
Old cost for budapest_11: 28.123 seconds

New cost: 0.053 seconds

I.e. once you hit the cached cache, the new cost is 0.19% of the baseline.

Note that the caches is not versioned, the path can be always extended
to contain a version number later if it's needed.

Also note that the cached content is not localized, so the language is
not part of the cache key.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/1206>.

Change-Id: Iad51dafcddedcd5dca13d5b59c3f645e59e3b145
