### PR TITLE
parse_access_log: ignore complete areas harder

### DIFF
--- a/tests/test_parse_access_log.py
+++ b/tests/test_parse_access_log.py
@@ -12,14 +12,22 @@ from typing import Set
 from typing import Tuple
 import datetime
 import io
+import os
 import subprocess
 import unittest
 import unittest.mock
 
 import test_config
 
+import areas
 import config
 import parse_access_log
+
+
+def get_relations() -> areas.Relations:
+    """Returns a Relations object that uses the test data and workdir."""
+    workdir = os.path.join(os.path.dirname(__file__), "workdir")
+    return areas.Relations(workdir)
 
 
 class MockDate(datetime.date):
@@ -96,6 +104,13 @@ class TestCheckTopEditedRelations(test_config.TestCase):
                 self.assertIn("city4", frequent_relations)
                 self.assertNotIn("bar", frequent_relations)
                 self.assertNotIn("baz", frequent_relations)
+
+
+class TestIsCompleteRelation(test_config.TestCase):
+    """Tests is_complete_relation()."""
+    def test_happy(self) -> None:
+        """Tests the happy path."""
+        self.assertFalse(parse_access_log.is_complete_relation(get_relations(), "gazdagret"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously a complete relation was just ignored from the frequent
relations set, which typically resulted in active=false.

Now we explicitly expect that in case it's complete then it should be
active=false.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/1201>.

Change-Id: I173a38320d1625db8a28404a347c286cecf2c2d0
