### PR TITLE
config: add a non-static way to get the workdir

### DIFF
--- a/tests/test_wsgi_additional.py
+++ b/tests/test_wsgi_additional.py
@@ -21,74 +21,164 @@ class TestStreets(test_wsgi.TestWsgi):
     """Tests additional streets."""
     def test_view_result_txt(self) -> None:
         """Tests the txt output."""
-        result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.txt")
-        self.assertEqual(result, "Only In OSM utca\n")
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.txt")
+            self.assertEqual(result, "Only In OSM utca\n")
 
     def test_view_result_chkl(self) -> None:
         """Tests the chkl output."""
-        result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.chkl")
-        self.assertEqual(result, "[ ] Only In OSM utca\n")
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.chkl")
+            self.assertEqual(result, "[ ] Only In OSM utca\n")
 
     def test_view_result_txt_no_osm_streets(self) -> None:
         """Tests the txt output, no osm streets case."""
-        relations = areas.Relations(config.Config.get_workdir())
-        relation = relations.get_relation("gazdagret")
-        hide_path = relation.get_files().get_osm_streets_path()
-        real_exists = os.path.exists
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            relations = areas.Relations(config.Config.get_workdir())
+            relation = relations.get_relation("gazdagret")
+            hide_path = relation.get_files().get_osm_streets_path()
+            real_exists = os.path.exists
 
-        def mock_exists(path: str) -> bool:
-            if path == hide_path:
-                return False
-            return real_exists(path)
-        with unittest.mock.patch('os.path.exists', mock_exists):
-            result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.txt")
-            self.assertEqual(result, "No existing streets")
+            def mock_exists(path: str) -> bool:
+                if path == hide_path:
+                    return False
+                return real_exists(path)
+            with unittest.mock.patch('os.path.exists', mock_exists):
+                result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.txt")
+                self.assertEqual(result, "No existing streets")
 
     def test_view_result_txt_no_ref_streets(self) -> None:
         """Tests the txt output, no ref streets case."""
-        relations = areas.Relations(config.Config.get_workdir())
-        relation = relations.get_relation("gazdagret")
-        hide_path = relation.get_files().get_ref_streets_path()
-        real_exists = os.path.exists
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            relations = areas.Relations(config.Config.get_workdir())
+            relation = relations.get_relation("gazdagret")
+            hide_path = relation.get_files().get_ref_streets_path()
+            real_exists = os.path.exists
 
-        def mock_exists(path: str) -> bool:
-            if path == hide_path:
-                return False
-            return real_exists(path)
-        with unittest.mock.patch('os.path.exists', mock_exists):
-            result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.txt")
-            self.assertEqual(result, "No reference streets")
+            def mock_exists(path: str) -> bool:
+                if path == hide_path:
+                    return False
+                return real_exists(path)
+            with unittest.mock.patch('os.path.exists', mock_exists):
+                result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.txt")
+                self.assertEqual(result, "No reference streets")
 
     def test_view_turbo_well_formed(self) -> None:
         """Tests if the view-turbo output is well-formed."""
