### PR TITLE
test: clean up not needed get_relation() functions

### DIFF
--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -23,17 +23,11 @@ import ranges
 import util
 
 
-def get_relations() -> areas.Relations:
-    """Returns a Relations object that uses the test data and workdir."""
-    workdir = os.path.join(os.path.dirname(__file__), "workdir")
-    return areas.Relations(workdir)
-
-
-class TestRelationGetOsmStreets(unittest.TestCase):
+class TestRelationGetOsmStreets(test_config.TestCase):
     """Tests Relation.get_osm_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("test")
         actual = [i.get_osm_name() for i in relation.get_osm_streets()]
         expected = ['B1', 'B2', 'HB1', 'HB2']
@@ -41,7 +35,7 @@ class TestRelationGetOsmStreets(unittest.TestCase):
 
     def test_street_is_node(self) -> None:
         """Tests the case when the street name is coming from a house number (node)."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gh830")
         actual = relation.get_osm_streets()
         self.assertEqual(len(actual), 1)
@@ -49,7 +43,7 @@ class TestRelationGetOsmStreets(unittest.TestCase):
 
     def test_no_house_number(self) -> None:
         """Tests the case when we have streets, but no house numbers."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("ujbuda")
         actual = [i.get_osm_name() for i in relation.get_osm_streets()]
         expected = ['OSM Name 1', 'Törökugrató utca', 'Tűzkő utca']
@@ -57,7 +51,7 @@ class TestRelationGetOsmStreets(unittest.TestCase):
 
     def test_conscriptionnumber(self) -> None:
         """Tests when there is only an addr:conscriptionnumber."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gh754"
         relation = relations.get_relation(relation_name)
         streets = [i.get_osm_name() for i in relation.get_osm_streets()]
@@ -70,7 +64,7 @@ class TestRelationGetOsmStreetsQuery(test_config.TestCase):
     """Tests Relation.get_osm_streets_query()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         self.assertEqual(os.path.join(os.path.dirname(__file__), "workdir"), relations.get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -82,18 +76,18 @@ class TestRelationGetOsmHousenumbersQuery(test_config.TestCase):
     """Tests Relation.get_osm_housenumbers_query()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         ret = relation.get_osm_housenumbers_query()
         self.assertEqual(ret, 'housenr aaa 2713748 bbb 3602713748 ccc\n')
 
 
-class TestRelationFilesWriteOsmStreets(unittest.TestCase):
+class TestRelationFilesWriteOsmStreets(test_config.TestCase):
     """Tests RelationFiles.write_osm_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         result_from_overpass = "@id\tname\n1\tTűzkő utca\n2\tTörökugrató utca\n3\tOSM Name 1\n4\tHamzsabégi út\n"
@@ -103,11 +97,11 @@ class TestRelationFilesWriteOsmStreets(unittest.TestCase):
         self.assertEqual(actual, expected)
 
 
-class TestRelationFilesWriteOsmHousenumbers(unittest.TestCase):
+class TestRelationFilesWriteOsmHousenumbers(test_config.TestCase):
     """Tests RelationFiles.write_osm_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gazdagret"
         result_from_overpass = "@id\taddr:street\taddr:housenumber\taddr:postcode\taddr:housename\t"
         result_from_overpass += "addr:conscriptionnumber\taddr:flats\taddr:floor\taddr:door\taddr:unit\tname\t@type\n\n"
@@ -130,7 +124,7 @@ class TestRelationGetStreetRanges(test_config.TestCase):
     """Tests Relation.get_street_ranges()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         filters = relation.get_street_ranges()
         expected_filters = {
@@ -144,14 +138,14 @@ class TestRelationGetStreetRanges(test_config.TestCase):
             'OSM Name 2': 'Ref Name 2',
             'Misspelled OSM Name 1': 'OSM Name 1',
         }
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         self.assertEqual(relations.get_relation("gazdagret").get_config().get_refstreets(), expected_streets)
         street_blacklist = relations.get_relation("gazdagret").get_config().get_street_filters()
         self.assertEqual(street_blacklist, ['Only In Ref Nonsense utca'])
 
     def test_empty(self) -> None:
         """Tests when the filter file is empty."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("empty")
         filters = relation.get_street_ranges()
         self.assertEqual(filters, {})
