### PR TITLE
stats, invalid-relations: ignore relation without an osm street list

### DIFF
--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -879,6 +879,22 @@ class TestInvalidRefstreets(TestWsgi):
         results = root.findall("body/h1/a")
         self.assertNotEqual(results, [])
 
+    def test_no_osm_sreets(self) -> None:
+        """Tests error handling when osm street list is missing for a relation."""
+        relations = areas.Relations(config.Config.get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_streets_path()
+        real_exists = os.path.exists
+
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/housenumber-stats/hungary/invalid-relations")
+            results = root.findall("body")
+            self.assertNotEqual(results, [])
+
 
 class TestNotFound(TestWsgi):
     """Tests the not-found page."""

--- a/webframe.py
+++ b/webframe.py
@@ -410,6 +410,8 @@ def handle_invalid_refstreets(relations: areas.Relations) -> yattag.doc.Doc:
 
     prefix = config.Config.get_uri_prefix()
     for relation in relations.get_relations():
+        if not os.path.exists(relation.get_files().get_osm_streets_path()):
+            continue
         invalid_refstreets = areas.get_invalid_refstreets(relation)
         osm_invalids, ref_invalids = invalid_refstreets
         key_invalids = areas.get_invalid_filter_keys(relation)


### PR DESCRIPTION
This is typically a new relation, the cron job didn't generate the
street list yet.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/1126>.

Change-Id: I4e66f4e181560819d4ae5b5db6ea15fb9f673f25
