### PR TITLE
split_house_number: no match can't happen

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,12 +1,6 @@
 [report]
 exclude_lines =
-    \# pragma: no cover$
     def __repr__
-    if self.debug:
-    if settings.DEBUG
-    raise AssertionError
-    raise NotImplementedError
-    if 0:
     ^if __name__ == .__main__.:$
     if sys.platform.startswith\("win"\):$
     if TYPE_CHECKING:$

--- a/util.py
+++ b/util.py
@@ -416,8 +416,7 @@ def build_reference_caches(
 def split_house_number(house_number: str) -> Tuple[int, str]:
     """Splits house_number into a numerical and a remainder part."""
     match = re.search(r"^([0-9]*)([^0-9].*|)$", house_number)
-    if not match:  # pragma: no cover
-        return (0, '')
+    assert match
     number = 0
     try:
         number = int(match.group(1))


### PR DESCRIPTION
Given that regex, even an empty string matches.

Change-Id: I2c72ea47d4969009fad31c7ea9dae38f07e4b9ce