@@ -161,7 +155,7 @@ class TestRelationGetRefStreetFromOsmStreet(test_config.TestCase):
     """Tests Relation.get_ref_street_from_osm_street()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         street = "Budaörsi út"
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -173,7 +167,7 @@ class TestRelationGetRefStreetFromOsmStreet(test_config.TestCase):
 
     def test_refsettlement_override(self) -> None:
         """Tests street-specific refsettlement override."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         street = "Teszt utca"
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -185,7 +179,7 @@ class TestRelationGetRefStreetFromOsmStreet(test_config.TestCase):
 
     def test_refstreets(self) -> None:
         """Tests OSM -> ref name mapping."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         street = "OSM Name 1"
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -197,7 +191,7 @@ class TestRelationGetRefStreetFromOsmStreet(test_config.TestCase):
 
     def test_nosuchrelation(self) -> None:
         """Tests a relation without a filter file."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         street = "OSM Name 1"
         relation_name = "nosuchrelation"
         relation = relations.get_relation(relation_name)
@@ -209,7 +203,7 @@ class TestRelationGetRefStreetFromOsmStreet(test_config.TestCase):
 
     def test_emptyrelation(self) -> None:
         """Tests a relation with an empty filter file."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         street = "OSM Name 1"
         relation_name = "empty"
         relation = relations.get_relation(relation_name)
@@ -221,7 +215,7 @@ class TestRelationGetRefStreetFromOsmStreet(test_config.TestCase):
 
     def test_range_level_override(self) -> None:
         """Tests the refsettlement range-level override."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         street = "Csiki-hegyek utca"
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -240,7 +234,7 @@ class TestNormalize(test_config.TestCase):
     """
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "139", "Budaörsi út", normalizers)
@@ -248,7 +242,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_not_in_range(self) -> None:
         """Tests when the number is not in range."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "999", "Budaörsi út", normalizers)
@@ -256,7 +250,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_not_a_number(self) -> None:
         """Tests the case when the house number is not a number."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "x", "Budaörsi út", normalizers)
@@ -264,7 +258,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_nofilter(self) -> None:
         """Tests the case when there is no filter for this street."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "1", "Budaörs út", normalizers)
@@ -272,7 +266,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_semicolon(self) -> None:
         """Tests the case when ';' is a separator."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "1;2", "Budaörs út", normalizers)
@@ -280,7 +274,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval(self) -> None:
         """Tests the 2-6 case: means implicit 4."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "2-6", "Budaörs út", normalizers)
@@ -288,7 +282,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval_parity(self) -> None:
         """Tests the 5-8 case: means just 5 and 8 as the parity doesn't match."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "5-8", "Budaörs út", normalizers)
@@ -296,7 +290,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval_interp_all(self) -> None:
         """Tests the 2-5 case: means implicit 3 and 4."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = [i.get_number() for i in areas.normalize(relation, "2-5", "Hamzsabégi út", normalizers)]
@@ -304,7 +298,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval_filter(self) -> None:
         """Tests the case where x-y is partially filtered out."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         # filter is 137-165
@@ -314,7 +308,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval_block(self) -> None:
         """Tests the case where x-y is nonsense: y is too large."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "2-2000", "Budaörs út", normalizers)
@@ -324,7 +318,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval_block2(self) -> None:
         """Tests the case where x-y is nonsense: y-x is too large."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "2-56", "Budaörs út", normalizers)
@@ -333,7 +327,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval_block3(self) -> None:
         """Tests the case where x-y is nonsense: x is 0."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "0-42", "Budaörs út", normalizers)
@@ -342,7 +336,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval_block4(self) -> None:
         """Tests the case where x-y is only partially useful: x is OK, but y is a suffix."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "42-1", "Budaörs út", normalizers)
@@ -351,7 +345,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_keep_suffix(self) -> None:
         """Tests that the * suffix is preserved."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_number = areas.normalize(relation, "1*", "Budaörs út", normalizers)
