### PR TITLE
additional housenumbers: add filter support

### DIFF
--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -241,6 +241,19 @@ housenumber ranges in a sensible way. Here are some examples:
 
 See `tests/test_areas.py` for even more details.
 
+=== Additional housenumbers analysis
+
+This is the opposite of missing housenumbers, i.e. check for OSM objects which are not in the
+reference. This can be helpful to find errors, but use it with care: just because you did not find a
+housenumber by survey, it doesn't mean it has to be deleted.
+
+The way to filter out valid data from the OSM list is to explicitly state what items are valid:
+
+----
+  Magasúti köz:
+    valid: ['13', '15']
+----
+
 === Automerge workflow for committers
 
 If you contribute to osm-gimmisn frequently, then you'll likely get self-review permissions granted.

--- a/tests/data/relation-gazdagret-filter-valid-bad-type.yaml
+++ b/tests/data/relation-gazdagret-filter-valid-bad-type.yaml
@@ -1,0 +1,3 @@
+filters:
+  'Budaörsi út':
+    valid: "hello"

--- a/tests/data/relation-gazdagret-filter-valid-bad.yaml
+++ b/tests/data/relation-gazdagret-filter-valid-bad.yaml
@@ -1,0 +1,3 @@
+filters:
+  'Budaörsi út':
+    valid: [1]

--- a/tests/data/relation-gazdagret-filter-valid-bad2.yaml
+++ b/tests/data/relation-gazdagret-filter-valid-bad2.yaml
@@ -1,0 +1,3 @@
+filters:
+  'Budaörsi út':
+    valid: ['1c 1']

--- a/tests/data/relation-gazdagret-filter-valid-good.yaml
+++ b/tests/data/relation-gazdagret-filter-valid-good.yaml
@@ -1,0 +1,3 @@
+filters:
+  'Budaörsi út':
+    valid: ['1c']

--- a/tests/data/relation-gazdagret-filter-valid-good2.yaml
+++ b/tests/data/relation-gazdagret-filter-valid-good2.yaml
@@ -1,0 +1,3 @@
+filters:
+  'Budaörsi út':
+    valid: ['42/1']

--- a/tests/data/relation-gazdagret.yaml
+++ b/tests/data/relation-gazdagret.yaml
@@ -20,6 +20,8 @@ filters:
     show-refstreet: false
   'OSM Name 2':
     show-refstreet: false
+  'Second Only In OSM utca':
+    valid: ['1']
 street-filters:
   - Only In Ref Nonsense utca
 osm-street-filters:

--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -591,8 +591,8 @@ class TestRelationGetAdditionalHousenumbers(test_config.TestCase):
         relation = relations.get_relation(relation_name)
         only_in_osm = relation.get_additional_housenumbers()
         only_in_osm_strs = [(name.get_osm_name(), [i.get_number() for i in numbers]) for name, numbers in only_in_osm]
-        self.assertEqual(only_in_osm_strs, [('Only In OSM utca', ['1']),
-                                            ('Second Only In OSM utca', ['1'])])
+        # Note how Second Only In OSM utca 1 is filtered out explicitly.
+        self.assertEqual(only_in_osm_strs, [('Only In OSM utca', ['1'])])
 
 
 def table_doc_to_string(table: List[List[yattag.doc.Doc]]) -> List[List[str]]:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -29,6 +29,8 @@ class TestValidatorMain(unittest.TestCase):
             "tests/data/relations.yaml",
             "tests/data/relation-gazdagret-filter-invalid-good.yaml",
             "tests/data/relation-gazdagret-filter-invalid-good2.yaml",
+            "tests/data/relation-gazdagret-filter-valid-good.yaml",
+            "tests/data/relation-gazdagret-filter-valid-good2.yaml",
         ]
         for path in paths:
             argv = ["", path]
@@ -254,6 +256,24 @@ class TestValidatorMainFailureMsg2(TestValidatorMainFailureMsgBase):
         expected = "failed to validate tests/data/relation-gazdagret-refstreets-bad-map.yaml"
         expected += ": osm and ref streets are not a 1:1 mapping in 'refstreets.'\n"
         self.assert_failure_msg("tests/data/relation-gazdagret-refstreets-bad-map.yaml", expected)
+
+    def test_relation_filters_valid_bad(self) -> None:
+        """Tests the relation path: bad filters -> ... -> valid subkey."""
+        expected = "failed to validate tests/data/relation-gazdagret-filter-valid-bad.yaml"
+        expected += ": expected value type for 'filters.Budaörsi út.valid[0]' is str\n"
+        self.assert_failure_msg("tests/data/relation-gazdagret-filter-valid-bad.yaml", expected)
+
+    def test_relation_filters_valid_bad2(self) -> None:
+        """Tests the relation path: bad filters -> ... -> valid subkey."""
+        expected = "failed to validate tests/data/relation-gazdagret-filter-valid-bad2.yaml"
+        expected += ": expected format for 'filters.Budaörsi út.valid[0]' is '42', '42a' or '42/1'\n"
+        self.assert_failure_msg("tests/data/relation-gazdagret-filter-valid-bad2.yaml", expected)
+
+    def test_relation_filters_valid_bad_type(self) -> None:
+        """Tests the relation path: bad type for the filters -> ... -> valid subkey."""
+        expected = "failed to validate tests/data/relation-gazdagret-filter-valid-bad-type.yaml"
+        expected += ": expected value type for 'filters.Budaörsi út.valid' is list\n"
+        self.assert_failure_msg("tests/data/relation-gazdagret-filter-valid-bad-type.yaml", expected)
 
 
 if __name__ == '__main__':

--- a/validator.py
+++ b/validator.py
@@ -72,8 +72,8 @@ def validate_ranges(errors: List[str], parent: str, ranges: List[Any], filter_da
         validate_range(errors, "%s[%s]" % (context, index), range_data, filter_data)
 
 
-def validate_filter_invalid(errors: List[str], parent: str, invalid: List[Any]) -> None:
-    """Validates an 'invalid' list."""
+def validate_filter_invalid_valid(errors: List[str], parent: str, invalid: List[Any]) -> None:
+    """Validates an 'invalid' or 'valid' list."""
     context = parent
     for index, invalid_data in enumerate(invalid):
         if not isinstance(invalid_data, str):
@@ -97,11 +97,11 @@ def validate_filter(errors: List[str], parent: str, filter_data: Dict[str, Any])
                 errors.append("expected value type for '%s%s' is list" % (context, key))
                 continue
             validate_ranges(errors, context + "ranges", value, filter_data)
-        elif key == "invalid":
+        elif key in ("invalid", "valid"):
             if not isinstance(value, list):
                 errors.append("expected value type for '%s%s' is list" % (context, key))
                 continue
-            validate_filter_invalid(errors, context + "invalid", value)
+            validate_filter_invalid_valid(errors, context + key, value)
         elif key == "refsettlement":
             if not isinstance(value, str):
                 errors.append("expected value type for '%s%s' is str" % (context, key))


### PR DESCRIPTION
The new "valid" list is similar to the "invalid" one, can filter out
delete suggestions which are fine in OSM, after all.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/580>.

Change-Id: I882f30e6df3e706a00c79ca469d84f98b36c3f3c
