### PR TITLE
additional housenumbers: add initial html output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ PYTHON_TEST_OBJECTS = \
 # These have good coverage.
 PYTHON_SAFE_OBJECTS = \
 	accept_language.py \
+	area_files.py \
 	areas.py \
 	cache.py \
 	cache_yamls.py \

--- a/area_files.py
+++ b/area_files.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Miklos Vajna and contributors.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""The area_files module contains file handling functionality, to be used by the areas module."""
+
+import os
+from typing import TextIO
+from typing import cast
+
+import i18n
+import util
+
+
+class RelationFilePaths:
+    """A relation's file interface provides access to files associated with a relation."""
+    def __init__(self, datadir: str, workdir: str, name: str):
+        self.__datadir = datadir
+        self.__workdir = workdir
+        self.__name = name
+
+    def get_ref_streets_path(self) -> str:
+        """Build the file name of the reference street list of a relation."""
+        return os.path.join(self.__workdir, "streets-reference-%s.lst" % self.__name)
+
+    def get_osm_streets_path(self) -> str:
+        """Build the file name of the OSM street list of a relation."""
+        return os.path.join(self.__workdir, "streets-%s.csv" % self.__name)
+
+    def get_osm_housenumbers_path(self) -> str:
+        """Build the file name of the OSM house number list of a relation."""
+        return os.path.join(self.__workdir, "street-housenumbers-%s.csv" % self.__name)
+
+    def get_ref_housenumbers_path(self) -> str:
+        """Build the file name of the reference house number list of a relation."""
+        return os.path.join(self.__workdir, "street-housenumbers-reference-%s.lst" % self.__name)
+
+    def get_housenumbers_percent_path(self) -> str:
+        """Builds the file name of the house number percent file of a relation."""
+        return os.path.join(self.__workdir, "%s.percent" % self.__name)
+
+    def get_housenumbers_htmlcache_path(self) -> str:
+        """Builds the file name of the house number HTML cache file of a relation."""
+        return os.path.join(self.__workdir, "%s.htmlcache.%s" % (self.__name, i18n.get_language()))
+
+    def get_housenumbers_txtcache_path(self) -> str:
+        """Builds the file name of the house number plain text cache file of a relation."""
+        return os.path.join(self.__workdir, "%s.txtcache" % self.__name)
+
+    def get_streets_percent_path(self) -> str:
+        """Builds the file name of the street percent file of a relation."""
+        return os.path.join(self.__workdir, "%s-streets.percent" % self.__name)
+
+    def get_streets_additional_count_path(self) -> str:
+        """Builds the file name of the street additional count file of a relation."""
+        return os.path.join(self.__workdir, "%s-additional-streets.count" % self.__name)
+
+    def get_housenumbers_additional_count_path(self) -> str:
+        """Builds the file name of the housenumber additional count file of a relation."""
+        return os.path.join(self.__workdir, "%s-additional-housenumbers.count" % self.__name)
+
+    def get_additional_housenumbers_htmlcache_path(self) -> str:
+        """Builds the file name of the additional house number HTML cache file of a relation."""
+        return os.path.join(self.__workdir, "%s.additional-htmlcache.%s" % (self.__name, i18n.get_language()))
+
+
+class RelationFiles(RelationFilePaths):
+    """Extends RelationFilePaths with streams."""
+    def get_ref_streets_stream(self, mode: str) -> TextIO:
+        """Opens the reference street list of a relation."""
+        path = self.get_ref_streets_path()
+        return cast(TextIO, open(path, mode=mode))
+
+    def __get_osm_streets_stream(self, mode: str) -> TextIO:
+        """Opens the OSM street list of a relation."""
+        path = self.get_osm_streets_path()
+        return cast(TextIO, open(path, mode=mode))
+
+    def get_osm_streets_csv_stream(self) -> util.CsvIO:
+        """Gets a CSV reader for the OSM street list."""
+        return util.CsvIO(self.__get_osm_streets_stream("r"))
+
+    def __get_osm_housenumbers_stream(self, mode: str) -> TextIO:
+        """Opens the OSM house number list of a relation."""
+        path = self.get_osm_housenumbers_path()
+        return cast(TextIO, open(path, mode=mode))
+
+    def get_osm_housenumbers_csv_stream(self) -> util.CsvIO:
+        """Gets a CSV reader for the OSM house number list."""
+        return util.CsvIO(self.__get_osm_housenumbers_stream("r"))
+
+    def get_ref_housenumbers_stream(self, mode: str) -> TextIO:
+        """Opens the reference house number list of a relation."""
+        return cast(TextIO, open(self.get_ref_housenumbers_path(), mode=mode))
+
+    def get_housenumbers_percent_stream(self, mode: str) -> TextIO:
+        """Opens the house number percent file of a relation."""
+        return cast(TextIO, open(self.get_housenumbers_percent_path(), mode=mode))
+
+    def get_housenumbers_htmlcache_stream(self, mode: str) -> TextIO:
+        """Opens the house number HTML cache file of a relation."""
+        return cast(TextIO, open(self.get_housenumbers_htmlcache_path(), mode=mode))
+
+    def get_housenumbers_txtcache_stream(self, mode: str) -> TextIO:
+        """Opens the house number plain text cache file of a relation."""
+        return cast(TextIO, open(self.get_housenumbers_txtcache_path(), mode=mode))
+
+    def get_streets_percent_stream(self, mode: str) -> TextIO:
+        """Opens the street percent file of a relation."""
+        return cast(TextIO, open(self.get_streets_percent_path(), mode=mode))
+
+    def get_streets_additional_count_stream(self, mode: str) -> TextIO:
+        """Opens the street additional count file of a relation."""
+        return cast(TextIO, open(self.get_streets_additional_count_path(), mode=mode))
+
+    def get_housenumbers_additional_count_stream(self, mode: str) -> TextIO:
+        """Opens the housenumbers additional count file of a relation."""
+        return cast(TextIO, open(self.get_housenumbers_additional_count_path(), mode=mode))
+
+    def write_osm_streets(self, result: str) -> None:
+        """Writes the result for overpass of Relation.get_osm_streets_query()."""
+        with self.__get_osm_streets_stream("w") as sock:
+            sock.write(result)
+
+    def write_osm_housenumbers(self, result: str) -> None:
+        """Writes the result for overpass of Relation.get_osm_housenumbers_query()."""
+        with self.__get_osm_housenumbers_stream(mode="w") as stream:
+            stream.write(result)
+
+    def get_additional_housenumbers_htmlcache_stream(self, mode: str) -> TextIO:
+        """Opens the additional house number HTML cache file of a relation."""
+        return cast(TextIO, open(self.get_additional_housenumbers_htmlcache_path(), mode=mode))
+
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -90,6 +90,17 @@ class TestIsMissingHousenumbersHtmlCached(test_config.TestCase):
             self.assertFalse(cache.is_missing_housenumbers_html_cached(relation))
 
 