@@ -361,7 +355,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_comma(self) -> None:
         """Tests the case when ',' is a separator."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "2,6", "Budaörs út", normalizers)
@@ -369,12 +363,12 @@ class TestNormalize(test_config.TestCase):
         self.assertEqual([i.get_number() for i in house_numbers], ["2", "6"])
 
 
-class TestRelationGetRefStreets(unittest.TestCase):
+class TestRelationGetRefStreets(test_config.TestCase):
     """Tests Relation.GetRefStreets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
         relation_name = "gazdagret"
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation(relation_name)
         house_numbers = relation.get_ref_streets()
         self.assertEqual(house_numbers, ['Hamzsabégi út',
@@ -385,13 +379,13 @@ class TestRelationGetRefStreets(unittest.TestCase):
                                          'Tűzkő utca'])
 
 
-class TestRelationGetOsmHouseNumbers(unittest.TestCase):
+class TestRelationGetOsmHouseNumbers(test_config.TestCase):
     """Tests Relation.get_osm_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
         relation_name = "gazdagret"
         street_name = "Törökugrató utca"
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation(relation_name)
         house_numbers = relation.get_osm_housenumbers(street_name)
         self.assertEqual([i.get_number() for i in house_numbers], ["1", "2"])
@@ -399,7 +393,7 @@ class TestRelationGetOsmHouseNumbers(unittest.TestCase):
     def test_addr_place(self) -> None:
         """Tests the case when addr:place is used instead of addr:street."""
         relation_name = "gh964"
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation(relation_name)
         street_name = "Tolvajos tanya"
         house_numbers = relation.get_osm_housenumbers(street_name)
@@ -410,7 +404,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
     """Tests Relation.get_missing_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         ongoing_streets, done_streets = relation.get_missing_housenumbers()
@@ -427,7 +421,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
 
     def test_letter_suffix(self) -> None:
         """Tests that 7/A is detected when 7/B is already mapped."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gh267"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -443,7 +437,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
 
     def test_letter_suffix_invalid(self) -> None:
         """Tests how 'invalid' interacts with normalization."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gh296"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -467,7 +461,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
 
     def test_invalid_simplify(self) -> None:
         """Tests how 'invalid' interacts with housenumber-letters: true or false."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gh385"
         relation = relations.get_relation(relation_name)
 
@@ -508,7 +502,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
 
     def test_letter_suffix_normalize(self) -> None:
         """Tests that '42 A' vs '42/A' is recognized as a match."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gh286"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -524,7 +518,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
 
     def test_letter_suffix_source_suffix(self) -> None:
         """Tests that '42/A*' and '42/a' matches."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gh299"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -535,7 +529,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
 
     def test_letter_suffix_normalize_semicolon(self) -> None:
         """Tests that 'a' is not stripped from '1;3a'."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gh303"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -554,7 +548,7 @@ class TestRelationGetMissingStreets(test_config.TestCase):
     """Tests Relation.get_missing_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         only_in_reference, in_both = relation.get_missing_streets()
@@ -569,7 +563,7 @@ class TestRelationGetAdditionalStreets(test_config.TestCase):
     """Tests Relation.get_additional_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         only_in_osm = relation.get_additional_streets()
@@ -582,7 +576,7 @@ class TestRelationGetAdditionalStreets(test_config.TestCase):
 
     def test_no_osm_street_filters(self) -> None:
         """Tests when the osm-street-filters key is missing."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gh385"
         relation = relations.get_relation(relation_name)
         self.assertEqual(relation.get_config().get_osm_street_filters(), [])
@@ -603,7 +597,7 @@ class TestRelationWriteMissingHouseNumbers(test_config.TestCase):
     """Tests Relation.write_missing_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         expected = util.get_content(relations.get_workdir(), "gazdagret.percent")
@@ -623,7 +617,7 @@ class TestRelationWriteMissingHouseNumbers(test_config.TestCase):
 
     def test_empty(self) -> None:
         """Tests the case when percent can't be determined."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "empty"
         relation = relations.get_relation(relation_name)
         ret = relation.write_missing_housenumbers()
@@ -634,7 +628,7 @@ class TestRelationWriteMissingHouseNumbers(test_config.TestCase):
 
     def test_interpolation_all(self) -> None:
         """Tests the case when the street is interpolation=all and coloring is wanted."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "budafok"
         relation = relations.get_relation(relation_name)
         ret = relation.write_missing_housenumbers()
