### PR TITLE
additional housenumbers: improve html output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ else
 	./deploy.sh
 endif
 
-update-pot: areas.py webframe.py wsgi.py wsgi_additional.py util.py Makefile
+update-pot: areas.py cache.py webframe.py wsgi.py wsgi_additional.py util.py Makefile
 	xgettext --keyword=_ --language=Python --add-comments --sort-output --from-code=UTF-8 -o po/osm-gimmisn.pot $(filter %.py,$^)
 
 update-po: po/osm-gimmisn.pot Makefile

--- a/areas.py
+++ b/areas.py
@@ -613,21 +613,20 @@ def numbered_streets_to_table(
     return table, todo_count
 
 
-def write_additional_housenumbers(relation: Relation) -> Tuple[int, List[List[yattag.doc.Doc]]]:
+def write_additional_housenumbers(relation: Relation) -> Tuple[int, int, List[List[yattag.doc.Doc]]]:
     """
     Calculate and write stat for the unexpected house number coverage of a relation.
-    Returns a tuple of: street count and table.
+    Returns a tuple of: todo street count, todo count and table.
     """
-    additional_housenumbers = relation.get_additional_housenumbers()
-    street_count = len(additional_housenumbers)
+    ongoing_streets = relation.get_additional_housenumbers()
+
+    table, todo_count = numbered_streets_to_table(relation, ongoing_streets)
 
     # Write the street count to a file, so the index page show it fast.
     with relation.get_files().get_housenumbers_additional_count_stream("w") as stream:
-        stream.write(str(len(additional_housenumbers)))
+        stream.write(str(todo_count))
 
-    table, _todo_count = numbered_streets_to_table(relation, additional_housenumbers)
-
-    return street_count, table
+    return len(ongoing_streets), todo_count, table
 
 
 def get_osm_housenumbers_query(relation: Relation) -> str:

--- a/cache.py
+++ b/cache.py
@@ -111,11 +111,11 @@ def get_additional_housenumbers_html(relation: areas.Relation) -> yattag.doc.Doc
         return doc
 
     ret = areas.write_additional_housenumbers(relation)
-    additional_street_count, table = ret
+    todo_street_count, todo_count, table = ret
 
     with doc.tag("p"):
-        doc.text(_("OpenStreetMap additionally has house numbers in the below {0} streets.")
-                 .format(str(additional_street_count)))
+        doc.text(_("OpenStreetMap additionally has the below {0} house numbers for {1} streets.")
+                 .format(str(todo_count), str(todo_street_count)))
         doc.stag("br")
         with doc.tag("a", href="https://github.com/vmiklos/osm-gimmisn/tree/master/doc"):
             doc.text(_("Filter incorrect information"))

--- a/po/hu/osm-gimmisn.po
+++ b/po/hu/osm-gimmisn.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: osm-gimmisn\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-26 21:54+0100\n"
-"PO-Revision-Date: 2021-04-23 23:52+0200\n"
+"POT-Creation-Date: 2021-05-14 22:04+0200\n"
+"PO-Revision-Date: 2021-05-14 22:06+0200\n"
 "Last-Translator: Miklos Vajna <osm-gimmisn@vmiklos.hu>\n"
 "Language-Team: Hungarian\n"
 "Language: hu\n"
@@ -17,312 +17,320 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: wsgi.py:164 wsgi.py:210
+#: cache.py:80 wsgi.py:188
 #, python-brace-format
 msgid " (existing: {0}, ready: {1})."
 msgstr " (meglévő: {0}, készültség: {1})."
 
-#: webframe.py:424
+#: webframe.py:465
 msgid "(empty)"
 msgstr "(üres)"
 
-#: webframe.py:425
+#: webframe.py:466
 msgid "(invalid)"
 msgstr "(hibás)"
 
-#: util.py:569
+#: util.py:574
 msgid "A reference name is invalid if it's in the OSM database."
 msgstr "Egy referencia név érvénytelen ha szerepel az OSM adatbázisban."
 
-#: wsgi.py:785
+#: wsgi.py:775
 msgid "Add new area"
 msgstr "Új terület hozzáadása"
 
-#: webframe.py:126 wsgi.py:776
+#: webframe.py:127 wsgi.py:766
 msgid "Additional streets"
 msgstr "További utcák"
 
-#: webframe.py:427
+#: webframe.py:468
 msgid "All editors"
 msgstr "Összes szerkesztő"
 
-#: webframe.py:447
+#: webframe.py:488
 msgid "All house number editors"
 msgstr "Összes házszám szerkesztő"
 
-#: webframe.py:414 webframe.py:417 webframe.py:442
+#: webframe.py:455 webframe.py:458 webframe.py:483
 msgid "All house numbers"
 msgstr "Minden házszám"
 
-#: webframe.py:415
+#: webframe.py:456
 msgid "All house numbers, last 2 weeks, as of {}"
 msgstr "Összes házszám, utolsó 2 hét, frissítve: {}"
 
-#: webframe.py:412
+#: webframe.py:453
 msgid "All house numbers, last year, as of {}"
 msgstr "Összes házszám, elmúlt év, frissítve: {}"
 
-#: webframe.py:444
+#: webframe.py:485
 msgid "All house numbers, monthly"
 msgstr "Minden házszám, havonta"
 
-#: wsgi.py:771
+#: wsgi.py:761
 msgid "Area"
 msgstr "Terület"
 
-#: webframe.py:198 wsgi.py:777
+#: webframe.py:199 wsgi.py:767
 msgid "Area boundary"
 msgstr "Terület határa"
 
-#: webframe.py:163
+#: webframe.py:164
 msgid "Area list"
 msgstr "Területek listája"
 
-#: webframe.py:416
+#: webframe.py:457
 msgid "At the start of this day"
 msgstr "Ennek a napnak a kezdetén"
 
-#: wsgi.py:627
+#: wsgi.py:617
 msgid "Based on position"
 msgstr "Pozíció alapján"
 
-#: webframe.py:93 webframe.py:103
+#: webframe.py:94 webframe.py:104
 msgid "Call Overpass to update"
 msgstr "Frissítés Overpass hívásával"
 
-#: wsgi.py:177 wsgi.py:219 wsgi_additional.py:86
+#: cache.py:93 wsgi.py:197 wsgi_additional.py:87
 msgid "Checklist format"
 msgstr "Csekklista formátum"
 
-#: webframe.py:343 webframe.py:422
+#: webframe.py:382 webframe.py:463
 msgid "City name"
 msgstr "Város neve"
 
-#: webframe.py:448
+#: webframe.py:489
 msgid "Coverage"
 msgstr "Lefedettség"
 
-#: webframe.py:429
+#: webframe.py:470
 #, python-brace-format
 msgid "Coverage is {1}%, as of {2}"
 msgstr "A lefedettség {1}%, frissítve: {2}"
 
-#: webframe.py:181
+#: webframe.py:182
 msgid "Creating from reference..."
 msgstr "Létrehozás referenciából..."
 
-#: webframe.py:431
+#: webframe.py:472
 msgid "Data source"
 msgstr "Adatforrás"
 
-#: webframe.py:209
+#: webframe.py:210
 msgid "Documentation"
 msgstr "Dokumentáció"
 
-#: webframe.py:407
+#: webframe.py:448
 msgid "During this day"
 msgstr "E nap folyamán"
 
-#: webframe.py:410
+#: webframe.py:451
 msgid "During this month"
 msgstr "E hónap folyamán"
 
-#: wsgi.py:653
+#: wsgi.py:643
 msgid "Error from GPS: "
 msgstr "GPS hiba: "
 
-#: webframe.py:180 webframe.py:549 webframe.py:571 wsgi.py:655
+#: webframe.py:181 webframe.py:591 webframe.py:613 wsgi.py:645
 msgid "Error from Overpass: "
 msgstr "Overpass hiba: "
 
-#: webframe.py:182 webframe.py:593 webframe.py:615
+#: webframe.py:183 webframe.py:635 webframe.py:657
 msgid "Error from reference: "
 msgstr "Hiba a referenciától: "
 
-#: wsgi.py:657
+#: wsgi.py:647
 msgid "Error from relations: "
 msgstr "Hiba a relációktól: "
 
-#: webframe.py:136 wsgi.py:773
+#: webframe.py:137 wsgi.py:763
 msgid "Existing house numbers"
 msgstr "Meglévő házszámok"
 
-#: webframe.py:141 wsgi.py:775
+#: webframe.py:142 wsgi.py:765
 msgid "Existing streets"
 msgstr "Meglévő utcák"
 
-#: wsgi.py:167
+#: cache.py:83 cache.py:121
 msgid "Filter incorrect information"
 msgstr "Téves információ szűrése"
 
-#: wsgi.py:643
+#: wsgi.py:633
 msgid "Filters:"
 msgstr "Szűrők:"
 
-#: webframe.py:344 wsgi.py:772
+#: webframe.py:383 wsgi.py:762
 msgid "House number coverage"
 msgstr "Házszám lefedettség"
 
-#: areas.py:573
+#: areas.py:587
 msgid "House numbers"
 msgstr "Házszámok"
 
-#: wsgi_additional.py:62
+#: wsgi_additional.py:63
 msgid "Identifier"
 msgstr "Azonosító"
 
-#: webframe.py:276
+#: webframe.py:314
 #, python-brace-format
 msgid "Internal error when serving {0}"
 msgstr "Belső hiba a {0} kiszolgálása során"
 
-#: webframe.py:450
+#: webframe.py:491
 msgid "Invalid relation settings"
 msgstr "Érvénytelen területi beállítások"
 
-#: webframe.py:47
+#: webframe.py:48
 msgid "Last update: "
 msgstr "Utolsó frissítés: "
 
-#: webframe.py:413
+#: webframe.py:454
 msgid "Latest for this month"
 msgstr "Legutóbbi erre a hónapra"
 
-#: areas.py:572
+#: areas.py:586
 msgid "Missing count"
 msgstr "Hiányzik db"
 
-#: webframe.py:117
+#: webframe.py:118
 msgid "Missing house numbers"
 msgstr "Hiányzó házszámok"
 
-#: webframe.py:122
+#: webframe.py:123
 msgid "Missing streets"
 msgstr "Hiányzó utcák"
 
-#: webframe.py:408 webframe.py:411 webframe.py:441
+#: webframe.py:449 webframe.py:452 webframe.py:482
 msgid "New house numbers"
 msgstr "Új házszámok"
 
-#: webframe.py:406
+#: webframe.py:447
 msgid "New house numbers, last 2 weeks, as of {}"
 msgstr "Új házszámok, utolsó 2 hét, frissítve: {}"
 
-#: webframe.py:409
+#: webframe.py:450
 msgid "New house numbers, last year, as of {}"
 msgstr "Új házszámok, elmúlt év, frissítve: {}"
 
-#: webframe.py:443
+#: webframe.py:484
 msgid "New house numbers, monthly"
 msgstr "Új házszámok, havonta"
 
-#: wsgi.py:113 wsgi.py:238 wsgi.py:277
+#: wsgi.py:114 wsgi.py:216 wsgi.py:240
 msgid "No existing house numbers"
 msgstr "Nincsenek meglévő házszámok"
 
-#: webframe.py:566
+#: webframe.py:608
 msgid "No existing house numbers: call Overpass to create..."
 msgstr "Nincsenek meglévő házszámok: létrehozás Overpass hívásával..."
 
-#: webframe.py:570
+#: webframe.py:612
 msgid "No existing house numbers: waiting for Overpass..."
 msgstr "Nincsenek meglévő házszámok: Overpass: várakozás..."
 
-#: wsgi.py:236 wsgi.py:275 wsgi.py:314 wsgi_additional.py:31
+#: wsgi.py:214 wsgi.py:238 wsgi.py:277 wsgi_additional.py:32
 msgid "No existing streets"
 msgstr "Nincsenek meglévő utcák"
 
-#: webframe.py:544
+#: webframe.py:586
 msgid "No existing streets: call Overpass to create..."
 msgstr "Nincsenek meglévő utcák: létrehozás Overpass hívásával..."
 
-#: webframe.py:548
+#: webframe.py:590
 msgid "No existing streets: waiting for Overpass..."
 msgstr "Nincsenek meglévő utcák: Overpass: várakozás..."
 
-#: wsgi.py:240 wsgi.py:279
+#: wsgi.py:218 wsgi.py:242
 msgid "No reference house numbers"
 msgstr "Nincsenek referencia házszámok"
 
-#: webframe.py:588
+#: webframe.py:630
 msgid "No reference house numbers: create from reference..."
 msgstr "Nincsenek referencia házszámok: létrehozás referenciából..."
 
-#: webframe.py:592
+#: webframe.py:634
 msgid "No reference house numbers: creating from reference..."
 msgstr "Nincsenek referencia házszámok: létrehozás referenciából..."
 
-#: wsgi.py:316 wsgi_additional.py:33
+#: wsgi.py:279 wsgi_additional.py:34
 msgid "No reference streets"
 msgstr "Nincsenek referencia utcák"
 
-#: webframe.py:614
+#: webframe.py:656
 msgid "No reference streets: creating from reference..."
 msgstr "Nincsenek referencia utcák: létrehozás referenciából..."
 
-#: webframe.py:610
+#: webframe.py:652
 msgid "No street list: create from reference..."
 msgstr "Nincsenek referencia utcák: létrehozás referenciából..."
 
-#: webframe.py:534
+#: webframe.py:576
 #, python-brace-format
 msgid "No such relation: {0}"
 msgstr "Nincs ilyen reláció: {0}"
 
-#: webframe.py:288
+#: webframe.py:327
 msgid "Not Found"
 msgstr "Nem található"
 
-#: webframe.py:358 webframe.py:477
+#: webframe.py:397 webframe.py:519
 msgid "Note"
 msgstr "Megjegyzés"
 
-#: util.py:568
+#: util.py:573
 msgid "Note: an OSM name is invalid if it's not in the OSM database."
 msgstr ""
 "Megjegyzés: egy OSM név érvénytelen ha nem szerepel az OSM adatbázisban."
 
-#: util.py:464
+#: util.py:469
 msgid "Note: wait for {} seconds"
 msgstr "Megjegyzés: {} másodperc várakozás szükséges"
 
-#: webframe.py:428
+#: webframe.py:469
 msgid ""
 "Number of editors, at least one housenumber is last changed by these users"
 msgstr ""
 "Szerkesztők száma, legalább egy házszámot ezek a szerkesztők változtattak "
 "meg utoljára"
 
-#: webframe.py:426
+#: webframe.py:467
 msgid "Number of house number editors, as of {}"
 msgstr "Házszám szerkesztők száma, frissítve: {}"
 
-#: webframe.py:423
+#: webframe.py:464
 msgid "Number of house numbers added in the past 30 days"
 msgstr "Az elmúlt 30 napban hozzáadott házszámok száma"
 
-#: webframe.py:430
+#: webframe.py:471
 msgid "Number of house numbers in database"
 msgstr "Adatbázisban szereplő házszámok száma"
 
-#: webframe.py:420
+#: webframe.py:461
 msgid "Number of house numbers last changed by this user"
 msgstr "Felhasználó által utoljára módosított házszámok száma"
 
-#: webframe.py:345
+#: webframe.py:384
 msgid "OSM count"
 msgstr "OSM szám"
 
-#: webframe.py:45
+#: webframe.py:46
 msgid "OSM data © OpenStreetMap contributors."
 msgstr "OSM adatok © OpenStreetMap közreműködők."
 
-#: wsgi_additional.py:80
+#: cache.py:117
+#, python-brace-format
+msgid ""
+"OpenStreetMap additionally has the below {0} house numbers for {1} streets."
+msgstr ""
+"Az OpenStreetmap tartalmazza a lenti {1} utcához tartozó "
+"további {0} házszámot."
+
+#: wsgi_additional.py:81
 #, python-brace-format
 msgid "OpenStreetMap additionally has the below {0} streets."
 msgstr "Az OpenStreetMap tartalmazza a lenti {0} további utcát."
 
-#: wsgi.py:162
+#: cache.py:78
 #, python-brace-format
 msgid ""
 "OpenStreetMap is possibly missing the below {0} house numbers for {1} "
@@ -331,65 +339,65 @@ msgstr ""
 "Elképzelhető, hogy az OpenStreetMap nem tartalmazza a lenti {1} utcához "
 "tartozó {0} házszámot."
 
-#: wsgi.py:209
+#: wsgi.py:187
 #, python-brace-format
 msgid "OpenStreetMap is possibly missing the below {0} streets."
 msgstr "Elképzelhető, hogy az OpenStreetMap nem tartalmazza a lenti {0} utcát."
 
-#: util.py:460
+#: util.py:465
 #, python-brace-format
 msgid "Overpass error: {0}"
 msgstr "Overpass error: {0}"
 
-#: webframe.py:192
+#: webframe.py:193
 msgid "Overpass turbo"
 msgstr "Overpass turbo"
 
-#: wsgi.py:213
+#: wsgi.py:191
 msgid "Overpass turbo query for streets with questionable names"
 msgstr "Overpass lekérdezés a kérdéses nevű utcákra"
 
-#: wsgi.py:171 wsgi_additional.py:89
+#: cache.py:87 wsgi_additional.py:90
 msgid "Overpass turbo query for the below streets"
 msgstr "Overpass lekérdezés a lenti utcákra"
 
-#: webframe.py:449
+#: webframe.py:490
 msgid "Per-city coverage"
 msgstr "Városonkénti lefedettség"
 
-#: wsgi.py:174 wsgi.py:216 wsgi_additional.py:83
+#: cache.py:90 wsgi.py:194 wsgi_additional.py:84
 msgid "Plain text format"
 msgstr "Egyszerű szöveg formátum"
 
-#: webframe.py:346
+#: webframe.py:385
 msgid "Reference count"
 msgstr "Referencia szám"
 
-#: wsgi.py:633
+#: wsgi.py:623
 msgid "Show complete areas"
 msgstr "Kész területek mutatása"
 
-#: wsgi_additional.py:64
+#: wsgi_additional.py:65
 msgid "Source"
 msgstr "Forrás"
 
-#: webframe.py:204
+#: webframe.py:205
 msgid "Statistics"
 msgstr "Statisztikák"
 
-#: wsgi.py:774
+#: wsgi.py:764
 msgid "Street coverage"
 msgstr "Utca lefedettség"
 
-#: areas.py:571 wsgi.py:204 wsgi_additional.py:65
+#: areas.py:585 wsgi.py:182 wsgi_additional.py:66
 msgid "Street name"
 msgstr "Utcanév"
 
-#: webframe.py:290
+#: webframe.py:329
 msgid "The requested URL was not found on this server."
 msgstr "A kért URL nem található ezen a kiszolgálón."
 
-#: webframe.py:360
+#: webframe.py:399
 msgid ""
 "These statistics are estimates, not taking house number filters into "
 "account.\n"
@@ -398,7 +406,7 @@ msgstr ""
 "Ezek a statisztikák becslések, nem véve figyelembe a házszám szűrőket.\n"
 "Csak olyan városok szerepelnek benne, amiknek van az OSM-ben házszámuk."
 
-#: webframe.py:479
+#: webframe.py:521
 msgid ""
 "These statistics are provided purely for interested editors, and are not\n"
 "intended to reflect quality of work done by any given editor in OSM. If you "
@@ -412,75 +420,75 @@ msgstr ""
 "használni, hogy motiváljad magad, az rendben van, de ne felejtsd, hogy "
 "kevesebb hasznos munka többet ér, mint sok haszontalan munka."
 
-#: webframe.py:446
+#: webframe.py:487
 msgid "Top edited cities"
 msgstr "Legaktívabb városok"
 
-#: webframe.py:421
+#: webframe.py:462
 msgid "Top edited cities, as of {}"
 msgstr "Legaktívabb városok, frissítve: {}"
 
-#: webframe.py:445
+#: webframe.py:486
 msgid "Top house number editors"
 msgstr "Legaktívabb házszám szerkesztők"
 
-#: webframe.py:418
+#: webframe.py:459
 msgid "Top house number editors, as of {}"
 msgstr "Legaktívabb házszám szerkesztők, frissítve: {}"
 
-#: wsgi_additional.py:63
+#: wsgi_additional.py:64
 msgid "Type"
 msgstr "Típus"
 
-#: webframe.py:67 webframe.py:81
+#: webframe.py:68 webframe.py:82
 msgid "Update from OSM"
 msgstr "Frissítés OSM-ből"
 
-#: webframe.py:73 webframe.py:87
+#: webframe.py:74 webframe.py:88
 msgid "Update from reference"
 msgstr "Frissítés referenciából"
 
-#: wsgi.py:71 wsgi.py:348
+#: wsgi.py:72 wsgi.py:311
 msgid "Update successful."
 msgstr "Frissítés sikeres."
 
-#: wsgi.py:67 wsgi.py:104 wsgi.py:334
+#: wsgi.py:68 wsgi.py:105 wsgi.py:297
 msgid "Update successful: "
 msgstr "Frissítés sikeres: "
 
-#: webframe.py:419
+#: webframe.py:460
 msgid "User name"
 msgstr "Felhasználó neve"
 
-#: webframe.py:42
+#: webframe.py:43
 msgid "Version: "
 msgstr "Verzió: "
 
-#: wsgi.py:69 wsgi.py:106 wsgi.py:337
+#: wsgi.py:70 wsgi.py:107 wsgi.py:300
 msgid "View missing house numbers"
 msgstr "Hiányzó házszámok megtekintése"
 
-#: webframe.py:97 webframe.py:107
+#: webframe.py:98 webframe.py:108
 msgid "View query"
 msgstr "Lekérdezés megtekintése"
 
-#: wsgi.py:652
+#: wsgi.py:642
 msgid "Waiting for GPS..."
 msgstr "GPS: várakozás..."
 
-#: webframe.py:179 wsgi.py:654
+#: webframe.py:180 wsgi.py:644
 msgid "Waiting for Overpass..."
 msgstr "Overpass: várakozás..."
 
-#: wsgi.py:658
+#: wsgi.py:648
 msgid "Waiting for redirect..."
 msgstr "Átirányítás: várakozás..."
 
-#: wsgi.py:656
+#: wsgi.py:646
 msgid "Waiting for relations..."
 msgstr "Területek: várakozás..."
 
-#: util.py:553
+#: util.py:558
 msgid ""
 "Warning: broken OSM <-> reference mapping, the following OSM names are "
 "invalid:"
@@ -488,7 +496,7 @@ msgstr ""
 "Figyelem: sérült OSM <-> referencia hozzárendelés, a következő OSM nevek "
 "érvénytelenek:"
 
-#: util.py:561
+#: util.py:566
 msgid ""
 "Warning: broken OSM <-> reference mapping, the following reference names are "
 "invalid:"
@@ -496,57 +504,57 @@ msgstr ""
 "Figyelem: sérült OSM <-> referencia hozzárendelés, a következő referencia "
 "nevek érvénytelenek:"
 
-#: util.py:579
+#: util.py:584
 msgid ""
 "Warning: broken filter key name, the following key names are not OSM names:"
 msgstr ""
 "Figyelem: sérült szűrő kulcs név, a következő kulcs nevek nem OSM nevek:"
 
-#: wsgi.py:641 wsgi.py:816
+#: wsgi.py:631 wsgi.py:808
 msgid "Where to map?"
 msgstr "Hol térképezzek?"
 
-#: wsgi.py:554
+#: wsgi.py:544
 msgid "additional streets"
 msgstr "további utcák"
 
-#: wsgi.py:751
+#: wsgi.py:741
 msgid "area boundary"
 msgstr "terület határa"
 
-#: wsgi.py:724 wsgi.py:805
+#: wsgi.py:714 wsgi.py:795
 msgid "existing house numbers"
 msgstr "meglévő házszámok"
 
-#: wsgi.py:741 wsgi.py:807
+#: wsgi.py:731 wsgi.py:797
 msgid "existing streets"
 msgstr "meglévő utcák"
 
-#: util.py:655
+#: util.py:685
 msgid "housenumber"
 msgstr "házszám"
 
-#: wsgi.py:510
+#: wsgi.py:500
 msgid "missing house numbers"
 msgstr "hiányzó házszámok"
 
-#: wsgi.py:532 wsgi.py:803
+#: wsgi.py:522 wsgi.py:793
 msgid "missing streets"
 msgstr "hiányzó utcák"
 
-#: areas.py:364
+#: areas.py:279
 msgid "street"
 msgstr "utca"
 
-#: wsgi.py:504 wsgi.py:526 wsgi.py:548 wsgi.py:723 wsgi.py:740
+#: wsgi.py:494 wsgi.py:516 wsgi.py:538 wsgi.py:713 wsgi.py:730
 msgid "updated"
 msgstr "frissítve"
 
-#: wsgi.py:801
+#: wsgi.py:791
 #, python-brace-format
 msgid "{0} missing house numbers"
 msgstr "{0} hiányzó házszámok"
 
-#: wsgi.py:549
+#: wsgi.py:539
 msgid "{} streets"
 msgstr "{} utca"

--- a/po/osm-gimmisn.pot
+++ b/po/osm-gimmisn.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-26 21:54+0100\n"
+"POT-Creation-Date: 2021-05-14 22:04+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,381 +17,387 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: wsgi.py:164 wsgi.py:210
+#: cache.py:80 wsgi.py:188
 #, python-brace-format
 msgid " (existing: {0}, ready: {1})."
 msgstr ""
 
-#: webframe.py:424
+#: webframe.py:465
 msgid "(empty)"
 msgstr ""
 
-#: webframe.py:425
+#: webframe.py:466
 msgid "(invalid)"
 msgstr ""
 
-#: util.py:569
+#: util.py:574
 msgid "A reference name is invalid if it's in the OSM database."
 msgstr ""
 
-#: wsgi.py:785
+#: wsgi.py:775
 msgid "Add new area"
 msgstr ""
 
-#: webframe.py:126 wsgi.py:776
+#: webframe.py:127 wsgi.py:766
 msgid "Additional streets"
 msgstr ""
 
-#: webframe.py:427
+#: webframe.py:468
 msgid "All editors"
 msgstr ""
 
-#: webframe.py:447
+#: webframe.py:488
 msgid "All house number editors"
 msgstr ""
 
-#: webframe.py:414 webframe.py:417 webframe.py:442
+#: webframe.py:455 webframe.py:458 webframe.py:483
 msgid "All house numbers"
 msgstr ""
 
-#: webframe.py:415
+#: webframe.py:456
 msgid "All house numbers, last 2 weeks, as of {}"
 msgstr ""
 
-#: webframe.py:412
+#: webframe.py:453
 msgid "All house numbers, last year, as of {}"
 msgstr ""
 
-#: webframe.py:444
+#: webframe.py:485
 msgid "All house numbers, monthly"
 msgstr ""
 
-#: wsgi.py:771
+#: wsgi.py:761
 msgid "Area"
 msgstr ""
 
-#: webframe.py:198 wsgi.py:777
+#: webframe.py:199 wsgi.py:767
 msgid "Area boundary"
 msgstr ""
 
-#: webframe.py:163
+#: webframe.py:164
 msgid "Area list"
 msgstr ""
 
-#: webframe.py:416
+#: webframe.py:457
 msgid "At the start of this day"
 msgstr ""
 
-#: wsgi.py:627
+#: wsgi.py:617
 msgid "Based on position"
 msgstr ""
 
-#: webframe.py:93 webframe.py:103
+#: webframe.py:94 webframe.py:104
 msgid "Call Overpass to update"
 msgstr ""
 
-#: wsgi.py:177 wsgi.py:219 wsgi_additional.py:86
+#: cache.py:93 wsgi.py:197 wsgi_additional.py:87
 msgid "Checklist format"
 msgstr ""
 
-#: webframe.py:343 webframe.py:422
+#: webframe.py:382 webframe.py:463
 msgid "City name"
 msgstr ""
 
-#: webframe.py:448
+#: webframe.py:489
 msgid "Coverage"
 msgstr ""
 
-#: webframe.py:429
+#: webframe.py:470
 #, python-brace-format
 msgid "Coverage is {1}%, as of {2}"
 msgstr ""
 
-#: webframe.py:181
+#: webframe.py:182
 msgid "Creating from reference..."
 msgstr ""
 
-#: webframe.py:431
+#: webframe.py:472
 msgid "Data source"
 msgstr ""
 
-#: webframe.py:209
+#: webframe.py:210
 msgid "Documentation"
 msgstr ""
 
-#: webframe.py:407
+#: webframe.py:448
 msgid "During this day"
 msgstr ""
 
-#: webframe.py:410
+#: webframe.py:451
 msgid "During this month"
 msgstr ""
 
-#: wsgi.py:653
+#: wsgi.py:643
 msgid "Error from GPS: "
 msgstr ""
 
-#: webframe.py:180 webframe.py:549 webframe.py:571 wsgi.py:655
+#: webframe.py:181 webframe.py:591 webframe.py:613 wsgi.py:645
 msgid "Error from Overpass: "
 msgstr ""
 
-#: webframe.py:182 webframe.py:593 webframe.py:615
+#: webframe.py:183 webframe.py:635 webframe.py:657
 msgid "Error from reference: "
 msgstr ""
 
-#: wsgi.py:657
+#: wsgi.py:647
 msgid "Error from relations: "
 msgstr ""
 
-#: webframe.py:136 wsgi.py:773
+#: webframe.py:137 wsgi.py:763
 msgid "Existing house numbers"
 msgstr ""
 
-#: webframe.py:141 wsgi.py:775
+#: webframe.py:142 wsgi.py:765
 msgid "Existing streets"
 msgstr ""
 
-#: wsgi.py:167
+#: cache.py:83 cache.py:121
 msgid "Filter incorrect information"
 msgstr ""
 
-#: wsgi.py:643
+#: wsgi.py:633
 msgid "Filters:"
 msgstr ""
 
-#: webframe.py:344 wsgi.py:772
+#: webframe.py:383 wsgi.py:762
 msgid "House number coverage"
 msgstr ""
 
-#: areas.py:573
+#: areas.py:587
 msgid "House numbers"
 msgstr ""
 
-#: wsgi_additional.py:62
+#: wsgi_additional.py:63
 msgid "Identifier"
 msgstr ""
 
-#: webframe.py:276
+#: webframe.py:314
 #, python-brace-format
 msgid "Internal error when serving {0}"
 msgstr ""
 
-#: webframe.py:450
+#: webframe.py:491
 msgid "Invalid relation settings"
 msgstr ""
 
-#: webframe.py:47
+#: webframe.py:48
 msgid "Last update: "
 msgstr ""
 
-#: webframe.py:413
+#: webframe.py:454
 msgid "Latest for this month"
 msgstr ""
 
-#: areas.py:572
+#: areas.py:586
 msgid "Missing count"
 msgstr ""
 
-#: webframe.py:117
+#: webframe.py:118
 msgid "Missing house numbers"
 msgstr ""
 
-#: webframe.py:122
+#: webframe.py:123
 msgid "Missing streets"
 msgstr ""
 
-#: webframe.py:408 webframe.py:411 webframe.py:441
+#: webframe.py:449 webframe.py:452 webframe.py:482
 msgid "New house numbers"
 msgstr ""
 
-#: webframe.py:406
+#: webframe.py:447
 msgid "New house numbers, last 2 weeks, as of {}"
 msgstr ""
 
-#: webframe.py:409
+#: webframe.py:450
 msgid "New house numbers, last year, as of {}"
 msgstr ""
 
-#: webframe.py:443
+#: webframe.py:484
 msgid "New house numbers, monthly"
 msgstr ""
 
-#: wsgi.py:113 wsgi.py:238 wsgi.py:277
+#: wsgi.py:114 wsgi.py:216 wsgi.py:240
 msgid "No existing house numbers"
 msgstr ""
 
-#: webframe.py:566
+#: webframe.py:608
 msgid "No existing house numbers: call Overpass to create..."
 msgstr ""
 
-#: webframe.py:570
+#: webframe.py:612
 msgid "No existing house numbers: waiting for Overpass..."
 msgstr ""
 
-#: wsgi.py:236 wsgi.py:275 wsgi.py:314 wsgi_additional.py:31
+#: wsgi.py:214 wsgi.py:238 wsgi.py:277 wsgi_additional.py:32
 msgid "No existing streets"
 msgstr ""
 
-#: webframe.py:544
+#: webframe.py:586
 msgid "No existing streets: call Overpass to create..."
 msgstr ""
 
-#: webframe.py:548
+#: webframe.py:590
 msgid "No existing streets: waiting for Overpass..."
 msgstr ""
 
-#: wsgi.py:240 wsgi.py:279
+#: wsgi.py:218 wsgi.py:242
 msgid "No reference house numbers"
 msgstr ""
 
-#: webframe.py:588
+#: webframe.py:630
 msgid "No reference house numbers: create from reference..."
 msgstr ""
 
-#: webframe.py:592
+#: webframe.py:634
 msgid "No reference house numbers: creating from reference..."
 msgstr ""
 
-#: wsgi.py:316 wsgi_additional.py:33
+#: wsgi.py:279 wsgi_additional.py:34
 msgid "No reference streets"
 msgstr ""
 
-#: webframe.py:614
+#: webframe.py:656
 msgid "No reference streets: creating from reference..."
 msgstr ""
 
-#: webframe.py:610
+#: webframe.py:652
 msgid "No street list: create from reference..."
 msgstr ""
 
-#: webframe.py:534
+#: webframe.py:576
 #, python-brace-format
 msgid "No such relation: {0}"
 msgstr ""
 
-#: webframe.py:288
+#: webframe.py:327
 msgid "Not Found"
 msgstr ""
 
-#: webframe.py:358 webframe.py:477
+#: webframe.py:397 webframe.py:519
 msgid "Note"
 msgstr ""
 
-#: util.py:568
+#: util.py:573
 msgid "Note: an OSM name is invalid if it's not in the OSM database."
 msgstr ""
 
-#: util.py:464
+#: util.py:469
 msgid "Note: wait for {} seconds"
 msgstr ""
 
-#: webframe.py:428
+#: webframe.py:469
 msgid ""
 "Number of editors, at least one housenumber is last changed by these users"
 msgstr ""
 
-#: webframe.py:426
+#: webframe.py:467
 msgid "Number of house number editors, as of {}"
 msgstr ""
 
-#: webframe.py:423
+#: webframe.py:464
 msgid "Number of house numbers added in the past 30 days"
 msgstr ""
 
-#: webframe.py:430
+#: webframe.py:471
 msgid "Number of house numbers in database"
 msgstr ""
 
-#: webframe.py:420
+#: webframe.py:461
 msgid "Number of house numbers last changed by this user"
 msgstr ""
 
-#: webframe.py:345
+#: webframe.py:384
 msgid "OSM count"
 msgstr ""
 
-#: webframe.py:45
+#: webframe.py:46
 msgid "OSM data © OpenStreetMap contributors."
 msgstr ""
 
-#: wsgi_additional.py:80
+#: cache.py:117
+#, python-brace-format
+msgid ""
+"OpenStreetMap additionally has the below {0} house numbers for {1} streets."
+msgstr ""
+
+#: wsgi_additional.py:81
 #, python-brace-format
 msgid "OpenStreetMap additionally has the below {0} streets."
 msgstr ""
 
-#: wsgi.py:162
+#: cache.py:78
 #, python-brace-format
 msgid ""
 "OpenStreetMap is possibly missing the below {0} house numbers for {1} "
 "streets."
 msgstr ""
 
-#: wsgi.py:209
+#: wsgi.py:187
 #, python-brace-format
 msgid "OpenStreetMap is possibly missing the below {0} streets."
 msgstr ""
 
-#: util.py:460
+#: util.py:465
 #, python-brace-format
 msgid "Overpass error: {0}"
 msgstr ""
 
-#: webframe.py:192
+#: webframe.py:193
 msgid "Overpass turbo"
 msgstr ""
 
-#: wsgi.py:213
+#: wsgi.py:191
 msgid "Overpass turbo query for streets with questionable names"
 msgstr ""
 
-#: wsgi.py:171 wsgi_additional.py:89
+#: cache.py:87 wsgi_additional.py:90
 msgid "Overpass turbo query for the below streets"
 msgstr ""
 
-#: webframe.py:449
+#: webframe.py:490
 msgid "Per-city coverage"
 msgstr ""
 
-#: wsgi.py:174 wsgi.py:216 wsgi_additional.py:83
+#: cache.py:90 wsgi.py:194 wsgi_additional.py:84
 msgid "Plain text format"
 msgstr ""
 
-#: webframe.py:346
+#: webframe.py:385
 msgid "Reference count"
 msgstr ""
 
-#: wsgi.py:633
+#: wsgi.py:623
 msgid "Show complete areas"
 msgstr ""
 
-#: wsgi_additional.py:64
+#: wsgi_additional.py:65
 msgid "Source"
 msgstr ""
 
-#: webframe.py:204
+#: webframe.py:205
 msgid "Statistics"
 msgstr ""
 
-#: wsgi.py:774
+#: wsgi.py:764
 msgid "Street coverage"
 msgstr ""
 
-#: areas.py:571 wsgi.py:204 wsgi_additional.py:65
+#: areas.py:585 wsgi.py:182 wsgi_additional.py:66
 msgid "Street name"
 msgstr ""
 
-#: webframe.py:290
+#: webframe.py:329
 msgid "The requested URL was not found on this server."
 msgstr ""
 
-#: webframe.py:360
+#: webframe.py:399
 msgid ""
 "These statistics are estimates, not taking house number filters into "
 "account.\n"
 "Only cities with house numbers in OSM are considered."
 msgstr ""
 
-#: webframe.py:479
+#: webframe.py:521
 msgid ""
 "These statistics are provided purely for interested editors, and are not\n"
 "intended to reflect quality of work done by any given editor in OSM. If you "
@@ -401,136 +407,136 @@ msgid ""
 "more meaningful than a lot of useless work."
 msgstr ""
 
-#: webframe.py:446
+#: webframe.py:487
 msgid "Top edited cities"
 msgstr ""
 
-#: webframe.py:421
+#: webframe.py:462
 msgid "Top edited cities, as of {}"
 msgstr ""
 
-#: webframe.py:445
+#: webframe.py:486
 msgid "Top house number editors"
 msgstr ""
 
-#: webframe.py:418
+#: webframe.py:459
 msgid "Top house number editors, as of {}"
 msgstr ""
 
-#: wsgi_additional.py:63
+#: wsgi_additional.py:64
 msgid "Type"
 msgstr ""
 
-#: webframe.py:67 webframe.py:81
+#: webframe.py:68 webframe.py:82
 msgid "Update from OSM"
 msgstr ""
 
-#: webframe.py:73 webframe.py:87
+#: webframe.py:74 webframe.py:88
 msgid "Update from reference"
 msgstr ""
 
-#: wsgi.py:71 wsgi.py:348
+#: wsgi.py:72 wsgi.py:311
 msgid "Update successful."
 msgstr ""
 
-#: wsgi.py:67 wsgi.py:104 wsgi.py:334
+#: wsgi.py:68 wsgi.py:105 wsgi.py:297
 msgid "Update successful: "
 msgstr ""
 
-#: webframe.py:419
+#: webframe.py:460
 msgid "User name"
 msgstr ""
 
-#: webframe.py:42
+#: webframe.py:43
 msgid "Version: "
 msgstr ""
 
-#: wsgi.py:69 wsgi.py:106 wsgi.py:337
+#: wsgi.py:70 wsgi.py:107 wsgi.py:300
 msgid "View missing house numbers"
 msgstr ""
 
-#: webframe.py:97 webframe.py:107
+#: webframe.py:98 webframe.py:108
 msgid "View query"
 msgstr ""
 
-#: wsgi.py:652
+#: wsgi.py:642
 msgid "Waiting for GPS..."
 msgstr ""
 
-#: webframe.py:179 wsgi.py:654
+#: webframe.py:180 wsgi.py:644
 msgid "Waiting for Overpass..."
 msgstr ""
 
-#: wsgi.py:658
+#: wsgi.py:648
 msgid "Waiting for redirect..."
 msgstr ""
 
-#: wsgi.py:656
+#: wsgi.py:646
 msgid "Waiting for relations..."
 msgstr ""
 
-#: util.py:553
+#: util.py:558
 msgid ""
 "Warning: broken OSM <-> reference mapping, the following OSM names are "
 "invalid:"
 msgstr ""
 
-#: util.py:561
+#: util.py:566
 msgid ""
 "Warning: broken OSM <-> reference mapping, the following reference names are "
 "invalid:"
 msgstr ""
 
-#: util.py:579
+#: util.py:584
 msgid ""
 "Warning: broken filter key name, the following key names are not OSM names:"
 msgstr ""
 
-#: wsgi.py:641 wsgi.py:816
+#: wsgi.py:631 wsgi.py:808
 msgid "Where to map?"
 msgstr ""
 
-#: wsgi.py:554
+#: wsgi.py:544
 msgid "additional streets"
 msgstr ""
 
-#: wsgi.py:751
+#: wsgi.py:741
 msgid "area boundary"
 msgstr ""
 
-#: wsgi.py:724 wsgi.py:805
+#: wsgi.py:714 wsgi.py:795
 msgid "existing house numbers"
 msgstr ""
 
-#: wsgi.py:741 wsgi.py:807
+#: wsgi.py:731 wsgi.py:797
 msgid "existing streets"
 msgstr ""
 
-#: util.py:655
+#: util.py:685
 msgid "housenumber"
 msgstr ""
 
-#: wsgi.py:510
+#: wsgi.py:500
 msgid "missing house numbers"
 msgstr ""
 
-#: wsgi.py:532 wsgi.py:803
+#: wsgi.py:522 wsgi.py:793
 msgid "missing streets"
 msgstr ""
 
-#: areas.py:364
+#: areas.py:279
 msgid "street"
 msgstr ""
 
-#: wsgi.py:504 wsgi.py:526 wsgi.py:548 wsgi.py:723 wsgi.py:740
+#: wsgi.py:494 wsgi.py:516 wsgi.py:538 wsgi.py:713 wsgi.py:730
 msgid "updated"
 msgstr ""
 
-#: wsgi.py:801
+#: wsgi.py:791
 #, python-brace-format
 msgid "{0} missing house numbers"
 msgstr ""
 
-#: wsgi.py:549
+#: wsgi.py:539
 msgid "{} streets"
 msgstr ""


### PR DESCRIPTION
Track the number of additional house numbers as well, not just the
number of streets that have additional house numbers. This way the
output is closer to the missing housenumbers page.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/580>.

Change-Id: I33b5107ae2618179a3c2036bdac6b85c01acc9ac
