### PR TITLE
data: nagykovacsi: existing streets

### DIFF
--- a/data/relation-nagykovacsi.yaml
+++ b/data/relation-nagykovacsi.yaml
@@ -11,7 +11,21 @@ osm-street-filters:
   # Nem igazi közterületek
   - Antónia-árok
   - Fehér út  # dűlőkataszterből
-
+  # A terepen ellenőrizve megvannak, a referenciából hiányoznak
+  - Benczúr utca
+  - Bogár utca
+  - Hanga utca
+  - Hérics utca
+  - Kastély köz
+  - Kökörcsin utca
+  - Kőrös köz
+  - Rozmaring köz
+  - Szeles köz
+  - Szent Márk utca
+  - Tátika utca
+  - Temető utca
+  - Tövis utca
+  - Viola utca
 refstreets:
   'Bajcsy-Zsilinszky utca': 'Bajcsy Zsilinszky Endre utca'
   'Petőfi Sándor utca': 'Petőfi utca'


### PR DESCRIPTION
Azok az utcák, amik a referenciából hiányoznak, de a terepen ellenőrizve megvannak.