### PR TITLE
data: szigetmonostor: add first 'valid' filter

### DIFF
--- a/data/relation-szigetmonostor.yaml
+++ b/data/relation-szigetmonostor.yaml
@@ -4,6 +4,8 @@ filters:
       # at least 65 is definitely out of range
       - {start: '1', end: '29'}
       - {start: '2', end: '28'}
+    # TODO survey for the rest
+    valid: ['8']
   Hársfa utca:
     ranges:
       # at least 8, 18 and 19 are out of range


### PR DESCRIPTION
Which is used to filter the output of /osm/additional-housenumbers/szigetmonostor/view-result

Change-Id: Idf31f6cc7034191af58eb6e19826a8e3ce2416a8