+class TestGetAdditionalHousenumbersHtml(test_config.TestCase):
+    """Tests get_additional_housenumbers_html()."""
+    def test_happy(self) -> None:
+        """Tests the case when we find the result in cache."""
+        relations = areas.Relations(config.Config.get_workdir())
+        relation = relations.get_relation("gazdagret")
+        first = cache.get_additional_housenumbers_html(relation)
+        second = cache.get_additional_housenumbers_html(relation)
+        self.assertEqual(first.getvalue(), second.getvalue())
+
+
 class TestIsMissingHousenumbersTxtCached(test_config.TestCase):
     """Tests is_missing_housenumbers_txt_cached()."""
     def test_happy(self) -> None:

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -644,6 +644,63 @@ class TestAdditionalStreets(TestWsgi):
             self.assertEqual(len(results), 1)
 
 
+class TestAdditionalHousenumbers(TestWsgi):
+    """Tests the additional house numbers page."""
+    def test_well_formed(self) -> None:
+        """Tests if the output is well-formed."""
+        root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
+        results = root.findall("body/table")
+        self.assertEqual(len(results), 1)
+
+    def test_no_osm_streets_well_formed(self) -> None:
+        """Tests if the output is well-formed, no osm streets case."""
+        relations = areas.Relations(config.Config.get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_streets_path()
+        real_exists = os.path.exists
+
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-osm-streets']")
+            self.assertEqual(len(results), 1)
+
+    def test_no_osm_housenumbers_well_formed(self) -> None:
+        """Tests if the output is well-formed, no osm housenumbers case."""
+        relations = areas.Relations(config.Config.get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_housenumbers_path()
+        real_exists = os.path.exists
+
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-osm-housenumbers']")
+            self.assertEqual(len(results), 1)
+
+    def test_no_ref_housenumbers_well_formed(self) -> None:
+        """Tests if the output is well-formed, no ref housenumbers case."""
+        relations = areas.Relations(config.Config.get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_ref_housenumbers_path()
+        real_exists = os.path.exists
+
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-ref-housenumbers']")
+            self.assertEqual(len(results), 1)
+
+
 class TestMain(TestWsgi):
     """Tests handle_main()."""
     def test_well_formed(self) -> None:

--- a/wsgi_additional.py
+++ b/wsgi_additional.py
@@ -15,6 +15,7 @@ import yattag
 
 from i18n import translate as _
 import areas
+import cache
 import config
 import util
 import webframe
@@ -90,6 +91,26 @@ def additional_streets_view_result(relations: areas.Relations, request_uri: str)
 
         doc.asis(util.html_table_from_list(table).getvalue())
         doc.asis(util.invalid_refstreets_to_html(areas.get_invalid_refstreets(relation)).getvalue())
+    return doc
+
+
+def additional_housenumbers_view_result(relations: areas.Relations, request_uri: str) -> yattag.doc.Doc:
+    """Expected request_uri: e.g. /osm/additional-housenumbers/budapest_11/view-result."""
+    tokens = request_uri.split("/")
+    relation_name = tokens[-2]
+    relation = relations.get_relation(relation_name)
+
+    doc = yattag.doc.Doc()
+    relation = relations.get_relation(relation_name)
+    prefix = config.Config.get_uri_prefix()
+    if not os.path.exists(relation.get_files().get_osm_streets_path()):
+        doc.asis(webframe.handle_no_osm_streets(prefix, relation_name).getvalue())
+    elif not os.path.exists(relation.get_files().get_osm_housenumbers_path()):
+        doc.asis(webframe.handle_no_osm_housenumbers(prefix, relation_name).getvalue())
+    elif not os.path.exists(relation.get_files().get_ref_housenumbers_path()):
+        doc.asis(webframe.handle_no_ref_housenumbers(prefix, relation_name).getvalue())
+    else:
+        doc = cache.get_additional_housenumbers_html(relation)
     return doc
 
 


### PR DESCRIPTION
Something like /additional-housenumbers/szigetmonostor/view-result
should now work, though it's not yet linked anywhere.

Still no filters yet.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/580>.

Change-Id: Idabf20d60e7f3adcf429f3631ab40bbf14918d65