@@ -647,7 +641,7 @@ class TestRelationWriteMissingHouseNumbers(test_config.TestCase):
 
     def test_sorting(self) -> None:
         """Tests that sorting is performed after range reduction."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gh414"
         relation = relations.get_relation(relation_name)
         ret = relation.write_missing_housenumbers()
@@ -664,7 +658,7 @@ class TestRelationWriteMissingStreets(test_config.TestCase):
     """Tests Relation.write_missing_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         expected = util.get_content(relations.get_workdir(), "gazdagret-streets.percent")
@@ -679,7 +673,7 @@ class TestRelationWriteMissingStreets(test_config.TestCase):
 
     def test_empty(self) -> None:
         """Tests the case when percent can't be determined."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "empty"
         relation = relations.get_relation(relation_name)
         ret = relation.write_missing_streets()
@@ -693,7 +687,7 @@ class TestRelationBuildRefHousenumbers(test_config.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
         memory_cache = util.build_reference_cache(refpath, "01")
         relation_name = "gazdagret"
@@ -712,7 +706,7 @@ class TestRelationBuildRefHousenumbers(test_config.TestCase):
 
     def test_missing(self) -> None:
         """Tests the case when the street is not in the reference."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
         memory_cache = util.build_reference_cache(refpath, "01")