-        root = self.get_dom_for_path("/additional-streets/gazdagret/view-turbo")
-        results = root.findall("body/pre")
-        self.assertEqual(len(results), 1)
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            root = self.get_dom_for_path("/additional-streets/gazdagret/view-turbo")
+            results = root.findall("body/pre")
+            self.assertEqual(len(results), 1)
 
 
 class TestHandleMainHousenrAdditionalCount(test_wsgi.TestWsgi):
     """Tests handle_main_housenr_additional_count()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(config.Config.get_workdir())
-        relation = relations.get_relation("budafok")
-        actual = wsgi.handle_main_housenr_additional_count(relation)
-        self.assertIn("42 house numbers", actual.getvalue())
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            relations = areas.Relations(config.Config.get_workdir())
+            relation = relations.get_relation("budafok")
+            actual = wsgi.handle_main_housenr_additional_count(relation)
+            self.assertIn("42 house numbers", actual.getvalue())
 
     def test_no_count_file(self) -> None:
         """Tests what happens when the count file is not there."""
-        relations = areas.Relations(config.Config.get_workdir())
-        relation = relations.get_relation("budafok")
-        hide_path = relation.get_files().get_housenumbers_additional_count_path()
-        real_exists = os.path.exists
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            relations = areas.Relations(config.Config.get_workdir())
+            relation = relations.get_relation("budafok")
+            hide_path = relation.get_files().get_housenumbers_additional_count_path()
+            real_exists = os.path.exists
 
-        def mock_exists(path: str) -> bool:
-            if path == hide_path:
-                return False
-            return real_exists(path)
-        with unittest.mock.patch('os.path.exists', mock_exists):
-            actual = wsgi.handle_main_housenr_additional_count(relation)
-        self.assertNotIn("42 housenumbers", actual.getvalue())
+            def mock_exists(path: str) -> bool:
+                if path == hide_path:
+                    return False
+                return real_exists(path)
+            with unittest.mock.patch('os.path.exists', mock_exists):
+                actual = wsgi.handle_main_housenr_additional_count(relation)
+            self.assertNotIn("42 housenumbers", actual.getvalue())
+
+
+class TestAdditionalHousenumbers(test_wsgi.TestWsgi):
+    """Tests the additional house numbers page."""
+    def test_well_formed(self) -> None:
+        """Tests if the output is well-formed."""
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
+            results = root.findall("body/table")
+            self.assertEqual(len(results), 1)
+
+    def test_no_osm_streets_well_formed(self) -> None:
+        """Tests if the output is well-formed, no osm streets case."""
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            relations = areas.Relations(config.Config.get_workdir())
+            relation = relations.get_relation("gazdagret")
+            hide_path = relation.get_files().get_osm_streets_path()
+            real_exists = os.path.exists
+
+            def mock_exists(path: str) -> bool:
+                if path == hide_path:
+                    return False
+                return real_exists(path)
+            with unittest.mock.patch('os.path.exists', mock_exists):
+                root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
+                results = root.findall("body/div[@id='no-osm-streets']")
+                self.assertEqual(len(results), 1)
+
+    def test_no_osm_housenumbers_well_formed(self) -> None:
+        """Tests if the output is well-formed, no osm housenumbers case."""
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            relations = areas.Relations(config.Config.get_workdir())
+            relation = relations.get_relation("gazdagret")
+            hide_path = relation.get_files().get_osm_housenumbers_path()
+            real_exists = os.path.exists
+
+            def mock_exists(path: str) -> bool:
+                if path == hide_path:
+                    return False
+                return real_exists(path)
+            with unittest.mock.patch('os.path.exists', mock_exists):
+                root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
+                results = root.findall("body/div[@id='no-osm-housenumbers']")
+                self.assertEqual(len(results), 1)
+
+    def test_no_ref_housenumbers_well_formed(self) -> None:
+        """Tests if the output is well-formed, no ref housenumbers case."""
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            relations = areas.Relations(config.Config.get_workdir())
+            relation = relations.get_relation("gazdagret")
+            hide_path = relation.get_files().get_ref_housenumbers_path()
+            real_exists = os.path.exists
+
+            def mock_exists(path: str) -> bool:
+                if path == hide_path:
+                    return False
+                return real_exists(path)
+            with unittest.mock.patch('os.path.exists', mock_exists):
+                root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
+                results = root.findall("body/div[@id='no-ref-housenumbers']")
+                self.assertEqual(len(results), 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_wsgi_json.py
+++ b/tests/test_wsgi_json.py
@@ -57,31 +57,38 @@ class TestJsonStreets(TestWsgiJson):
     """Tests streets_update_result_json()."""
     def test_update_result_json(self) -> None:
         """Tests if the update-result json output is well-formed."""
-        result_from_overpass = "@id\tname\n1\tTűzkő utca\n2\tTörökugrató utca\n3\tOSM Name 1\n4\tHamzsabégi út\n"
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            result_from_overpass = "@id\tname\n1\tTűzkő utca\n2\tTörökugrató utca\n3\tOSM Name 1\n4\tHamzsabégi út\n"
 
-        def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
-            buf = io.BytesIO()
-            buf.write(result_from_overpass.encode('utf-8'))
-            buf.seek(0)
-            return buf
-        with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-            root = self.get_json_for_path("/streets/gazdagret/update-result.json")
-            self.assertEqual(root["error"], "")
+            def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
+                buf = io.BytesIO()
+                buf.write(result_from_overpass.encode('utf-8'))
+                buf.seek(0)
+                return buf
+            with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
+                root = self.get_json_for_path("/streets/gazdagret/update-result.json")
+                self.assertEqual(root["error"], "")
 
     def test_update_result_json_error(self) -> None:
         """Tests if the update-result json output on error is well-formed."""
-
-        def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
-            raise urllib.error.HTTPError(url="", code=0, msg="", hdrs={}, fp=io.BytesIO())
-        with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-            root = self.get_json_for_path("/streets/gazdagret/update-result.json")
-            self.assertEqual(root["error"], "HTTP Error 0: ")
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
+                raise urllib.error.HTTPError(url="", code=0, msg="", hdrs={}, fp=io.BytesIO())
+            with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
+                root = self.get_json_for_path("/streets/gazdagret/update-result.json")
+                self.assertEqual(root["error"], "HTTP Error 0: ")
 
 
 class TestJsonStreetHousenumbers(TestWsgiJson):
     """Tests street_housenumbers_update_result_json()."""
     def test_update_result_json(self) -> None:
         """Tests if the update-result output is well-formed."""
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
         result_from_overpass = "@id\taddr:street\taddr:housenumber\taddr:postcode\taddr:housename\t"
         result_from_overpass += "addr:conscriptionnumber\taddr:flats\taddr:floor\taddr:door\taddr:unit\tname\t@type\n\n"
         result_from_overpass += "1\tTörökugrató utca\t1\t\t\t\t\t\t\t\t\tnode\n"
@@ -99,33 +106,42 @@ class TestJsonStreetHousenumbers(TestWsgiJson):
             buf.seek(0)
             return buf
         with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-            root = self.get_json_for_path("/street-housenumbers/gazdagret/update-result.json")
+            with unittest.mock.patch("config.make_config", mock_make_config):
+                root = self.get_json_for_path("/street-housenumbers/gazdagret/update-result.json")
             self.assertEqual(root["error"], "")
 
     def test_update_result_error_json(self) -> None:
         """Tests if the update-result output on error is well-formed."""
-
-        def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
-            raise urllib.error.HTTPError(url="", code=0, msg="", hdrs={}, fp=io.BytesIO())
-        with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-            root = self.get_json_for_path("/street-housenumbers/gazdagret/update-result.json")
-            self.assertEqual(root["error"], "HTTP Error 0: ")
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
+                raise urllib.error.HTTPError(url="", code=0, msg="", hdrs={}, fp=io.BytesIO())
+            with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
+                root = self.get_json_for_path("/street-housenumbers/gazdagret/update-result.json")
+                self.assertEqual(root["error"], "HTTP Error 0: ")
 
 
 class TestJsonMissingHousenumbers(TestWsgiJson):
     """Tests missing_housenumbers_update_result_json()."""
     def test_update_result_json(self) -> None:
         """Tests if the update-result json output is well-formed."""
-        root = self.get_json_for_path("/missing-housenumbers/gazdagret/update-result.json")
-        self.assertEqual(root["error"], "")
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            root = self.get_json_for_path("/missing-housenumbers/gazdagret/update-result.json")
+            self.assertEqual(root["error"], "")
 
 
 class TestJsonMissingStreets(TestWsgiJson):
     """Tests missing_streets_update_result_json()."""
     def test_update_result_json(self) -> None:
         """Tests if the update-result json output is well-formed."""
-        root = self.get_json_for_path("/missing-streets/gazdagret/update-result.json")
-        self.assertEqual(root["error"], "")
+        def mock_make_config() -> config.Config2:
+            return config.Config2("tests")
+        with unittest.mock.patch("config.make_config", mock_make_config):
+            root = self.get_json_for_path("/missing-streets/gazdagret/update-result.json")
+            self.assertEqual(root["error"], "")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The problem with static getters is that the whole process needs
restarting when updating e.g. the reference to a new version. The fix
for this is to migrate to non-static getters, workdir is a start. (And
even not all workdir get calls are converted yet.)

Change-Id: Id43634d7b2ca05530889dd66b6d6583ef9e76f51
