### PR TITLE
Add a dependency dumper for thw own python modules

### DIFF
--- a/tools/dump-deps.sh
+++ b/tools/dump-deps.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 Miklos Vajna. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+
+#
+# Dumps a dependency graph of python modules.
+#
+
+echo "digraph {" > deps.dot
+for module_file in *.py
+do
+    module=$(basename $module_file .py)
+    for dependency in $(grep ^import $module_file|sed 's/import //'; grep ^from $module_file |sed 's/from \(.*\) import.*/\1/g'|sort -u)
+    do
+        if [ ! -e "$dependency.py" ]; then
+            continue
+        fi
+        echo "$module -> $dependency;" >> deps.dot
+    done
+done
+echo "}" >> deps.dot
+dot -Tpng -o deps.png deps.dot
+xdg-open deps.png
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab:


### PR DESCRIPTION
Helps seeing what are the leaf modules which are possible to port to C
(or equivalent), if wanted.

Change-Id: I463d1eb741ece7869993f324e1a8f02cd366c847