@@ -731,7 +725,7 @@ class TestRelationBuildRefStreets(test_config.TestCase):
         refpath = os.path.join(refdir, "utcak_20190514.tsv")
         memory_cache = util.build_street_reference_cache(refpath)
         relation_name = "gazdagret"
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation(relation_name)
         ret = relation.get_config().build_ref_streets(memory_cache)
         self.assertEqual(ret, ['Törökugrató utca',
@@ -749,7 +743,7 @@ class TestRelationWriteRefHousenumbers(test_config.TestCase):
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
         refpath2 = os.path.join(refdir, "hazszamok_kieg_20190808.tsv")
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gazdagret"
         expected = util.get_content(relations.get_workdir(), "street-housenumbers-reference-gazdagret.lst")
         relation = relations.get_relation(relation_name)
@@ -761,7 +755,7 @@ class TestRelationWriteRefHousenumbers(test_config.TestCase):
         """Tests the case when the refcounty code is missing in the reference."""
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "nosuchrefcounty"
         relation = relations.get_relation(relation_name)
         try:
@@ -773,7 +767,7 @@ class TestRelationWriteRefHousenumbers(test_config.TestCase):
         """Tests the case when the refsettlement code is missing in the reference."""
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "nosuchrefsettlement"
         relation = relations.get_relation(relation_name)
         try:
@@ -787,7 +781,7 @@ class TestRelationWriteRefStreets(test_config.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         refpath = config.get_abspath(os.path.join("refdir", "utcak_20190514.tsv"))
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         expected = util.get_content(relations.get_workdir(), "streets-reference-gazdagret.lst")
@@ -800,7 +794,7 @@ class TestRelations(test_config.TestCase):
     """Tests the Relations class."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         expected_relation_names = [
             "budafok",
             "empty",
@@ -849,7 +843,7 @@ class TestRelationConfigMissingStreets(test_config.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         relation_name = "ujbuda"
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation(relation_name)
         ret = relation.get_config().should_check_missing_streets()
         self.assertEqual(ret, "only")
@@ -857,7 +851,7 @@ class TestRelationConfigMissingStreets(test_config.TestCase):
     def test_empty(self) -> None:
         """Tests the default value."""
         relation_name = "empty"
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation(relation_name)
         self.assertEqual(relation.get_name(), "empty")
         ret = relation.get_config().should_check_missing_streets()
@@ -866,7 +860,7 @@ class TestRelationConfigMissingStreets(test_config.TestCase):
     def test_nosuchrelation(self) -> None:
         """Tests a relation without a filter file."""
         relation_name = "nosuchrelation"
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation(relation_name)
         ret = relation.get_config().should_check_missing_streets()
         self.assertEqual(ret, "yes")
@@ -877,7 +871,7 @@ class TestRelationConfigLetterSuffixStyle(unittest.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         relation_name = "empty"
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation(relation_name)
         self.assertEqual(relation.get_config().get_letter_suffix_style(), util.LetterSuffixStyle.UPPER)
         relation.get_config().set_letter_suffix_style(util.LetterSuffixStyle.LOWER)
@@ -888,7 +882,7 @@ class TestRefmegyeGetName(unittest.TestCase):
     """Tests refcounty_get_name()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         self.assertEqual(relations.refcounty_get_name("01"), "Budapest")
         self.assertEqual(relations.refcounty_get_name("99"), "")
 
@@ -897,7 +891,7 @@ class TestRefmegyeGetReftelepulesIds(test_config.TestCase):
     """Tests refcounty_get_refsettlement_ids()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         self.assertEqual(relations.refcounty_get_refsettlement_ids("01"), ["011", "012"])
         self.assertEqual(relations.refcounty_get_refsettlement_ids("99"), [])
 
@@ -906,7 +900,7 @@ class TestReftelepulesGetName(test_config.TestCase):
     """Tests refsettlement_get_name()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         self.assertEqual(relations.refsettlement_get_name("01", "011"), "Újbuda")
         self.assertEqual(relations.refsettlement_get_name("99", ""), "")
         self.assertEqual(relations.refsettlement_get_name("01", "99"), "")
@@ -916,7 +910,7 @@ class TestRelationsGetAliases(test_config.TestCase):
     """Tests Relalations.get_aliases()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         # Expect an alias -> canonicalname map.
         expected = {
             "budapest_22": "budafok"
@@ -928,7 +922,7 @@ class TestRelationStreetIsEvenOdd(test_config.TestCase):
     """Tests RelationConfig.get_street_is_even_odd()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         self.assertFalse(relation.get_config().get_street_is_even_odd("Hamzsabégi út"))
 
@@ -939,7 +933,7 @@ class TestRelationShowRefstreet(test_config.TestCase):
     """Tests RelationConfig.should_show_ref_street()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         self.assertFalse(relation.should_show_ref_street("Törökugrató utca"))
         self.assertTrue(relation.should_show_ref_street("Hamzsabégi út"))
@@ -949,7 +943,7 @@ class TestRelationIsActive(test_config.TestCase):
     """Tests RelationConfig.is_active()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         self.assertTrue(relation.get_config().is_active())
 
@@ -958,7 +952,7 @@ class TestMakeTurboQueryForStreets(test_config.TestCase):
     """Tests make_turbo_query_for_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         fro = ["A2"]
         ret = areas.make_turbo_query_for_streets(relation, fro)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -16,24 +16,18 @@ import cache
 import config
 
 
-def get_relations() -> areas.Relations:
-    """Returns a Relations object that uses the test data and workdir."""
-    workdir = os.path.join(os.path.dirname(__file__), "workdir")
-    return areas.Relations(workdir)
-
-
 class TestIsMissingHousenumbersHtmlCached(test_config.TestCase):
     """Tests is_missing_housenumbers_html_cached()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         cache.get_missing_housenumbers_html(relation)
         self.assertTrue(cache.is_missing_housenumbers_html_cached(relation))
 
     def test_no_cache(self) -> None:
         """Tests the case when there is no cache."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         cache.get_missing_housenumbers_html(relation)
         cache_path = relation.get_files().get_housenumbers_htmlcache_path()
@@ -48,7 +42,7 @@ class TestIsMissingHousenumbersHtmlCached(test_config.TestCase):
 
     def test_osm_housenumbers_new(self) -> None:
         """Tests the case when osm_housenumbers is new, so the cache entry is old."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         cache.get_missing_housenumbers_html(relation)
         cache_path = relation.get_files().get_housenumbers_htmlcache_path()
@@ -64,7 +58,7 @@ class TestIsMissingHousenumbersHtmlCached(test_config.TestCase):
 
     def test_ref_housenumbers_new(self) -> None:
         """Tests the case when ref_housenumbers is new, so the cache entry is old."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         cache.get_missing_housenumbers_html(relation)
         cache_path = relation.get_files().get_housenumbers_htmlcache_path()
@@ -80,7 +74,7 @@ class TestIsMissingHousenumbersHtmlCached(test_config.TestCase):
 
     def test_relation_new(self) -> None:
         """Tests the case when relation is new, so the cache entry is old."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         cache.get_missing_housenumbers_html(relation)
         cache_path = relation.get_files().get_housenumbers_htmlcache_path()
@@ -100,7 +94,7 @@ class TestIsMissingHousenumbersTxtCached(test_config.TestCase):
     """Tests is_missing_housenumbers_txt_cached()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         cache.get_missing_housenumbers_txt(relation)
         self.assertTrue(cache.is_missing_housenumbers_txt_cached(relation))

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -25,12 +25,6 @@ import cron
 import util
 
 
-def get_relations() -> areas.Relations:
-    """Returns a Relations object that uses the test data and workdir."""
-    workdir = os.path.join(os.path.dirname(__file__), "workdir")
-    return areas.Relations(workdir)
-
-
 def mock_urlopen_raise_error(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
     """Mock urlopen(), always throwing an error."""
     raise urllib.error.HTTPError(url="", code=0, msg="", hdrs={}, fp=io.BytesIO())
@@ -77,7 +71,7 @@ class TestUpdateRefHousenumbers(test_config.TestCase):
     """Tests update_ref_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         for relation_name in relations.get_active_names():
             if relation_name not in ("gazdagret", "ujbuda"):
                 relations.get_relation(relation_name).get_config().set_active(False)
@@ -99,7 +93,7 @@ class TestUpdateRefStreets(test_config.TestCase):
     """Tests update_ref_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         for relation_name in relations.get_active_names():
             # gellerthegy is streets=no
             if relation_name not in ("gazdagret", "gellerthegy"):
@@ -122,7 +116,7 @@ class TestUpdateMissingHousenumbers(test_config.TestCase):
     """Tests update_missing_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         for relation_name in relations.get_active_names():
             # ujbuda is streets=only
             if relation_name not in ("gazdagret", "ujbuda"):
@@ -144,7 +138,7 @@ class TestUpdateMissingStreets(test_config.TestCase):
     """Tests update_missing_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         for relation_name in relations.get_active_names():
             # gellerthegy is streets=no
             if relation_name not in ("gazdagret", "gellerthegy"):
@@ -166,7 +160,7 @@ class TestUpdateAdditionalStreets(test_config.TestCase):
     """Tests update_additional_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         for relation_name in relations.get_active_names():
             # gellerthegy is streets=no
             if relation_name not in ("gazdagret", "gellerthegy"):
@@ -213,9 +207,9 @@ class TestUpdateOsmHousenumbers(test_config.TestCase):
             buf.seek(0)
             return buf
 
+        relations = areas.Relations(config.Config.get_workdir())
         with unittest.mock.patch("cron.overpass_sleep", mock_overpass_sleep):
             with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-                relations = get_relations()
                 for relation_name in relations.get_active_names():
                     if relation_name != "gazdagret":
                         relations.get_relation(relation_name).get_config().set_active(False)
@@ -238,9 +232,9 @@ class TestUpdateOsmHousenumbers(test_config.TestCase):
             nonlocal mock_overpass_sleep_called
             mock_overpass_sleep_called = True
 
+        relations = areas.Relations(config.Config.get_workdir())
         with unittest.mock.patch("cron.overpass_sleep", mock_overpass_sleep):
             with unittest.mock.patch('urllib.request.urlopen', mock_urlopen_raise_error):
-                relations = get_relations()
                 for relation_name in relations.get_active_names():
                     if relation_name != "gazdagret":
                         relations.get_relation(relation_name).get_config().set_active(False)
@@ -271,9 +265,9 @@ class TestUpdateOsmStreets(test_config.TestCase):
             buf.seek(0)
             return buf
 
+        relations = areas.Relations(config.Config.get_workdir())
         with unittest.mock.patch("cron.overpass_sleep", mock_overpass_sleep):
             with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-                relations = get_relations()
                 for relation_name in relations.get_active_names():
                     if relation_name != "gazdagret":
                         relations.get_relation(relation_name).get_config().set_active(False)
@@ -296,9 +290,9 @@ class TestUpdateOsmStreets(test_config.TestCase):
             nonlocal mock_overpass_sleep_called
             mock_overpass_sleep_called = True
 
+        relations = areas.Relations(config.Config.get_workdir())
         with unittest.mock.patch("cron.overpass_sleep", mock_overpass_sleep):
             with unittest.mock.patch('urllib.request.urlopen', mock_urlopen_raise_error):
-                relations = get_relations()
                 for relation_name in relations.get_active_names():
                     if relation_name != "gazdagret":
                         relations.get_relation(relation_name).get_config().set_active(False)
@@ -410,7 +404,7 @@ class TestOurMain(test_config.TestCase):
             nonlocal calls
             calls += 1
 
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         with unittest.mock.patch("cron.update_osm_streets", count_calls):
             with unittest.mock.patch("cron.update_osm_housenumbers", count_calls):
                 with unittest.mock.patch("cron.update_ref_streets", count_calls):
@@ -439,7 +433,7 @@ class TestOurMain(test_config.TestCase):
             nonlocal calls
             calls += 1
 
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         with unittest.mock.patch("cron.update_stats", count_calls):
             cron.our_main(relations, mode="stats", update=False, overpass=True)
 

--- a/tests/test_parse_access_log.py
+++ b/tests/test_parse_access_log.py
@@ -12,7 +12,6 @@ from typing import Set
 from typing import Tuple
 import datetime
 import io
-import os
 import subprocess
 import unittest
 import unittest.mock
@@ -22,12 +21,6 @@ import test_config
 import areas
 import config
 import parse_access_log
-
-
-def get_relations() -> areas.Relations:
-    """Returns a Relations object that uses the test data and workdir."""
-    workdir = os.path.join(os.path.dirname(__file__), "workdir")
-    return areas.Relations(workdir)
 
 
 class MockDate(datetime.date):
@@ -110,7 +103,8 @@ class TestIsCompleteRelation(test_config.TestCase):
     """Tests is_complete_relation()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        self.assertFalse(parse_access_log.is_complete_relation(get_relations(), "gazdagret"))
+        relations = areas.Relations(config.Config.get_workdir())
+        self.assertFalse(parse_access_log.is_complete_relation(relations, "gazdagret"))
 
 
 if __name__ == '__main__':

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -41,12 +41,6 @@ if TYPE_CHECKING:
     from wsgiref.types import StartResponse
 
 
-def get_relations() -> areas.Relations:
-    """Returns a Relations object that uses the test data and workdir."""
-    workdir = os.path.join(os.path.dirname(__file__), "workdir")
-    return areas.Relations(workdir)
-
-
 class TestWsgi(test_config.TestCase):
     """Base class for wsgi tests."""
     def __init__(self, method_name: str) -> None:
@@ -218,7 +212,7 @@ class TestMissingHousenumbers(TestWsgi):
 
     def test_no_osm_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm streets case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_streets_path()
         real_exists = os.path.exists
@@ -234,7 +228,7 @@ class TestMissingHousenumbers(TestWsgi):
 
     def test_no_osm_housenumbers_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm housenumbers case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_housenumbers_path()
         real_exists = os.path.exists
@@ -250,7 +244,7 @@ class TestMissingHousenumbers(TestWsgi):
 
     def test_no_ref_housenumbers_well_formed(self) -> None:
         """Tests if the output is well-formed, no ref housenumbers case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_ref_housenumbers_path()
         real_exists = os.path.exists
@@ -321,14 +315,14 @@ Tűzkő utca	[1], [2]"""
                 return False
             return real_exists(path)
 
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_streets_path()
         with unittest.mock.patch('os.path.exists', mock_exists):
             result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl")
             self.assertEqual(result, "No existing streets")
 
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_housenumbers_path()
         with unittest.mock.patch('os.path.exists', mock_exists):
@@ -337,7 +331,7 @@ Tűzkő utca	[1], [2]"""
 
     def test_view_result_chkl_no_ref_housenumbers(self) -> None:
         """Tests the chkl output, no ref housenumbers case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_ref_housenumbers_path()
         real_exists = os.path.exists
@@ -352,7 +346,7 @@ Tűzkő utca	[1], [2]"""
 
     def test_view_result_txt_no_osm_streets(self) -> None:
         """Tests the txt output, no osm streets case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_streets_path()
         real_exists = os.path.exists
@@ -367,7 +361,7 @@ Tűzkő utca	[1], [2]"""
 
     def test_view_result_txt_no_osm_housenumbers(self) -> None:
         """Tests the txt output, no osm housenumbers case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_housenumbers_path()
         real_exists = os.path.exists
@@ -382,7 +376,7 @@ Tűzkő utca	[1], [2]"""
 
     def test_view_result_txt_no_ref_housenumbers(self) -> None:
         """Tests the txt output, no ref housenumbers case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_ref_housenumbers_path()
         real_exists = os.path.exists
@@ -465,7 +459,7 @@ class TestStreetHousenumbers(TestWsgi):
 
     def test_no_osm_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm streets case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_housenumbers_path()
         real_exists = os.path.exists
@@ -502,7 +496,7 @@ class TestMissingStreets(TestWsgi):
 
     def test_no_osm_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm streets case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_streets_path()
         real_exists = os.path.exists
@@ -518,7 +512,7 @@ class TestMissingStreets(TestWsgi):
 
     def test_no_ref_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no ref streets case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_ref_streets_path()
         real_exists = os.path.exists
@@ -544,7 +538,7 @@ class TestMissingStreets(TestWsgi):
 
     def test_view_result_txt_no_osm_streets(self) -> None:
         """Tests the txt output, no osm streets case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_streets_path()
         real_exists = os.path.exists
@@ -559,7 +553,7 @@ class TestMissingStreets(TestWsgi):
 
     def test_view_result_txt_no_ref_streets(self) -> None:
         """Tests the txt output, no ref streets case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_ref_streets_path()
         real_exists = os.path.exists
@@ -619,7 +613,7 @@ class TestAdditionalStreets(TestWsgi):
 
     def test_no_osm_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm streets case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_streets_path()
         real_exists = os.path.exists
@@ -635,7 +629,7 @@ class TestAdditionalStreets(TestWsgi):
 
     def test_no_ref_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no ref streets case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_ref_streets_path()
         real_exists = os.path.exists
@@ -663,7 +657,8 @@ class TestMain(TestWsgi):
         environ = {
             "PATH_INFO": ""
         }
-        ret = webframe.get_request_uri(environ, get_relations())
+        relations = areas.Relations(config.Config.get_workdir())
+        ret = webframe.get_request_uri(environ, relations)
         self.assertEqual(ret, "")
 
     def test_filter_for_incomplete_well_formed(self) -> None:

--- a/tests/test_wsgi_additional.py
+++ b/tests/test_wsgi_additional.py
@@ -13,12 +13,7 @@ import unittest.mock
 import test_wsgi
 
 import areas
-
-
-def get_relations() -> areas.Relations:
-    """Returns a Relations object that uses the test data and workdir."""
-    workdir = os.path.join(os.path.dirname(__file__), "workdir")
-    return areas.Relations(workdir)
+import config
 
 
 class TestStreets(test_wsgi.TestWsgi):
@@ -35,7 +30,7 @@ class TestStreets(test_wsgi.TestWsgi):
 
     def test_view_result_txt_no_osm_streets(self) -> None:
         """Tests the txt output, no osm streets case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_streets_path()
         real_exists = os.path.exists
@@ -50,7 +45,7 @@ class TestStreets(test_wsgi.TestWsgi):
 
     def test_view_result_txt_no_ref_streets(self) -> None:
         """Tests the txt output, no ref streets case."""
-        relations = get_relations()
+        relations = areas.Relations(config.Config.get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_ref_streets_path()
         real_exists = os.path.exists

--- a/tests/test_wsgi_json.py
+++ b/tests/test_wsgi_json.py
@@ -16,26 +16,18 @@ from typing import Tuple
 from typing import cast
 import io
 import json
-import os
 import unittest
 import unittest.mock
 import urllib.error
 
 import test_config
 
-import areas
 import config
 import wsgi
 
 if TYPE_CHECKING:
     # pylint: disable=no-name-in-module,import-error,unused-import
     from wsgiref.types import StartResponse
-
-
-def get_relations() -> areas.Relations:
-    """Returns a Relations object that uses the test data and workdir."""
-    workdir = os.path.join(os.path.dirname(__file__), "workdir")
-    return areas.Relations(workdir)
 
 
 class TestWsgiJson(test_config.TestCase):


### PR DESCRIPTION
tests/test_config.py already provides a way to see test/workdir as the
workdir.

Change-Id: I79cfd21f5789a1ed5e1282e36ffba5ccf25f42a2
