### PR TITLE
Rework to avoid ConfigContext

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,7 +9,6 @@ The config module contains functionality related to configuration handling.
 It intentionally doesn't import any other 'own' modules, so it can be used anywhere.
 """
 
-from typing import Any
 from typing import List
 from typing import Optional
 import configparser
@@ -120,27 +119,6 @@ class Config:
         Config.__get()
         assert Config.__config is not None
         return Config.__config.get("wsgi", "cron_update_inactive", fallback="False").strip() == "True"
-
-
-class ConfigContext:
-    """Context manager for Config."""
-    def __init__(self, key: str, value: str) -> None:
-        """Remembers what should be the new value."""
-        self.key = key
-        self.value = value
-        self.old_value = ""
-        if Config.has_value(key):
-            self.old_value = Config.get_value(key)
-
-    def __enter__(self) -> 'ConfigContext':
-        """Switches to the new value."""
-        Config.set_value(self.key, self.value)
-        return self
-
-    def __exit__(self, _exc_type: Any, _exc_value: Any, _exc_traceback: Any) -> bool:
-        """Switches back to the old value."""
-        Config.set_value(self.key, self.old_value)
-        return True
 
 
 def get_abspath(path: str) -> str:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -407,10 +407,11 @@ class TestGetValue(unittest.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
 
-        with config.ConfigContext("workdir", "/path/to/workdir"):
-            actual = config.Config.get_value("workdir")
-            expected = "/path/to/workdir"
-            self.assertEqual(actual, expected)
+        config.Config.set_value("workdir", "/path/to/workdir")
+        actual = config.Config.get_value("workdir")
+        expected = "/path/to/workdir"
+        self.assertEqual(actual, expected)
+        config.Config.set_value("workdir", "")
 
 
 class TestGetContent(unittest.TestCase):

--- a/tests/test_webframe.py
+++ b/tests/test_webframe.py
@@ -120,11 +120,12 @@ class TestLocalToUiTz(test_config.TestCase):
     """Tests local_to_ui_tz()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        with config.ConfigContext("timezone", "Europe/Budapest"):
-            local_dt = datetime.datetime.fromtimestamp(0)
-            ui_dt = webframe.local_to_ui_tz(local_dt)
-            if time.strftime('%Z%z') == "CET+0100":
-                self.assertEqual(ui_dt.timestamp(), 0)
+        config.Config.set_value("timezone", "Europe/Budapest")
+        local_dt = datetime.datetime.fromtimestamp(0)
+        ui_dt = webframe.local_to_ui_tz(local_dt)
+        if time.strftime('%Z%z') == "CET+0100":
+            self.assertEqual(ui_dt.timestamp(), 0)
+        config.Config.set_value("timezone", "")
 
 
 class TestFillMissingHeaderItems(unittest.TestCase):

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -759,10 +759,11 @@ class TestMain(TestWsgi):
 
     def test_custom_locale(self) -> None:
         """Tests the main page with a custom locale."""
-        with config.ConfigContext("locale", "en_US.UTF-8"):
-            root = self.get_dom_for_path("")
-            results = root.findall("body/table")
-            self.assertEqual(len(results), 1)
+        config.Config.set_value("locale", "en_US.UTF-8")
+        root = self.get_dom_for_path("")
+        results = root.findall("body/table")
+        self.assertEqual(len(results), 1)
+        config.Config.set_value("locale", "")
 
     def test_failing_locale(self) -> None:
         """Tests the main page with a failing locale."""


### PR DESCRIPTION
Its purpose is to mutate shared state, avoid that.

Change-Id: Iabfaf2359b64def7e813fa482c4038e5ff8ec3a9
