### PR TITLE
config: rework to avoid make_config()

### DIFF
--- a/additional_housenumbers.py
+++ b/additional_housenumbers.py
@@ -14,9 +14,8 @@ import config
 import util
 
 
-def main() -> None:
+def main(conf: config.Config) -> None:
     """Commandline interface."""
-    conf = config.make_config()
     workdir = conf.get_workdir()
 
     relation_name = sys.argv[1]
@@ -35,6 +34,6 @@ def main() -> None:
 
 
 if __name__ == '__main__':
-    main()
+    main(config.Config(""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/additional_streets.py
+++ b/additional_streets.py
@@ -13,9 +13,8 @@ import areas
 import config
 
 
-def main() -> None:
+def main(conf: config.Config) -> None:
     """Commandline interface."""
-    conf = config.make_config()
     workdir = conf.get_workdir()
 
     relation_name = sys.argv[1]
@@ -29,6 +28,6 @@ def main() -> None:
 
 
 if __name__ == '__main__':
-    main()
+    main(config.Config(""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/config.py
+++ b/config.py
@@ -87,9 +87,4 @@ class Config:
         return self.__config.get("wsgi", "cron_update_inactive", fallback="False").strip() == "True"
 
 
-def make_config() -> Config:
-    """Factory for Config."""
-    return Config("")
-
-
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/cron.py
+++ b/cron.py
@@ -348,10 +348,9 @@ def our_main(conf: config.Config, relations: areas.Relations, mode: str, update:
                 break
 
 
-def main() -> None:
+def main(conf: config.Config) -> None:
     """Commandline interface to this module."""
 
-    conf = config.make_config()
     util.set_locale(conf)
 
     workdir = conf.get_workdir()
@@ -395,6 +394,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    main(config.Config(""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/get_reference_housenumbers.py
+++ b/get_reference_housenumbers.py
@@ -13,12 +13,11 @@ import areas
 import config
 
 
-def main() -> None:
+def main(conf: config.Config) -> None:
     """Commandline interface to this module."""
 
     relation_name = sys.argv[1]
 
-    conf = config.make_config()
     references = conf.get_reference_housenumber_paths()
     workdir = conf.get_workdir()
     relations = areas.Relations(workdir)
@@ -27,6 +26,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    main(config.Config(""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/get_reference_streets.py
+++ b/get_reference_streets.py
@@ -13,12 +13,11 @@ import areas
 import config
 
 
-def main() -> None:
+def main(conf: config.Config) -> None:
     """Commandline interface to this module."""
 
     relation_name = sys.argv[1]
 
-    conf = config.make_config()
     reference = conf.get_reference_street_path()
     workdir = conf.get_workdir()
     relations = areas.Relations(workdir)
@@ -27,6 +26,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    main(config.Config(""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/invalid_refstreets.py
+++ b/invalid_refstreets.py
@@ -11,9 +11,8 @@ import areas
 import config
 
 
-def main() -> None:
+def main(conf: config.Config) -> None:
     """Commandline interface."""
-    conf = config.make_config()
     workdir = conf.get_workdir()
     relations = areas.Relations(workdir)
     for relation in relations.get_relations():
@@ -26,6 +25,6 @@ def main() -> None:
 
 
 if __name__ == '__main__':
-    main()
+    main(config.Config(""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/missing_housenumbers.py
+++ b/missing_housenumbers.py
@@ -14,9 +14,8 @@ import config
 import util
 
 
-def main() -> None:
+def main(conf: config.Config) -> None:
     """Commandline interface."""
-    conf = config.make_config()
     workdir = conf.get_workdir()
 
     relation_name = sys.argv[1]
@@ -36,6 +35,6 @@ def main() -> None:
 
 
 if __name__ == '__main__':
-    main()
+    main(config.Config(""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/missing_streets.py
+++ b/missing_streets.py
@@ -13,9 +13,8 @@ import areas
 import config
 
 
-def main() -> None:
+def main(conf: config.Config) -> None:
     """Commandline interface."""
-    conf = config.make_config()
     workdir = conf.get_workdir()
 
     relation_name = sys.argv[1]
@@ -29,6 +28,6 @@ def main() -> None:
 
 
 if __name__ == '__main__':
-    main()
+    main(config.Config(""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/overpass_query.py
+++ b/overpass_query.py
@@ -50,9 +50,8 @@ def overpass_query_need_sleep(conf: config.Config) -> int:
     return sleep
 
 
-def main() -> None:
+def main(conf: config.Config) -> None:
     """Commandline interface to this module."""
-    conf = config.make_config()
     with open(sys.argv[1]) as stream:
         query = stream.read()
 
@@ -65,6 +64,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    main(config.Config(""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/parse_access_log.py
+++ b/parse_access_log.py
@@ -141,13 +141,12 @@ def check_top_edited_relations(frequent_relations: Set[str], workdir: str) -> No
             frequent_relations.remove(city[0])
 
 
-def main() -> None:
+def main(conf: config.Config) -> None:
     """Commandline interface."""
     log_file = sys.argv[1]
 
     relation_create_dates: Dict[str, datetime.date] = get_relation_create_dates()
 
-    conf = config.make_config()
     relations = areas.Relations(conf.get_workdir())
     frequent_relations = get_frequent_relations(conf, log_file)
     check_top_edited_relations(frequent_relations, conf.get_workdir())
@@ -171,6 +170,6 @@ def main() -> None:
 
 
 if __name__ == '__main__':
-    main()
+    main(config.Config(""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -23,16 +23,11 @@ import ranges
 import util
 
 
-def mock_make_config() -> config.Config:
-    """Creates a Config instance that has its root as /tests."""
-    return config.Config("tests")
-
-
 class TestRelationGetOsmStreets(test_config.TestCase):
     """Tests Relation.get_osm_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("test")
         actual = [i.get_osm_name() for i in relation.get_osm_streets()]
         expected = ['B1', 'B2', 'HB1', 'HB2']
@@ -40,7 +35,7 @@ class TestRelationGetOsmStreets(test_config.TestCase):
 
     def test_street_is_node(self) -> None:
         """Tests the case when the street name is coming from a house number (node)."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gh830")
         actual = relation.get_osm_streets()
         self.assertEqual(len(actual), 1)
@@ -48,7 +43,7 @@ class TestRelationGetOsmStreets(test_config.TestCase):
 
     def test_no_house_number(self) -> None:
         """Tests the case when we have streets, but no house numbers."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("ujbuda")
         actual = [i.get_osm_name() for i in relation.get_osm_streets()]
         expected = ['OSM Name 1', 'Törökugrató utca', 'Tűzkő utca']
@@ -56,7 +51,7 @@ class TestRelationGetOsmStreets(test_config.TestCase):
 
     def test_conscriptionnumber(self) -> None:
         """Tests when there is only an addr:conscriptionnumber."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gh754"
         relation = relations.get_relation(relation_name)
         streets = [i.get_osm_name() for i in relation.get_osm_streets()]
@@ -69,7 +64,7 @@ class TestRelationGetOsmStreetsQuery(test_config.TestCase):
     """Tests Relation.get_osm_streets_query()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         self.assertEqual(os.path.join(os.path.dirname(__file__), "workdir"), relations.get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -81,7 +76,7 @@ class TestRelationGetOsmHousenumbersQuery(test_config.TestCase):
     """Tests Relation.get_osm_housenumbers_query()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         ret = relation.get_osm_housenumbers_query()
@@ -92,7 +87,7 @@ class TestRelationFilesWriteOsmStreets(test_config.TestCase):
     """Tests RelationFiles.write_osm_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         result_from_overpass = "@id\tname\n1\tTűzkő utca\n2\tTörökugrató utca\n3\tOSM Name 1\n4\tHamzsabégi út\n"
@@ -106,7 +101,7 @@ class TestRelationFilesWriteOsmHousenumbers(test_config.TestCase):
     """Tests RelationFiles.write_osm_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gazdagret"
         result_from_overpass = "@id\taddr:street\taddr:housenumber\taddr:postcode\taddr:housename\t"
         result_from_overpass += "addr:conscriptionnumber\taddr:flats\taddr:floor\taddr:door\taddr:unit\tname\t@type\n\n"
@@ -129,7 +124,7 @@ class TestRelationGetStreetRanges(test_config.TestCase):
     """Tests Relation.get_street_ranges()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         filters = relation.get_street_ranges()
         expected_filters = {
@@ -143,14 +138,14 @@ class TestRelationGetStreetRanges(test_config.TestCase):
             'OSM Name 2': 'Ref Name 2',
             'Misspelled OSM Name 1': 'OSM Name 1',
         }
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         self.assertEqual(relations.get_relation("gazdagret").get_config().get_refstreets(), expected_streets)
         street_blacklist = relations.get_relation("gazdagret").get_config().get_street_filters()
         self.assertEqual(street_blacklist, ['Only In Ref Nonsense utca'])
 
     def test_empty(self) -> None:
         """Tests when the filter file is empty."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("empty")
         filters = relation.get_street_ranges()
         self.assertEqual(filters, {})
@@ -160,7 +155,7 @@ class TestRelationGetRefStreetFromOsmStreet(test_config.TestCase):
     """Tests Relation.get_ref_street_from_osm_street()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         street = "Budaörsi út"
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -172,7 +167,7 @@ class TestRelationGetRefStreetFromOsmStreet(test_config.TestCase):
 
     def test_refsettlement_override(self) -> None:
         """Tests street-specific refsettlement override."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         street = "Teszt utca"
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -184,7 +179,7 @@ class TestRelationGetRefStreetFromOsmStreet(test_config.TestCase):
 
     def test_refstreets(self) -> None:
         """Tests OSM -> ref name mapping."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         street = "OSM Name 1"
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -196,7 +191,7 @@ class TestRelationGetRefStreetFromOsmStreet(test_config.TestCase):
 
     def test_nosuchrelation(self) -> None:
         """Tests a relation without a filter file."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         street = "OSM Name 1"
         relation_name = "nosuchrelation"
         relation = relations.get_relation(relation_name)
@@ -208,7 +203,7 @@ class TestRelationGetRefStreetFromOsmStreet(test_config.TestCase):
 
     def test_emptyrelation(self) -> None:
         """Tests a relation with an empty filter file."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         street = "OSM Name 1"
         relation_name = "empty"
         relation = relations.get_relation(relation_name)
@@ -220,7 +215,7 @@ class TestRelationGetRefStreetFromOsmStreet(test_config.TestCase):
 
     def test_range_level_override(self) -> None:
         """Tests the refsettlement range-level override."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         street = "Csiki-hegyek utca"
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -239,7 +234,7 @@ class TestNormalize(test_config.TestCase):
     """
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "139", "Budaörsi út", normalizers)
@@ -247,7 +242,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_not_in_range(self) -> None:
         """Tests when the number is not in range."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "999", "Budaörsi út", normalizers)
@@ -255,7 +250,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_not_a_number(self) -> None:
         """Tests the case when the house number is not a number."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "x", "Budaörsi út", normalizers)
@@ -263,7 +258,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_nofilter(self) -> None:
         """Tests the case when there is no filter for this street."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "1", "Budaörs út", normalizers)
@@ -271,7 +266,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_semicolon(self) -> None:
         """Tests the case when ';' is a separator."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "1;2", "Budaörs út", normalizers)
@@ -279,7 +274,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval(self) -> None:
         """Tests the 2-6 case: means implicit 4."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "2-6", "Budaörs út", normalizers)
@@ -287,7 +282,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval_parity(self) -> None:
         """Tests the 5-8 case: means just 5 and 8 as the parity doesn't match."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "5-8", "Budaörs út", normalizers)
@@ -295,7 +290,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval_interp_all(self) -> None:
         """Tests the 2-5 case: means implicit 3 and 4."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = [i.get_number() for i in areas.normalize(relation, "2-5", "Hamzsabégi út", normalizers)]
@@ -303,7 +298,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval_filter(self) -> None:
         """Tests the case where x-y is partially filtered out."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         # filter is 137-165
@@ -313,7 +308,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval_block(self) -> None:
         """Tests the case where x-y is nonsense: y is too large."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "2-2000", "Budaörs út", normalizers)
@@ -323,7 +318,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval_block2(self) -> None:
         """Tests the case where x-y is nonsense: y-x is too large."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "2-56", "Budaörs út", normalizers)
@@ -332,7 +327,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval_block3(self) -> None:
         """Tests the case where x-y is nonsense: x is 0."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "0-42", "Budaörs út", normalizers)
@@ -341,7 +336,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_interval_block4(self) -> None:
         """Tests the case where x-y is only partially useful: x is OK, but y is a suffix."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "42-1", "Budaörs út", normalizers)
@@ -350,7 +345,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_keep_suffix(self) -> None:
         """Tests that the * suffix is preserved."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_number = areas.normalize(relation, "1*", "Budaörs út", normalizers)
@@ -360,7 +355,7 @@ class TestNormalize(test_config.TestCase):
 
     def test_separator_comma(self) -> None:
         """Tests the case when ',' is a separator."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "2,6", "Budaörs út", normalizers)
@@ -373,7 +368,7 @@ class TestRelationGetRefStreets(test_config.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         relation_name = "gazdagret"
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation(relation_name)
         house_numbers = relation.get_ref_streets()
         self.assertEqual(house_numbers, ['Hamzsabégi út',
@@ -390,7 +385,7 @@ class TestRelationGetOsmHouseNumbers(test_config.TestCase):
         """Tests the happy path."""
         relation_name = "gazdagret"
         street_name = "Törökugrató utca"
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation(relation_name)
         house_numbers = relation.get_osm_housenumbers(street_name)
         self.assertEqual([i.get_number() for i in house_numbers], ["1", "2"])
@@ -398,7 +393,7 @@ class TestRelationGetOsmHouseNumbers(test_config.TestCase):
     def test_addr_place(self) -> None:
         """Tests the case when addr:place is used instead of addr:street."""
         relation_name = "gh964"
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation(relation_name)
         street_name = "Tolvajos tanya"
         house_numbers = relation.get_osm_housenumbers(street_name)
@@ -409,7 +404,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
     """Tests Relation.get_missing_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         ongoing_streets, done_streets = relation.get_missing_housenumbers()
@@ -426,7 +421,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
 
     def test_letter_suffix(self) -> None:
         """Tests that 7/A is detected when 7/B is already mapped."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gh267"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -442,7 +437,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
 
     def test_letter_suffix_invalid(self) -> None:
         """Tests how 'invalid' interacts with normalization."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gh296"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -466,7 +461,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
 
     def test_invalid_simplify(self) -> None:
         """Tests how 'invalid' interacts with housenumber-letters: true or false."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gh385"
         relation = relations.get_relation(relation_name)
 
@@ -507,7 +502,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
 
     def test_letter_suffix_normalize(self) -> None:
         """Tests that '42 A' vs '42/A' is recognized as a match."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gh286"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -523,7 +518,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
 
     def test_letter_suffix_source_suffix(self) -> None:
         """Tests that '42/A*' and '42/a' matches."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gh299"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -534,7 +529,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
 
     def test_letter_suffix_normalize_semicolon(self) -> None:
         """Tests that 'a' is not stripped from '1;3a'."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gh303"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -553,7 +548,7 @@ class TestRelationGetMissingStreets(test_config.TestCase):
     """Tests Relation.get_missing_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         only_in_reference, in_both = relation.get_missing_streets()
@@ -568,7 +563,7 @@ class TestRelationGetAdditionalStreets(test_config.TestCase):
     """Tests Relation.get_additional_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         only_in_osm = relation.get_additional_streets()
@@ -581,7 +576,7 @@ class TestRelationGetAdditionalStreets(test_config.TestCase):
 
     def test_no_osm_street_filters(self) -> None:
         """Tests when the osm-street-filters key is missing."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gh385"
         relation = relations.get_relation(relation_name)
         self.assertEqual(relation.get_config().get_osm_street_filters(), [])
@@ -591,7 +586,7 @@ class TestRelationGetAdditionalHousenumbers(test_config.TestCase):
     """Tests Relation.get_additional_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         only_in_osm = relation.get_additional_housenumbers()
@@ -615,7 +610,7 @@ class TestRelationWriteMissingHouseNumbers(test_config.TestCase):
     """Tests Relation.write_missing_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         expected = util.get_content(relations.get_workdir(), "gazdagret.percent")
@@ -635,7 +630,7 @@ class TestRelationWriteMissingHouseNumbers(test_config.TestCase):
 
     def test_empty(self) -> None:
         """Tests the case when percent can't be determined."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "empty"
         relation = relations.get_relation(relation_name)
         ret = relation.write_missing_housenumbers()
@@ -646,7 +641,7 @@ class TestRelationWriteMissingHouseNumbers(test_config.TestCase):
 
     def test_interpolation_all(self) -> None:
         """Tests the case when the street is interpolation=all and coloring is wanted."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "budafok"
         relation = relations.get_relation(relation_name)
         ret = relation.write_missing_housenumbers()
@@ -659,7 +654,7 @@ class TestRelationWriteMissingHouseNumbers(test_config.TestCase):
 
     def test_sorting(self) -> None:
         """Tests that sorting is performed after range reduction."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gh414"
         relation = relations.get_relation(relation_name)
         ret = relation.write_missing_housenumbers()
@@ -676,7 +671,7 @@ class TestRelationWriteMissingStreets(test_config.TestCase):
     """Tests Relation.write_missing_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         expected = util.get_content(relations.get_workdir(), "gazdagret-streets.percent")
@@ -691,7 +686,7 @@ class TestRelationWriteMissingStreets(test_config.TestCase):
 
     def test_empty(self) -> None:
         """Tests the case when percent can't be determined."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "empty"
         relation = relations.get_relation(relation_name)
         ret = relation.write_missing_streets()
@@ -705,7 +700,7 @@ class TestRelationBuildRefHousenumbers(test_config.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
         memory_cache = util.build_reference_cache(refpath, "01")
         relation_name = "gazdagret"
@@ -724,7 +719,7 @@ class TestRelationBuildRefHousenumbers(test_config.TestCase):
 
     def test_missing(self) -> None:
         """Tests the case when the street is not in the reference."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
         memory_cache = util.build_reference_cache(refpath, "01")
@@ -743,7 +738,7 @@ class TestRelationBuildRefStreets(test_config.TestCase):
         refpath = os.path.join(refdir, "utcak_20190514.tsv")
         memory_cache = util.build_street_reference_cache(refpath)
         relation_name = "gazdagret"
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation(relation_name)
         ret = relation.get_config().build_ref_streets(memory_cache)
         self.assertEqual(ret, ['Törökugrató utca',
@@ -761,7 +756,7 @@ class TestRelationWriteRefHousenumbers(test_config.TestCase):
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
         refpath2 = os.path.join(refdir, "hazszamok_kieg_20190808.tsv")
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gazdagret"
         expected = util.get_content(relations.get_workdir(), "street-housenumbers-reference-gazdagret.lst")
         relation = relations.get_relation(relation_name)
@@ -773,7 +768,7 @@ class TestRelationWriteRefHousenumbers(test_config.TestCase):
         """Tests the case when the refcounty code is missing in the reference."""
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "nosuchrefcounty"
         relation = relations.get_relation(relation_name)
         try:
@@ -785,7 +780,7 @@ class TestRelationWriteRefHousenumbers(test_config.TestCase):
         """Tests the case when the refsettlement code is missing in the reference."""
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "nosuchrefsettlement"
         relation = relations.get_relation(relation_name)
         try:
@@ -799,7 +794,7 @@ class TestRelationWriteRefStreets(test_config.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         refpath = config.get_abspath(os.path.join("refdir", "utcak_20190514.tsv"))
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         expected = util.get_content(relations.get_workdir(), "streets-reference-gazdagret.lst")
@@ -812,7 +807,7 @@ class TestRelations(test_config.TestCase):
     """Tests the Relations class."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         expected_relation_names = [
             "budafok",
             "empty",
@@ -861,7 +856,7 @@ class TestRelationConfigMissingStreets(test_config.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         relation_name = "ujbuda"
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation(relation_name)
         ret = relation.get_config().should_check_missing_streets()
         self.assertEqual(ret, "only")
@@ -869,7 +864,7 @@ class TestRelationConfigMissingStreets(test_config.TestCase):
     def test_empty(self) -> None:
         """Tests the default value."""
         relation_name = "empty"
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation(relation_name)
         self.assertEqual(relation.get_name(), "empty")
         ret = relation.get_config().should_check_missing_streets()
@@ -878,7 +873,7 @@ class TestRelationConfigMissingStreets(test_config.TestCase):
     def test_nosuchrelation(self) -> None:
         """Tests a relation without a filter file."""
         relation_name = "nosuchrelation"
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation(relation_name)
         ret = relation.get_config().should_check_missing_streets()
         self.assertEqual(ret, "yes")
@@ -889,7 +884,7 @@ class TestRelationConfigLetterSuffixStyle(unittest.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         relation_name = "empty"
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation(relation_name)
         self.assertEqual(relation.get_config().get_letter_suffix_style(), util.LetterSuffixStyle.UPPER)
         relation.get_config().set_letter_suffix_style(util.LetterSuffixStyle.LOWER)
@@ -900,7 +895,7 @@ class TestRefmegyeGetName(unittest.TestCase):
     """Tests refcounty_get_name()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         self.assertEqual(relations.refcounty_get_name("01"), "Budapest")
         self.assertEqual(relations.refcounty_get_name("99"), "")
@@ -910,7 +905,7 @@ class TestRefmegyeGetReftelepulesIds(test_config.TestCase):
     """Tests refcounty_get_refsettlement_ids()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         self.assertEqual(relations.refcounty_get_refsettlement_ids("01"), ["011", "012"])
         self.assertEqual(relations.refcounty_get_refsettlement_ids("99"), [])
@@ -920,7 +915,7 @@ class TestReftelepulesGetName(test_config.TestCase):
     """Tests refsettlement_get_name()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         self.assertEqual(relations.refsettlement_get_name("01", "011"), "Újbuda")
         self.assertEqual(relations.refsettlement_get_name("99", ""), "")
@@ -931,7 +926,7 @@ class TestRelationsGetAliases(test_config.TestCase):
     """Tests Relalations.get_aliases()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         # Expect an alias -> canonicalname map.
         expected = {
@@ -944,7 +939,7 @@ class TestRelationStreetIsEvenOdd(test_config.TestCase):
     """Tests RelationConfig.get_street_is_even_odd()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         relation = relations.get_relation("gazdagret")
         self.assertFalse(relation.get_config().get_street_is_even_odd("Hamzsabégi út"))
@@ -956,7 +951,7 @@ class TestRelationShowRefstreet(test_config.TestCase):
     """Tests RelationConfig.should_show_ref_street()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         self.assertFalse(relation.should_show_ref_street("Törökugrató utca"))
         self.assertTrue(relation.should_show_ref_street("Hamzsabégi út"))
@@ -966,7 +961,7 @@ class TestRelationIsActive(test_config.TestCase):
     """Tests RelationConfig.is_active()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         self.assertTrue(relation.get_config().is_active())
 
@@ -975,7 +970,7 @@ class TestMakeTurboQueryForStreets(test_config.TestCase):
     """Tests make_turbo_query_for_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         fro = ["A2"]
         ret = areas.make_turbo_query_for_streets(relation, fro)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -16,16 +16,11 @@ import cache
 import config
 
 
-def mock_make_config() -> config.Config:
-    """Creates a Config instance that has its root as /tests."""
-    return config.Config("tests")
-
-
 class TestIsMissingHousenumbersHtmlCached(test_config.TestCase):
     """Tests is_missing_housenumbers_html_cached()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         relation = relations.get_relation("gazdagret")
         cache.get_missing_housenumbers_html(conf, relation)
@@ -33,7 +28,7 @@ class TestIsMissingHousenumbersHtmlCached(test_config.TestCase):
 
     def test_no_cache(self) -> None:
         """Tests the case when there is no cache."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         relation = relations.get_relation("gazdagret")
         cache.get_missing_housenumbers_html(conf, relation)
@@ -49,7 +44,7 @@ class TestIsMissingHousenumbersHtmlCached(test_config.TestCase):
 
     def test_osm_housenumbers_new(self) -> None:
         """Tests the case when osm_housenumbers is new, so the cache entry is old."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         relation = relations.get_relation("gazdagret")
         cache.get_missing_housenumbers_html(conf, relation)
@@ -66,7 +61,7 @@ class TestIsMissingHousenumbersHtmlCached(test_config.TestCase):
 
     def test_ref_housenumbers_new(self) -> None:
         """Tests the case when ref_housenumbers is new, so the cache entry is old."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         relation = relations.get_relation("gazdagret")
         cache.get_missing_housenumbers_html(conf, relation)
@@ -83,7 +78,7 @@ class TestIsMissingHousenumbersHtmlCached(test_config.TestCase):
 
     def test_relation_new(self) -> None:
         """Tests the case when relation is new, so the cache entry is old."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         relation = relations.get_relation("gazdagret")
         cache.get_missing_housenumbers_html(conf, relation)
@@ -104,7 +99,7 @@ class TestGetAdditionalHousenumbersHtml(test_config.TestCase):
     """Tests get_additional_housenumbers_html()."""
     def test_happy(self) -> None:
         """Tests the case when we find the result in cache."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         relation = relations.get_relation("gazdagret")
         first = cache.get_additional_housenumbers_html(relation)
@@ -116,7 +111,7 @@ class TestIsMissingHousenumbersTxtCached(test_config.TestCase):
     """Tests is_missing_housenumbers_txt_cached()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         relation = relations.get_relation("gazdagret")
         cache.get_missing_housenumbers_txt(relation)

--- a/tests/test_cache_yamls.py
+++ b/tests/test_cache_yamls.py
@@ -15,12 +15,6 @@ import test_config
 
 import areas
 import cache_yamls
-import config
-
-
-def mock_make_config() -> config.Config:
-    """Creates a Config instance that has its root as /tests."""
-    return config.Config("tests")
 
 
 class TestMain(test_config.TestCase):
@@ -41,7 +35,7 @@ class TestMain(test_config.TestCase):
         relation_ids = []
         with open(relation_ids_path) as stream:
             relation_ids = json.load(stream)
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         osmids = sorted([relation.get_config().get_osmrelation() for relation in relations.get_relations()])
         self.assertEqual(relation_ids, sorted(set(osmids)))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,11 @@ import unittest.mock
 import config
 
 
+def make_test_config() -> config.Config:
+    """Creates a Config instance that has its root as /tests."""
+    return config.Config("tests")
+
+
 def mock_get_abspath(path: str) -> str:
     """Mock get_abspath() that uses the test directory."""
     if os.path.isabs(path):
@@ -32,11 +37,11 @@ class TestCase(unittest.TestCase):
         self.get_abspath_patcher.stop()
 
 
-class TestMakeConfig(unittest.TestCase):
-    """Tests make_config()."""
+class TestGetAbspath(unittest.TestCase):
+    """Tests get_abspath()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = config.make_config()
+        conf = config.Config("")
         abs_path = conf.get_abspath("file")
         self.assertEqual(abs_path, os.path.join(os.getcwd(), "file"))
 

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -25,11 +25,6 @@ import cron
 import util
 
 
-def mock_make_config() -> config.Config:
-    """Creates a Config instance that has its root as /tests."""
-    return config.Config("tests")
-
-
 def mock_urlopen_raise_error(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
     """Mock urlopen(), always throwing an error."""
     raise urllib.error.HTTPError(url="", code=0, msg="", hdrs={}, fp=io.BytesIO())
@@ -46,7 +41,7 @@ class TestOverpassSleep(unittest.TestCase):
         def mock_sleep(_seconds: float) -> None:
             nonlocal mock_sleep_called
             mock_sleep_called = True
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         with unittest.mock.patch('overpass_query.overpass_query_need_sleep', mock_overpass_query_need_sleep):
             with unittest.mock.patch('time.sleep', mock_sleep):
                 cron.overpass_sleep(conf)
@@ -67,7 +62,7 @@ class TestOverpassSleep(unittest.TestCase):
         def mock_sleep(seconds: float) -> None:
             nonlocal captured_seconds
             captured_seconds = seconds
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         with unittest.mock.patch('overpass_query.overpass_query_need_sleep', mock_overpass_query_need_sleep):
             with unittest.mock.patch('time.sleep', mock_sleep):
                 cron.overpass_sleep(conf)
@@ -78,7 +73,7 @@ class TestUpdateRefHousenumbers(test_config.TestCase):
     """Tests update_ref_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         for relation_name in relations.get_active_names():
             if relation_name not in ("gazdagret", "ujbuda"):
@@ -101,7 +96,7 @@ class TestUpdateRefStreets(test_config.TestCase):
     """Tests update_ref_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         for relation_name in relations.get_active_names():
             # gellerthegy is streets=no
@@ -125,7 +120,7 @@ class TestUpdateMissingHousenumbers(test_config.TestCase):
     """Tests update_missing_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         for relation_name in relations.get_active_names():
             # ujbuda is streets=only
@@ -148,7 +143,7 @@ class TestUpdateMissingStreets(test_config.TestCase):
     """Tests update_missing_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         for relation_name in relations.get_active_names():
             # gellerthegy is streets=no
@@ -171,7 +166,7 @@ class TestUpdateAdditionalStreets(test_config.TestCase):
     """Tests update_additional_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         for relation_name in relations.get_active_names():
             # gellerthegy is streets=no
@@ -219,7 +214,7 @@ class TestUpdateOsmHousenumbers(test_config.TestCase):
             buf.seek(0)
             return buf
 
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         with unittest.mock.patch("cron.overpass_sleep", mock_overpass_sleep):
             with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
@@ -245,7 +240,7 @@ class TestUpdateOsmHousenumbers(test_config.TestCase):
             nonlocal mock_overpass_sleep_called
             mock_overpass_sleep_called = True
 
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         with unittest.mock.patch("cron.overpass_sleep", mock_overpass_sleep):
             with unittest.mock.patch('urllib.request.urlopen', mock_urlopen_raise_error):
@@ -279,7 +274,7 @@ class TestUpdateOsmStreets(test_config.TestCase):
             buf.seek(0)
             return buf
 
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         with unittest.mock.patch("cron.overpass_sleep", mock_overpass_sleep):
             with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
@@ -305,7 +300,7 @@ class TestUpdateOsmStreets(test_config.TestCase):
             nonlocal mock_overpass_sleep_called
             mock_overpass_sleep_called = True
 
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         with unittest.mock.patch("cron.overpass_sleep", mock_overpass_sleep):
             with unittest.mock.patch('urllib.request.urlopen', mock_urlopen_raise_error):
@@ -344,7 +339,7 @@ class TestUpdateStats(test_config.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
 
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         mock_overpass_sleep_called = False
 
         def mock_overpass_sleep(_conf: config.Config) -> None:
@@ -385,7 +380,7 @@ class TestUpdateStats(test_config.TestCase):
 
     def test_http_error(self) -> None:
         """Tests the case when we keep getting HTTP errors."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         mock_overpass_sleep_called = False
 
         def mock_overpass_sleep(_conf: config.Config) -> None:
@@ -400,7 +395,7 @@ class TestUpdateStats(test_config.TestCase):
 
     def test_no_overpass(self) -> None:
         """Tests the case when we don't call overpass."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         mock_overpass_sleep_called = False
 
         def mock_overpass_sleep() -> None:
@@ -423,7 +418,7 @@ class TestOurMain(test_config.TestCase):
             nonlocal calls
             calls += 1
 
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         with unittest.mock.patch("cron.update_osm_streets", count_calls):
             with unittest.mock.patch("cron.update_osm_housenumbers", count_calls):
@@ -453,7 +448,7 @@ class TestOurMain(test_config.TestCase):
             nonlocal calls
             calls += 1
 
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         with unittest.mock.patch("cron.update_stats", count_calls):
             cron.our_main(conf, relations, mode="stats", update=False, overpass=True)
@@ -483,12 +478,12 @@ class TestMain(test_config.TestCase):
             nonlocal mock_info_called
             mock_info_called = True
 
+        conf = config.Config("tests")
         with unittest.mock.patch("cron.our_main", mock_main):
             with unittest.mock.patch("logging.info", mock_info):
                 argv = [""]
                 with unittest.mock.patch('sys.argv', argv):
-                    with unittest.mock.patch("config.make_config", mock_make_config):
-                        cron.main()
+                    cron.main(conf)
 
         self.assertTrue(mock_main_called)
         self.assertTrue(mock_info_called)
@@ -507,13 +502,13 @@ class TestMain(test_config.TestCase):
             nonlocal mock_error_called
             mock_error_called = True
 
+        conf = config.Config("tests")
         with unittest.mock.patch("cron.our_main", mock_our_main):
             with unittest.mock.patch("logging.info", mock_info):
                 with unittest.mock.patch("logging.error", mock_error):
                     argv = [""]
                     with unittest.mock.patch('sys.argv', argv):
-                        with unittest.mock.patch("config.make_config", mock_make_config):
-                            cron.main()
+                        cron.main(conf)
 
         self.assertTrue(mock_error_called)
 

--- a/tests/test_get_reference_housenumbers.py
+++ b/tests/test_get_reference_housenumbers.py
@@ -16,11 +16,6 @@ import get_reference_housenumbers
 import util
 
 
-def mock_make_config() -> config.Config:
-    """Creates a Config instance that has its root as /tests."""
-    return config.Config("tests")
-
-
 class TestMain(test_config.TestCase):
     """Tests main()."""
     def test_happy(self) -> None:
@@ -28,9 +23,9 @@ class TestMain(test_config.TestCase):
         expected = util.get_content(config.get_abspath("workdir/street-housenumbers-reference-gazdagret.lst"))
 
         argv = ["", "gazdagret"]
+        conf = config.Config("tests")
         with unittest.mock.patch('sys.argv', argv):
-            with unittest.mock.patch("config.make_config", mock_make_config):
-                get_reference_housenumbers.main()
+            get_reference_housenumbers.main(conf)
 
         actual = util.get_content(config.get_abspath("workdir/street-housenumbers-reference-gazdagret.lst"))
         self.assertEqual(actual, expected)

--- a/tests/test_get_reference_streets.py
+++ b/tests/test_get_reference_streets.py
@@ -16,11 +16,6 @@ import get_reference_streets
 import util
 
 
-def mock_make_config() -> config.Config:
-    """Creates a Config instance that has its root as /tests."""
-    return config.Config("tests")
-
-
 class TestMain(test_config.TestCase):
     """Tests main()."""
     def test_happy(self) -> None:
@@ -28,9 +23,9 @@ class TestMain(test_config.TestCase):
         expected = util.get_content(config.get_abspath("workdir/streets-reference-gazdagret.lst"))
 
         argv = ["", "gazdagret"]
+        conf = config.Config("tests")
         with unittest.mock.patch('sys.argv', argv):
-            with unittest.mock.patch("config.make_config", mock_make_config):
-                get_reference_streets.main()
+            get_reference_streets.main(conf)
 
         actual = util.get_content(config.get_abspath("workdir/streets-reference-gazdagret.lst"))
         self.assertEqual(actual, expected)

--- a/tests/test_missing_housenumbers.py
+++ b/tests/test_missing_housenumbers.py
@@ -16,21 +16,16 @@ import config
 import missing_housenumbers
 
 
-def mock_make_config() -> config.Config:
-    """Creates a Config instance that has its root as /tests."""
-    return config.Config("tests")
-
-
 class TestMain(test_config.TestCase):
     """Tests main()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
         argv = ["", "gh195"]
         buf = io.StringIO()
+        conf = config.Config("tests")
         with unittest.mock.patch('sys.argv', argv):
             with unittest.mock.patch('sys.stdout', buf):
-                with unittest.mock.patch("config.make_config", mock_make_config):
-                    missing_housenumbers.main()
+                missing_housenumbers.main(conf)
 
         buf.seek(0)
         self.assertEqual(buf.read(), "Kalotaszeg utca\t3\n['25', '27-37', '31*']\n")

--- a/tests/test_missing_streets.py
+++ b/tests/test_missing_streets.py
@@ -16,21 +16,16 @@ import config
 import missing_streets
 
 
-def mock_make_config() -> config.Config:
-    """Creates a Config instance that has its root as /tests."""
-    return config.Config("tests")
-
-
 class TestMain(test_config.TestCase):
     """Tests main()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
         argv = ["", "gazdagret"]
         buf = io.StringIO()
+        conf = config.Config("tests")
         with unittest.mock.patch('sys.argv', argv):
             with unittest.mock.patch('sys.stdout', buf):
-                with unittest.mock.patch("config.make_config", mock_make_config):
-                    missing_streets.main()
+                missing_streets.main(conf)
 
         buf.seek(0)
         self.assertEqual(buf.read(), "Only In Ref utca\n")

--- a/tests/test_overpass_query.py
+++ b/tests/test_overpass_query.py
@@ -82,27 +82,25 @@ class TestMain(unittest.TestCase):
     """Tests main()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-
+        conf = config.Config("tests")
         with unittest.mock.patch('urllib.request.urlopen', gen_urlopen("overpass-interpreter-happy")):
             buf = io.StringIO()
             with unittest.mock.patch('sys.stdout', buf):
                 argv = ["", "tests/mock/overpass-interpreter-happy.request-data"]
                 with unittest.mock.patch('sys.argv', argv):
-                    with unittest.mock.patch("config.make_config", mock_make_config):
-                        overpass_query.main()
+                    overpass_query.main(conf)
             buf.seek(0)
             self.assertTrue(buf.read().startswith("@id"))
 
     def test_failure(self) -> None:
         """Tests the failure path."""
+        conf = config.Config("tests")
         with unittest.mock.patch('urllib.request.urlopen', gen_urlopen("")):
             buf = io.StringIO()
             with unittest.mock.patch('sys.stdout', buf):
                 argv = ["", "tests/mock/overpass-interpreter-happy.request-data"]
                 with unittest.mock.patch('sys.argv', argv):
-                    overpass_query.main()
+                    overpass_query.main(conf)
             buf.seek(0)
             self.assertTrue(buf.read().startswith("overpass query failed"))
 

--- a/tests/test_parse_access_log.py
+++ b/tests/test_parse_access_log.py
@@ -19,13 +19,7 @@ import unittest.mock
 import test_config
 
 import areas
-import config
 import parse_access_log
-
-
-def mock_make_config() -> config.Config:
-    """Creates a Config instance that has its root as /tests."""
-    return config.Config("tests")
 
 
 class MockDate(datetime.date):
@@ -42,6 +36,7 @@ class TestMain(test_config.TestCase):
         """Tests the happy path."""
         argv = ["", "tests/mock/access_log"]
         buf = io.StringIO()
+        conf = test_config.make_test_config()
         real_subprocess_run = subprocess.run
 
         def mock_subprocess_run(args: List[str], stdout: Any, check: bool) -> Any:
@@ -57,8 +52,7 @@ author-time 1588975200
             with unittest.mock.patch('sys.stdout', buf):
                 with unittest.mock.patch('datetime.date', MockDate):
                     with unittest.mock.patch('subprocess.run', mock_subprocess_run):
-                        with unittest.mock.patch("config.make_config", mock_make_config):
-                            parse_access_log.main()
+                        parse_access_log.main(conf)
 
         buf.seek(0)
         actual = buf.read()
@@ -92,7 +86,7 @@ class TestCheckTopEditedRelations(test_config.TestCase):
                 ("bar", 2),
                 ("baz", 2)
             ]
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         with unittest.mock.patch('datetime.date', MockDate):
             with unittest.mock.patch('stats.get_topcities', mock_get_topcities):
                 frequent_relations: Set[str] = {"foo", "bar"}
@@ -110,7 +104,7 @@ class TestIsCompleteRelation(test_config.TestCase):
     """Tests is_complete_relation()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         relations = areas.Relations(conf.get_workdir())
         self.assertFalse(parse_access_log.is_complete_relation(relations, "gazdagret"))
 

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -41,16 +41,12 @@ if TYPE_CHECKING:
     from wsgiref.types import StartResponse
 
 
-def mock_make_config() -> config.Config:
-    """Creates a Config instance that has its root as /tests."""
-    return config.Config("tests")
-
-
 class TestWsgi(test_config.TestCase):
     """Base class for wsgi tests."""
     def __init__(self, method_name: str) -> None:
         test_config.TestCase.__init__(self, method_name)
         self.gzip_compress = False
+        self.conf = test_config.make_test_config()
 
     def get_dom_for_path(self, path: str, absolute: bool = False, expected_status: str = "") -> ET.Element:
         """Generates an XML DOM for a given wsgi path."""
@@ -63,8 +59,7 @@ class TestWsgi(test_config.TestCase):
             header_dict = dict(response_headers)
             self.assertEqual(header_dict["Content-type"], "text/html; charset=utf-8")
 
-        conf = mock_make_config()
-        prefix = conf.get_uri_prefix()
+        prefix = self.conf.get_uri_prefix()
         if not absolute:
             path = prefix + path
         environ = {
@@ -73,7 +68,7 @@ class TestWsgi(test_config.TestCase):
         if self.gzip_compress:
             environ["HTTP_ACCEPT_ENCODING"] = "gzip, deflate"
         callback = cast('StartResponse', start_response)
-        output_iterable = wsgi.application(environ, callback)
+        output_iterable = wsgi.application(environ, callback, self.conf)
         output_list = cast(List[bytes], output_iterable)
         self.assertTrue(output_list)
         if self.gzip_compress:
@@ -96,13 +91,12 @@ class TestWsgi(test_config.TestCase):
             else:
                 self.assertEqual(header_dict["Content-type"], "text/plain; charset=utf-8")
 
-        conf = mock_make_config()
-        prefix = conf.get_uri_prefix()
+        prefix = self.conf.get_uri_prefix()
         environ = {
             "PATH_INFO": prefix + path
         }
         callback = cast('StartResponse', start_response)
-        output_iterable = wsgi.application(environ, callback)
+        output_iterable = wsgi.application(environ, callback, self.conf)
         output_list = cast(List[bytes], output_iterable)
         self.assertTrue(output_list)
         output = output_list[0].decode('utf-8')
@@ -116,13 +110,12 @@ class TestWsgi(test_config.TestCase):
             header_dict = dict(response_headers)
             self.assertEqual(header_dict["Content-type"], "text/css; charset=utf-8")
 
-        conf = mock_make_config()
-        prefix = conf.get_uri_prefix()
+        prefix = self.conf.get_uri_prefix()
         environ = {
             "PATH_INFO": prefix + path
         }
         callback = cast('StartResponse', start_response)
-        output_iterable = wsgi.application(environ, callback)
+        output_iterable = wsgi.application(environ, callback, self.conf)
         output_list = cast(List[bytes], output_iterable)
         self.assertTrue(output_list)
         output = output_list[0].decode('utf-8')
@@ -133,68 +126,62 @@ class TestStreets(TestWsgi):
     """Tests handle_streets()."""
     def test_well_formed(self) -> None:
         """Tests if the output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/streets/gazdagret/view-result")
-            results = root.findall("body/table")
-            self.assertEqual(len(results), 1)
+        root = self.get_dom_for_path("/streets/gazdagret/view-result")
+        results = root.findall("body/table")
+        self.assertEqual(len(results), 1)
 
     def test_view_query_well_formed(self) -> None:
         """Tests if the view-query output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/streets/gazdagret/view-query")
-            results = root.findall("body/pre")
-            self.assertEqual(len(results), 1)
+        root = self.get_dom_for_path("/streets/gazdagret/view-query")
+        results = root.findall("body/pre")
+        self.assertEqual(len(results), 1)
 
     def test_update_result_well_formed(self) -> None:
         """Tests if the update-result output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            result_from_overpass = "@id\tname\n1\tTűzkő utca\n2\tTörökugrató utca\n3\tOSM Name 1\n4\tHamzsabégi út\n"
+        result_from_overpass = "@id\tname\n1\tTűzkő utca\n2\tTörökugrató utca\n3\tOSM Name 1\n4\tHamzsabégi út\n"
 
-            def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
-                buf = io.BytesIO()
-                buf.write(result_from_overpass.encode('utf-8'))
-                buf.seek(0)
-                return buf
-            with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-                root = self.get_dom_for_path("/streets/gazdagret/update-result")
-                results = root.findall("body")
-                self.assertEqual(len(results), 1)
+        def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
+            buf = io.BytesIO()
+            buf.write(result_from_overpass.encode('utf-8'))
+            buf.seek(0)
+            return buf
+        with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
+            root = self.get_dom_for_path("/streets/gazdagret/update-result")
+            results = root.findall("body")
+            self.assertEqual(len(results), 1)
 
     def test_update_result_error_well_formed(self) -> None:
         """Tests if the update-result output on error is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
-                raise urllib.error.HTTPError(url="", code=0, msg="", hdrs={}, fp=io.BytesIO())
-            with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-                root = self.get_dom_for_path("/streets/gazdagret/update-result")
-                results = root.findall("body/div[@id='overpass-error']")
-                self.assertTrue(results)
+        def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
+            raise urllib.error.HTTPError(url="", code=0, msg="", hdrs={}, fp=io.BytesIO())
+        with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
+            root = self.get_dom_for_path("/streets/gazdagret/update-result")
+            results = root.findall("body/div[@id='overpass-error']")
+            self.assertTrue(results)
 
     def test_update_result_missing_streets_well_formed(self) -> None:
         """
         Tests if the update-result output is well-formed for should_check_missing_streets() ==
         "only".
         """
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            result_from_overpass = "@id\tname\n3\tOSM Name 1\n2\tTörökugrató utca\n1\tTűzkő utca\n"
+        result_from_overpass = "@id\tname\n3\tOSM Name 1\n2\tTörökugrató utca\n1\tTűzkő utca\n"
 
-            def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
-                buf = io.BytesIO()
-                buf.write(result_from_overpass.encode('utf-8'))
-                buf.seek(0)
-                return buf
-            with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-                root = self.get_dom_for_path("/streets/ujbuda/update-result")
-                results = root.findall("body")
-                self.assertEqual(len(results), 1)
+        def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
+            buf = io.BytesIO()
+            buf.write(result_from_overpass.encode('utf-8'))
+            buf.seek(0)
+            return buf
+        with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
+            root = self.get_dom_for_path("/streets/ujbuda/update-result")
+            results = root.findall("body")
+            self.assertEqual(len(results), 1)
 
 
 class TestMissingHousenumbers(TestWsgi):
     """Tests the missing house numbers page."""
     def test_well_formed(self) -> None:
         """Tests if the output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/missing-housenumbers/gazdagret/view-result")
+        root = self.get_dom_for_path("/missing-housenumbers/gazdagret/view-result")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
         # refstreets: >0 invalid osm name
@@ -206,87 +193,79 @@ class TestMissingHousenumbers(TestWsgi):
 
     def test_no_such_relation(self) -> None:
         """Tests the output for a non-existing relation."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/missing-housenumbers/gazdagret42/view-result")
+        root = self.get_dom_for_path("/missing-housenumbers/gazdagret42/view-result")
         results = root.findall("body/div[@id='no-such-relation-error']")
         self.assertEqual(len(results), 1)
 
     def test_well_formed_compat(self) -> None:
         """Tests if the output is well-formed (URL rewrite)."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/suspicious-streets/gazdagret/view-result")
+        root = self.get_dom_for_path("/suspicious-streets/gazdagret/view-result")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
 
     def test_well_formed_compat_relation(self) -> None:
         """Tests if the output is well-formed (URL rewrite for relation name)."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/suspicious-streets/budapest_22/view-result")
-            results = root.findall("body/table")
-            self.assertEqual(len(results), 1)
+        root = self.get_dom_for_path("/suspicious-streets/budapest_22/view-result")
+        results = root.findall("body/table")
+        self.assertEqual(len(results), 1)
 
     def test_no_osm_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm streets case."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_osm_streets_path()
-            real_exists = os.path.exists
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_streets_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                root = self.get_dom_for_path("/missing-housenumbers/gazdagret/view-result")
-                results = root.findall("body/div[@id='no-osm-streets']")
-                self.assertEqual(len(results), 1)
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/missing-housenumbers/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-osm-streets']")
+            self.assertEqual(len(results), 1)
 
     def test_no_osm_housenumbers_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm housenumbers case."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_osm_housenumbers_path()
-            real_exists = os.path.exists
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_housenumbers_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                root = self.get_dom_for_path("/missing-housenumbers/gazdagret/view-result")
-                results = root.findall("body/div[@id='no-osm-housenumbers']")
-                self.assertEqual(len(results), 1)
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/missing-housenumbers/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-osm-housenumbers']")
+            self.assertEqual(len(results), 1)
 
     def test_no_ref_housenumbers_well_formed(self) -> None:
         """Tests if the output is well-formed, no ref housenumbers case."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_ref_housenumbers_path()
-            real_exists = os.path.exists
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_ref_housenumbers_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                root = self.get_dom_for_path("/missing-housenumbers/gazdagret/view-result")
-                results = root.findall("body/div[@id='no-ref-housenumbers']")
-                self.assertEqual(len(results), 1)
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/missing-housenumbers/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-ref-housenumbers']")
+            self.assertEqual(len(results), 1)
 
     def test_view_result_txt(self) -> None:
         """Tests the txt output."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            result = self.get_txt_for_path("/missing-housenumbers/budafok/view-result.txt")
-            # Note how 12 is ordered after 2.
-            self.assertEqual(result, "Vöröskúti határsor\t[2, 12, 34, 36*]")
+        result = self.get_txt_for_path("/missing-housenumbers/budafok/view-result.txt")
+        # Note how 12 is ordered after 2.
+        self.assertEqual(result, "Vöröskúti határsor\t[2, 12, 34, 36*]")
 
     def test_view_result_txt_even_odd(self) -> None:
         """Tests the txt output (even-odd streets)."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.txt")
+        result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.txt")
         expected = """Hamzsabégi út	[1]
 Törökugrató utca	[7], [10]
 Tűzkő utca	[1], [2]"""
@@ -294,15 +273,13 @@ Tűzkő utca	[1], [2]"""
 
     def test_view_result_chkl(self) -> None:
         """Tests the chkl output."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            result = self.get_txt_for_path("/missing-housenumbers/budafok/view-result.chkl")
-            # Note how 12 is ordered after 2.
-            self.assertEqual(result, "[ ] Vöröskúti határsor [2, 12, 34, 36*]")
+        result = self.get_txt_for_path("/missing-housenumbers/budafok/view-result.chkl")
+        # Note how 12 is ordered after 2.
+        self.assertEqual(result, "[ ] Vöröskúti határsor [2, 12, 34, 36*]")
 
     def test_view_result_chkl_even_odd(self) -> None:
         """Tests the chkl output (even-odd streets)."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl")
+        result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl")
         expected = """[ ] Hamzsabégi út [1]
 [ ] Törökugrató utca [7], [10]
 [ ] Tűzkő utca [1], [2]"""
@@ -319,8 +296,7 @@ Tűzkő utca	[1], [2]"""
 
         with unittest.mock.patch("util.format_even_odd", mock_format_even_odd):
             with unittest.mock.patch("wsgi.get_chkl_split_limit", mock_get_chkl_split_limit):
-                with unittest.mock.patch("config.make_config", mock_make_config):
-                    result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl")
+                result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl")
                 expected = """[ ] Hamzsabégi út [1]
 [ ] Törökugrató utca [1, 3]
 [ ] Törökugrató utca [2, 4]
@@ -330,112 +306,104 @@ Tűzkő utca	[1], [2]"""
 
     def test_view_result_chkl_no_osm_streets_hn(self) -> None:
         """Tests the chkl output, no osm streets/hn case."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            hide_path = ""
-            real_exists = os.path.exists
+        hide_path = ""
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
 
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_osm_streets_path()
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl")
-                self.assertEqual(result, "No existing streets")
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_streets_path()
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl")
+            self.assertEqual(result, "No existing streets")
 
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_osm_housenumbers_path()
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl")
-                self.assertEqual(result, "No existing house numbers")
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_housenumbers_path()
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl")
+            self.assertEqual(result, "No existing house numbers")
 
     def test_view_result_chkl_no_ref_housenumbers(self) -> None:
         """Tests the chkl output, no ref housenumbers case."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_ref_housenumbers_path()
-            real_exists = os.path.exists
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_ref_housenumbers_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl")
-                self.assertEqual(result, "No reference house numbers")
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl")
+            self.assertEqual(result, "No reference house numbers")
 
     def test_view_result_txt_no_osm_streets(self) -> None:
         """Tests the txt output, no osm streets case."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_osm_streets_path()
-            real_exists = os.path.exists
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_streets_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.txt")
-                self.assertEqual(result, "No existing streets")
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.txt")
+            self.assertEqual(result, "No existing streets")
 
     def test_view_result_txt_no_osm_housenumbers(self) -> None:
         """Tests the txt output, no osm housenumbers case."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_osm_housenumbers_path()
-            real_exists = os.path.exists
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_housenumbers_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.txt")
-                self.assertEqual(result, "No existing house numbers")
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.txt")
+            self.assertEqual(result, "No existing house numbers")
 
     def test_view_result_txt_no_ref_housenumbers(self) -> None:
         """Tests the txt output, no ref housenumbers case."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_ref_housenumbers_path()
-            real_exists = os.path.exists
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_ref_housenumbers_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.txt")
-                self.assertEqual(result, "No reference house numbers")
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            result = self.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.txt")
+            self.assertEqual(result, "No reference house numbers")
 
     def test_view_turbo_well_formed(self) -> None:
         """Tests if the view-turbo output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/missing-housenumbers/gazdagret/view-turbo")
+        root = self.get_dom_for_path("/missing-housenumbers/gazdagret/view-turbo")
         results = root.findall("body/pre")
         self.assertEqual(len(results), 1)
 
     def test_view_query_well_formed(self) -> None:
         """Tests if the view-query output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/missing-housenumbers/gazdagret/view-query")
+        root = self.get_dom_for_path("/missing-housenumbers/gazdagret/view-query")
         results = root.findall("body/pre")
         self.assertEqual(len(results), 1)
 
     def test_update_result_link(self) -> None:
         """Tests if the update-result output links back to the correct page."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/missing-housenumbers/gazdagret/update-result")
-        conf = mock_make_config()
+        root = self.get_dom_for_path("/missing-housenumbers/gazdagret/update-result")
+        conf = test_config.make_test_config()
         prefix = conf.get_uri_prefix()
         results = root.findall("body/a[@href='" + prefix + "/missing-housenumbers/gazdagret/view-result']")
         self.assertEqual(len(results), 1)
@@ -445,19 +413,17 @@ class TestStreetHousenumbers(TestWsgi):
     """Tests handle_street_housenumbers()."""
     def test_view_result_update_result_link(self) -> None:
         """Tests view result: the update-result link."""
-        conf = mock_make_config()
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/street-housenumbers/gazdagret/view-result")
-            uri = conf.get_uri_prefix() + "/missing-housenumbers/gazdagret/view-result"
-            results = root.findall("body/div[@id='toolbar']/a[@href='" + uri + "']")
-            self.assertTrue(results)
+        conf = test_config.make_test_config()
+        root = self.get_dom_for_path("/street-housenumbers/gazdagret/view-result")
+        uri = conf.get_uri_prefix() + "/missing-housenumbers/gazdagret/view-result"
+        results = root.findall("body/div[@id='toolbar']/a[@href='" + uri + "']")
+        self.assertTrue(results)
 
     def test_view_query_well_formed(self) -> None:
         """Tests if the view-query output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/street-housenumbers/gazdagret/view-query")
-            results = root.findall("body/pre")
-            self.assertEqual(len(results), 1)
+        root = self.get_dom_for_path("/street-housenumbers/gazdagret/view-query")
+        results = root.findall("body/pre")
+        self.assertEqual(len(results), 1)
 
     def test_update_result_well_formed(self) -> None:
         """Tests if the update-result output is well-formed."""
@@ -472,16 +438,15 @@ class TestStreetHousenumbers(TestWsgi):
         result_from_overpass += "1\tOnly In OSM utca\t1\t\t\t\t\t\t\t\t\tnode\n"
         result_from_overpass += "1\tSecond Only In OSM utca\t1\t\t\t\t\t\t\t\t\tnode\n"
 
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
-                buf = io.BytesIO()
-                buf.write(result_from_overpass.encode('utf-8'))
-                buf.seek(0)
-                return buf
-            with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-                root = self.get_dom_for_path("/street-housenumbers/gazdagret/update-result")
-                results = root.findall("body")
-                self.assertEqual(len(results), 1)
+        def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
+            buf = io.BytesIO()
+            buf.write(result_from_overpass.encode('utf-8'))
+            buf.seek(0)
+            return buf
+        with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
+            root = self.get_dom_for_path("/street-housenumbers/gazdagret/update-result")
+            results = root.findall("body")
+            self.assertEqual(len(results), 1)
 
     def test_update_result_error_well_formed(self) -> None:
         """Tests if the update-result output on error is well-formed."""
@@ -489,36 +454,33 @@ class TestStreetHousenumbers(TestWsgi):
         def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
             raise urllib.error.HTTPError(url="", code=0, msg="", hdrs={}, fp=io.BytesIO())
 
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-                root = self.get_dom_for_path("/street-housenumbers/gazdagret/update-result")
-                results = root.findall("body/div[@id='overpass-error']")
-                self.assertTrue(results)
+        with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
+            root = self.get_dom_for_path("/street-housenumbers/gazdagret/update-result")
+            results = root.findall("body/div[@id='overpass-error']")
+            self.assertTrue(results)
 
     def test_no_osm_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm streets case."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_osm_housenumbers_path()
-            real_exists = os.path.exists
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_housenumbers_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                root = self.get_dom_for_path("/street-housenumbers/gazdagret/view-result")
-                results = root.findall("body/div[@id='no-osm-housenumbers']")
-                self.assertEqual(len(results), 1)
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/street-housenumbers/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-osm-housenumbers']")
+            self.assertEqual(len(results), 1)
 
 
 class TestMissingStreets(TestWsgi):
     """Tests the missing streets page."""
     def test_well_formed(self) -> None:
         """Tests if the output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/missing-streets/gazdagret/view-result")
+        root = self.get_dom_for_path("/missing-streets/gazdagret/view-result")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
         # refstreets: >0 invalid osm name
@@ -530,107 +492,97 @@ class TestMissingStreets(TestWsgi):
 
     def test_well_formed_compat(self) -> None:
         """Tests if the output is well-formed (URL rewrite)."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/suspicious-relations/gazdagret/view-result")
-            results = root.findall("body/table")
-            self.assertEqual(len(results), 1)
+        root = self.get_dom_for_path("/suspicious-relations/gazdagret/view-result")
+        results = root.findall("body/table")
+        self.assertEqual(len(results), 1)
 
     def test_no_osm_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm streets case."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_osm_streets_path()
-            real_exists = os.path.exists
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_streets_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                root = self.get_dom_for_path("/missing-streets/gazdagret/view-result")
-                results = root.findall("body/div[@id='no-osm-streets']")
-                self.assertEqual(len(results), 1)
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/missing-streets/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-osm-streets']")
+            self.assertEqual(len(results), 1)
 
     def test_no_ref_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no ref streets case."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_ref_streets_path()
-            real_exists = os.path.exists
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_ref_streets_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                root = self.get_dom_for_path("/missing-streets/gazdagret/view-result")
-                results = root.findall("body/div[@id='no-ref-streets']")
-                self.assertEqual(len(results), 1)
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/missing-streets/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-ref-streets']")
+            self.assertEqual(len(results), 1)
 
     def test_view_result_txt(self) -> None:
         """Tests the txt output."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            result = self.get_txt_for_path("/missing-streets/gazdagret/view-result.txt")
+        result = self.get_txt_for_path("/missing-streets/gazdagret/view-result.txt")
         self.assertEqual(result, "Only In Ref utca\n")
 
     def test_view_result_chkl(self) -> None:
         """Tests the chkl output."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            result = self.get_txt_for_path("/missing-streets/gazdagret/view-result.chkl")
+        result = self.get_txt_for_path("/missing-streets/gazdagret/view-result.chkl")
         self.assertEqual(result, "[ ] Only In Ref utca\n")
 
     def test_view_result_txt_no_osm_streets(self) -> None:
         """Tests the txt output, no osm streets case."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_osm_streets_path()
-            real_exists = os.path.exists
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_streets_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                result = self.get_txt_for_path("/missing-streets/gazdagret/view-result.txt")
-                self.assertEqual(result, "No existing streets")
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            result = self.get_txt_for_path("/missing-streets/gazdagret/view-result.txt")
+            self.assertEqual(result, "No existing streets")
 
     def test_view_result_txt_no_ref_streets(self) -> None:
         """Tests the txt output, no ref streets case."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_ref_streets_path()
-            real_exists = os.path.exists
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_ref_streets_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                result = self.get_txt_for_path("/missing-streets/gazdagret/view-result.txt")
-                self.assertEqual(result, "No reference streets")
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            result = self.get_txt_for_path("/missing-streets/gazdagret/view-result.txt")
+            self.assertEqual(result, "No reference streets")
 
     def test_view_query_well_formed(self) -> None:
         """Tests if the view-query output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/missing-streets/gazdagret/view-query")
+        root = self.get_dom_for_path("/missing-streets/gazdagret/view-query")
         results = root.findall("body/pre")
         self.assertEqual(len(results), 1)
 
     def test_update_result(self) -> None:
         """Tests the update-result output."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/missing-streets/gazdagret/update-result")
+        root = self.get_dom_for_path("/missing-streets/gazdagret/update-result")
         results = root.findall("body/div[@id='update-success']")
         self.assertEqual(len(results), 1)
 
     def test_view_turbo(self) -> None:
         """Tests the view-turbo output."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/missing-streets/gazdagret/view-turbo")
+        root = self.get_dom_for_path("/missing-streets/gazdagret/view-turbo")
         results = root.findall("body/pre")
         self.assertEqual(len(results), 1)
         self.assertIn("OSM Name 1", cast(Container[Any], results[0].text))
@@ -642,8 +594,7 @@ class TestMain(TestWsgi):
     """Tests handle_main()."""
     def test_well_formed(self) -> None:
         """Tests if the output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/")
+        root = self.get_dom_for_path("/")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
 
@@ -652,50 +603,44 @@ class TestMain(TestWsgi):
         environ = {
             "PATH_INFO": ""
         }
-        conf = mock_make_config()
-        relations = areas.Relations(mock_make_config().get_workdir())
+        conf = test_config.make_test_config()
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         ret = webframe.get_request_uri(environ, conf, relations)
         self.assertEqual(ret, "")
 
     def test_filter_for_incomplete_well_formed(self) -> None:
         """Tests if the /osm/filter-for/incomplete output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/filter-for/incomplete")
+        root = self.get_dom_for_path("/filter-for/incomplete")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
 
     def test_filter_for_everything_well_formed(self) -> None:
         """Tests if the /osm/filter-for/everything output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/filter-for/everything")
+        root = self.get_dom_for_path("/filter-for/everything")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
 
     def test_filter_for_refcounty_well_formed(self) -> None:
         """Tests if the /osm/filter-for/refcounty output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/filter-for/refcounty/01/whole-county")
+        root = self.get_dom_for_path("/filter-for/refcounty/01/whole-county")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
 
     def test_filter_for_refcounty_no_refsettlement(self) -> None:
         """Tests if the /osm/filter-for/refcounty output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/filter-for/refcounty/67/whole-county")
+        root = self.get_dom_for_path("/filter-for/refcounty/67/whole-county")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
 
     def test_filter_for_refcounty_refsettlement_well_formed(self) -> None:
         """Tests if the /osm/filter-for/refcounty/<value>/refsettlement/<value> output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/filter-for/refcounty/01/refsettlement/011")
+        root = self.get_dom_for_path("/filter-for/refcounty/01/refsettlement/011")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
 
     def test_filter_for_relations(self) -> None:
         """Tests if the /osm/filter-for/relations/... output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/filter-for/relations/44,45")
+        root = self.get_dom_for_path("/filter-for/relations/44,45")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
         table = results[0]
@@ -704,14 +649,10 @@ class TestMain(TestWsgi):
 
     def test_custom_locale(self) -> None:
         """Tests the main page with a custom locale."""
-        def make_config() -> config.Config:
-            conf = config.Config("tests")
-            conf.set_value("locale", "en_US.UTF-8")
-            return conf
-        with unittest.mock.patch("config.make_config", make_config):
-            root = self.get_dom_for_path("")
-            results = root.findall("body/table")
-            self.assertEqual(len(results), 1)
+        self.conf.set_value("locale", "en_US.UTF-8")
+        root = self.get_dom_for_path("")
+        results = root.findall("body/table")
+        self.assertEqual(len(results), 1)
 
     def test_failing_locale(self) -> None:
         """Tests the main page with a failing locale."""
@@ -720,13 +661,13 @@ class TestMain(TestWsgi):
             raise locale.Error()
 
         with unittest.mock.patch('locale.setlocale', mock_setlocale):
-            with unittest.mock.patch("config.make_config", mock_make_config):
-                root = self.get_dom_for_path("")
+            root = self.get_dom_for_path("")
             results = root.findall("body/table")
             self.assertEqual(len(results), 1)
 
     def test_application_exception(self) -> None:
         """Tests application(), exception catching case."""
+        conf = config.Config("tests")
         environ = {
             "PATH_INFO": "/"
         }
@@ -736,14 +677,18 @@ class TestMain(TestWsgi):
             header_dict = dict(response_headers)
             self.assertEqual(header_dict["Content-type"], "text/html; charset=utf-8")
 
-        def mock_application(environ: Dict[str, Any], start_response: 'StartResponse') -> Iterable[bytes]:
+        def mock_application(
+            environ: Dict[str, Any],
+            start_response: 'StartResponse',
+            conf: config.Config
+        ) -> Iterable[bytes]:
             int("a")
             # Never reached.
-            return wsgi.our_application(environ, start_response)
+            return wsgi.our_application(environ, start_response, conf)
 
         with unittest.mock.patch('wsgi.our_application', mock_application):
             callback = cast('StartResponse', start_response)
-            output_iterable = wsgi.application(environ, callback)
+            output_iterable = wsgi.application(environ, callback, conf)
             output_list = cast(List[bytes], output_iterable)
             self.assertTrue(output_list)
             output = output_list[0].decode('utf-8')
@@ -753,23 +698,31 @@ class TestMain(TestWsgi):
         """Tests main()."""
         serving = False
 
+        def start_response(_status: str, _response_headers: List[Tuple[str, str]]) -> None:
+            pass
+
         class MockServer:
             """Mock WSGI server."""
+            def __init__(self, app: Any) -> None:
+                self.app = app
+
             # pylint: disable=no-self-use
             def serve_forever(self) -> None:
                 """Handles one request at a time until shutdown."""
+                self.app({}, start_response)
                 nonlocal serving
                 serving = True
 
-        def mock_make_server(_host: str, _port: int, _app: Any) -> MockServer:
+        def mock_make_server(_host: str, _port: int, app: Any) -> MockServer:
             """Creates a new mock WSGI server."""
-            return MockServer()
+            return MockServer(app)
 
+        conf = config.Config("tests")
         with unittest.mock.patch('wsgiref.simple_server.make_server', mock_make_server):
             # Capture standard output.
             buf = io.StringIO()
             with unittest.mock.patch('sys.stdout', buf):
-                wsgi.main()
+                wsgi.main(conf)
         self.assertTrue(serving)
 
 
@@ -821,51 +774,46 @@ class TestWebhooks(TestWsgi):
         def mock_subprocess_run(_args: List[str], _check: bool) -> None:
             nonlocal invoked
 
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            with unittest.mock.patch('subprocess.run', mock_subprocess_run):
-                wsgi.handle_github_webhook(environ)
-            self.assertFalse(invoked)
+        with unittest.mock.patch('subprocess.run', mock_subprocess_run):
+            wsgi.handle_github_webhook(environ)
+        self.assertFalse(invoked)
 
     def test_route(self) -> None:
         """Tests the /osm/webhooks/github -> handle_github_webhook() routing."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            mock_called = False
+        mock_called = False
 
-            def mock_handler(_environ: Dict[str, BinaryIO]) -> yattag.doc.Doc:
-                nonlocal mock_called
-                mock_called = True
-                return util.html_escape("")
+        def mock_handler(_environ: Dict[str, BinaryIO]) -> yattag.doc.Doc:
+            nonlocal mock_called
+            mock_called = True
+            return util.html_escape("")
 
-            with unittest.mock.patch("wsgi.handle_github_webhook", mock_handler):
-                self.get_dom_for_path("/webhooks/github")
-            self.assertTrue(mock_called)
+        with unittest.mock.patch("wsgi.handle_github_webhook", mock_handler):
+            self.get_dom_for_path("/webhooks/github")
+        self.assertTrue(mock_called)
 
 
 class TestStatic(TestWsgi):
     """Tests /osm/static/."""
     def test_css(self) -> None:
         """Tests /osm/static/, css case."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            result = self.get_css_for_path("/static/osm.min.css")
-            # Starts with a JS comment.
-            self.assertTrue(result.endswith("}"))
+        result = self.get_css_for_path("/static/osm.min.css")
+        # Starts with a JS comment.
+        self.assertTrue(result.endswith("}"))
 
     def test_robots(self) -> None:
         """Tests robots.txt."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            result = self.get_txt_for_path("/robots.txt")
-            self.assertEqual(result, "User-agent: *\n")
+        result = self.get_txt_for_path("/robots.txt")
+        self.assertEqual(result, "User-agent: *\n")
 
 
 class TestStats(TestWsgi):
     """Tests handle_stats()."""
     def test_well_formed(self) -> None:
         """Tests if the output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/housenumber-stats/hungary/")
-            results = root.findall("body/h2")
-            # 8 chart types + note
-            self.assertEqual(len(results), 9)
+        root = self.get_dom_for_path("/housenumber-stats/hungary/")
+        results = root.findall("body/h2")
+        # 8 chart types + note
+        self.assertEqual(len(results), 9)
 
 
 def mock_strftime(_fmt: str, _tuple: Optional[Any] = None) -> str:
@@ -877,25 +825,23 @@ class TestStatsCityProgress(TestWsgi):
     """Tests handle_stats_cityprogress()."""
     def test_well_formed(self) -> None:
         """Tests if the output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            with unittest.mock.patch('time.strftime', mock_strftime):
-                root = self.get_dom_for_path("/housenumber-stats/hungary/cityprogress")
-                results = root.findall("body/table")
-                self.assertEqual(len(results), 1)
+        with unittest.mock.patch('time.strftime', mock_strftime):
+            root = self.get_dom_for_path("/housenumber-stats/hungary/cityprogress")
+            results = root.findall("body/table")
+            self.assertEqual(len(results), 1)
 
 
 class TestInvalidRefstreets(TestWsgi):
     """Tests handle_invalid_refstreets()."""
     def test_well_formed(self) -> None:
         """Tests if the output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/housenumber-stats/hungary/invalid-relations")
+        root = self.get_dom_for_path("/housenumber-stats/hungary/invalid-relations")
         results = root.findall("body/h1/a")
         self.assertNotEqual(results, [])
 
     def test_no_osm_sreets(self) -> None:
         """Tests error handling when osm street list is missing for a relation."""
-        relations = areas.Relations(mock_make_config().get_workdir())
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_streets_path()
         real_exists = os.path.exists
@@ -906,8 +852,7 @@ class TestInvalidRefstreets(TestWsgi):
             return real_exists(path)
 
         with unittest.mock.patch('os.path.exists', mock_exists):
-            with unittest.mock.patch("config.make_config", mock_make_config):
-                root = self.get_dom_for_path("/housenumber-stats/hungary/invalid-relations")
+            root = self.get_dom_for_path("/housenumber-stats/hungary/invalid-relations")
             results = root.findall("body")
             self.assertNotEqual(results, [])
 
@@ -916,21 +861,19 @@ class TestNotFound(TestWsgi):
     """Tests the not-found page."""
     def test_well_formed(self) -> None:
         """Tests if the output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/asdf", absolute=True, expected_status="404 Not Found")
-            results = root.findall("body/h1")
-            self.assertNotEqual(results, [])
+        root = self.get_dom_for_path("/asdf", absolute=True, expected_status="404 Not Found")
+        results = root.findall("body/h1")
+        self.assertNotEqual(results, [])
 
 
 class TestCompress(TestWsgi):
     """Tests gzip compress case."""
     def test_well_formed(self) -> None:
         """Tests if the output is well-formed."""
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            self.gzip_compress = True
-            root = self.get_dom_for_path("/")
-            results = root.findall("body/table")
-            self.assertEqual(len(results), 1)
+        self.gzip_compress = True
+        root = self.get_dom_for_path("/")
+        results = root.findall("body/table")
+        self.assertEqual(len(results), 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_wsgi_additional.py
+++ b/tests/test_wsgi_additional.py
@@ -12,6 +12,7 @@ import unittest.mock
 
 import yattag
 
+import test_config
 import test_wsgi
 
 import areas
@@ -23,181 +24,145 @@ class TestStreets(test_wsgi.TestWsgi):
     """Tests additional streets."""
     def test_view_result_txt(self) -> None:
         """Tests the txt output."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.txt")
-            self.assertEqual(result, "Only In OSM utca\n")
+        result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.txt")
+        self.assertEqual(result, "Only In OSM utca\n")
 
     def test_view_result_chkl(self) -> None:
         """Tests the chkl output."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.chkl")
-            self.assertEqual(result, "[ ] Only In OSM utca\n")
+        result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.chkl")
+        self.assertEqual(result, "[ ] Only In OSM utca\n")
 
     def test_view_result_txt_no_osm_streets(self) -> None:
         """Tests the txt output, no osm streets case."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            conf = mock_make_config()
-            relations = areas.Relations(conf.get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_osm_streets_path()
-            real_exists = os.path.exists
+        conf = test_config.make_test_config()
+        relations = areas.Relations(conf.get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_streets_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.txt")
-                self.assertEqual(result, "No existing streets")
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.txt")
+            self.assertEqual(result, "No existing streets")
 
     def test_view_result_txt_no_ref_streets(self) -> None:
         """Tests the txt output, no ref streets case."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            conf = mock_make_config()
-            relations = areas.Relations(conf.get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_ref_streets_path()
-            real_exists = os.path.exists
+        conf = test_config.make_test_config()
+        relations = areas.Relations(conf.get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_ref_streets_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.txt")
-                self.assertEqual(result, "No reference streets")
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.txt")
+            self.assertEqual(result, "No reference streets")
 
     def test_view_turbo_well_formed(self) -> None:
         """Tests if the view-turbo output is well-formed."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/additional-streets/gazdagret/view-turbo")
-            results = root.findall("body/pre")
-            self.assertEqual(len(results), 1)
+        root = self.get_dom_for_path("/additional-streets/gazdagret/view-turbo")
+        results = root.findall("body/pre")
+        self.assertEqual(len(results), 1)
 
 
 class TestHandleMainHousenrAdditionalCount(test_wsgi.TestWsgi):
     """Tests handle_main_housenr_additional_count()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            conf = mock_make_config()
-            relations = areas.Relations(conf.get_workdir())
-            relation = relations.get_relation("budafok")
-            actual = wsgi.handle_main_housenr_additional_count(conf, relation)
-            self.assertIn("42 house numbers", actual.getvalue())
+        conf = test_config.make_test_config()
+        relations = areas.Relations(conf.get_workdir())
+        relation = relations.get_relation("budafok")
+        actual = wsgi.handle_main_housenr_additional_count(conf, relation)
+        self.assertIn("42 house numbers", actual.getvalue())
 
     def test_no_count_file(self) -> None:
         """Tests what happens when the count file is not there."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            conf = mock_make_config()
-            relations = areas.Relations(conf.get_workdir())
-            relation = relations.get_relation("budafok")
-            hide_path = relation.get_files().get_housenumbers_additional_count_path()
-            real_exists = os.path.exists
+        conf = test_config.make_test_config()
+        relations = areas.Relations(conf.get_workdir())
+        relation = relations.get_relation("budafok")
+        hide_path = relation.get_files().get_housenumbers_additional_count_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                actual = wsgi.handle_main_housenr_additional_count(conf, relation)
-            self.assertNotIn("42 housenumbers", actual.getvalue())
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            actual = wsgi.handle_main_housenr_additional_count(conf, relation)
+        self.assertNotIn("42 housenumbers", actual.getvalue())
 
 
 class TestAdditionalHousenumbers(test_wsgi.TestWsgi):
     """Tests the additional house numbers page."""
     def test_well_formed(self) -> None:
         """Tests if the output is well-formed."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
-            results = root.findall("body/table")
-            self.assertEqual(len(results), 1)
+        root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
+        results = root.findall("body/table")
+        self.assertEqual(len(results), 1)
 
     def test_no_osm_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm streets case."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            conf = mock_make_config()
-            relations = areas.Relations(conf.get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_osm_streets_path()
-            real_exists = os.path.exists
+        conf = test_config.make_test_config()
+        relations = areas.Relations(conf.get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_streets_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
-                results = root.findall("body/div[@id='no-osm-streets']")
-                self.assertEqual(len(results), 1)
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-osm-streets']")
+            self.assertEqual(len(results), 1)
 
     def test_no_osm_housenumbers_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm housenumbers case."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            conf = mock_make_config()
-            relations = areas.Relations(conf.get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_osm_housenumbers_path()
-            real_exists = os.path.exists
+        conf = test_config.make_test_config()
+        relations = areas.Relations(conf.get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_housenumbers_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
-                results = root.findall("body/div[@id='no-osm-housenumbers']")
-                self.assertEqual(len(results), 1)
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-osm-housenumbers']")
+            self.assertEqual(len(results), 1)
 
     def test_no_ref_housenumbers_well_formed(self) -> None:
         """Tests if the output is well-formed, no ref housenumbers case."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            conf = mock_make_config()
-            relations = areas.Relations(conf.get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_ref_housenumbers_path()
-            real_exists = os.path.exists
+        conf = test_config.make_test_config()
+        relations = areas.Relations(conf.get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_ref_housenumbers_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
-                results = root.findall("body/div[@id='no-ref-housenumbers']")
-                self.assertEqual(len(results), 1)
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-ref-housenumbers']")
+            self.assertEqual(len(results), 1)
 
 
 class TestAdditionalStreets(test_wsgi.TestWsgi):
     """Tests the additional streets page."""
     def test_well_formed(self) -> None:
         """Tests if the output is well-formed."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_dom_for_path("/additional-streets/gazdagret/view-result")
+        root = self.get_dom_for_path("/additional-streets/gazdagret/view-result")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
         # refstreets: >0 invalid osm name
@@ -209,57 +174,48 @@ class TestAdditionalStreets(test_wsgi.TestWsgi):
 
     def test_street_from_housenr_well_formed(self) -> None:
         """Tests if the output is well-formed when the street name comes from a housenr."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            def mock_check_existing_relation(
-                _conf: config.Config,
-                _relations: areas.Relations,
-                _request_uri: str
-            ) -> yattag.doc.Doc:
-                return yattag.doc.Doc()
-            with unittest.mock.patch('webframe.check_existing_relation', mock_check_existing_relation):
-                root = self.get_dom_for_path("/additional-streets/gh611/view-result")
-            results = root.findall("body/table")
-            self.assertEqual(len(results), 1)
+        def mock_check_existing_relation(
+            _conf: config.Config,
+            _relations: areas.Relations,
+            _request_uri: str
+        ) -> yattag.doc.Doc:
+            return yattag.doc.Doc()
+        with unittest.mock.patch('webframe.check_existing_relation', mock_check_existing_relation):
+            root = self.get_dom_for_path("/additional-streets/gh611/view-result")
+        results = root.findall("body/table")
+        self.assertEqual(len(results), 1)
 
     def test_no_osm_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm streets case."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_osm_streets_path()
-            real_exists = os.path.exists
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_osm_streets_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                root = self.get_dom_for_path("/additional-streets/gazdagret/view-result")
-                results = root.findall("body/div[@id='no-osm-streets']")
-                self.assertEqual(len(results), 1)
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/additional-streets/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-osm-streets']")
+            self.assertEqual(len(results), 1)
 
     def test_no_ref_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no ref streets case."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            relations = areas.Relations(mock_make_config().get_workdir())
-            relation = relations.get_relation("gazdagret")
-            hide_path = relation.get_files().get_ref_streets_path()
-            real_exists = os.path.exists
+        relations = areas.Relations(test_config.make_test_config().get_workdir())
+        relation = relations.get_relation("gazdagret")
+        hide_path = relation.get_files().get_ref_streets_path()
+        real_exists = os.path.exists
 
-            def mock_exists(path: str) -> bool:
-                if path == hide_path:
-                    return False
-                return real_exists(path)
-            with unittest.mock.patch('os.path.exists', mock_exists):
-                root = self.get_dom_for_path("/additional-streets/gazdagret/view-result")
-                results = root.findall("body/div[@id='no-ref-streets']")
-                self.assertEqual(len(results), 1)
+        def mock_exists(path: str) -> bool:
+            if path == hide_path:
+                return False
+            return real_exists(path)
+        with unittest.mock.patch('os.path.exists', mock_exists):
+            root = self.get_dom_for_path("/additional-streets/gazdagret/view-result")
+            results = root.findall("body/div[@id='no-ref-streets']")
+            self.assertEqual(len(results), 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_wsgi_json.py
+++ b/tests/test_wsgi_json.py
@@ -46,7 +46,7 @@ class TestWsgiJson(test_config.TestCase):
             "PATH_INFO": prefix + path
         }
         callback = cast('StartResponse', start_response)
-        output_iterable = wsgi.application(environ, callback)
+        output_iterable = wsgi.application(environ, callback, conf)
         output_list = cast(List[str], output_iterable)
         self.assertTrue(output_list)
         output = output_list[0]
@@ -57,41 +57,34 @@ class TestJsonStreets(TestWsgiJson):
     """Tests streets_update_result_json()."""
     def test_update_result_json(self) -> None:
         """Tests if the update-result json output is well-formed."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        conf = mock_make_config()
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            result_from_overpass = "@id\tname\n1\tTűzkő utca\n2\tTörökugrató utca\n3\tOSM Name 1\n4\tHamzsabégi út\n"
+        conf = test_config.make_test_config()
+        result_from_overpass = "@id\tname\n1\tTűzkő utca\n2\tTörökugrató utca\n3\tOSM Name 1\n4\tHamzsabégi út\n"
 
-            def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
-                buf = io.BytesIO()
-                buf.write(result_from_overpass.encode('utf-8'))
-                buf.seek(0)
-                return buf
-            with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-                root = self.get_json_for_path(conf, "/streets/gazdagret/update-result.json")
-                self.assertEqual(root["error"], "")
+        def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
+            buf = io.BytesIO()
+            buf.write(result_from_overpass.encode('utf-8'))
+            buf.seek(0)
+            return buf
+        with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
+            root = self.get_json_for_path(conf, "/streets/gazdagret/update-result.json")
+            self.assertEqual(root["error"], "")
 
     def test_update_result_json_error(self) -> None:
         """Tests if the update-result json output on error is well-formed."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        conf = mock_make_config()
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
-                raise urllib.error.HTTPError(url="", code=0, msg="", hdrs={}, fp=io.BytesIO())
-            with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-                root = self.get_json_for_path(conf, "/streets/gazdagret/update-result.json")
-                self.assertEqual(root["error"], "HTTP Error 0: ")
+        conf = test_config.make_test_config()
+
+        def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
+            raise urllib.error.HTTPError(url="", code=0, msg="", hdrs={}, fp=io.BytesIO())
+        with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
+            root = self.get_json_for_path(conf, "/streets/gazdagret/update-result.json")
+            self.assertEqual(root["error"], "HTTP Error 0: ")
 
 
 class TestJsonStreetHousenumbers(TestWsgiJson):
     """Tests street_housenumbers_update_result_json()."""
     def test_update_result_json(self) -> None:
         """Tests if the update-result output is well-formed."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        conf = mock_make_config()
+        conf = test_config.make_test_config()
         result_from_overpass = "@id\taddr:street\taddr:housenumber\taddr:postcode\taddr:housename\t"
         result_from_overpass += "addr:conscriptionnumber\taddr:flats\taddr:floor\taddr:door\taddr:unit\tname\t@type\n\n"
         result_from_overpass += "1\tTörökugrató utca\t1\t\t\t\t\t\t\t\t\tnode\n"
@@ -109,45 +102,36 @@ class TestJsonStreetHousenumbers(TestWsgiJson):
             buf.seek(0)
             return buf
         with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-            with unittest.mock.patch("config.make_config", mock_make_config):
-                root = self.get_json_for_path(conf, "/street-housenumbers/gazdagret/update-result.json")
+            root = self.get_json_for_path(conf, "/street-housenumbers/gazdagret/update-result.json")
             self.assertEqual(root["error"], "")
 
     def test_update_result_error_json(self) -> None:
         """Tests if the update-result output on error is well-formed."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        conf = mock_make_config()
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
-                raise urllib.error.HTTPError(url="", code=0, msg="", hdrs={}, fp=io.BytesIO())
-            with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
-                root = self.get_json_for_path(conf, "/street-housenumbers/gazdagret/update-result.json")
-                self.assertEqual(root["error"], "HTTP Error 0: ")
+        conf = test_config.make_test_config()
+
+        def mock_urlopen(_url: str, _data: Optional[bytes] = None) -> BinaryIO:
+            raise urllib.error.HTTPError(url="", code=0, msg="", hdrs={}, fp=io.BytesIO())
+        with unittest.mock.patch('urllib.request.urlopen', mock_urlopen):
+            root = self.get_json_for_path(conf, "/street-housenumbers/gazdagret/update-result.json")
+            self.assertEqual(root["error"], "HTTP Error 0: ")
 
 
 class TestJsonMissingHousenumbers(TestWsgiJson):
     """Tests missing_housenumbers_update_result_json()."""
     def test_update_result_json(self) -> None:
         """Tests if the update-result json output is well-formed."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        conf = mock_make_config()
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_json_for_path(conf, "/missing-housenumbers/gazdagret/update-result.json")
-            self.assertEqual(root["error"], "")
+        conf = test_config.make_test_config()
+        root = self.get_json_for_path(conf, "/missing-housenumbers/gazdagret/update-result.json")
+        self.assertEqual(root["error"], "")
 
 
 class TestJsonMissingStreets(TestWsgiJson):
     """Tests missing_streets_update_result_json()."""
     def test_update_result_json(self) -> None:
         """Tests if the update-result json output is well-formed."""
-        def mock_make_config() -> config.Config:
-            return config.Config("tests")
-        conf = mock_make_config()
-        with unittest.mock.patch("config.make_config", mock_make_config):
-            root = self.get_json_for_path(conf, "/missing-streets/gazdagret/update-result.json")
-            self.assertEqual(root["error"], "")
+        conf = test_config.make_test_config()
+        root = self.get_json_for_path(conf, "/missing-streets/gazdagret/update-result.json")
+        self.assertEqual(root["error"], "")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We pass config around anyway, and this saves a lot of code.

Change-Id: I699cdd49c053f0a023693bb6dffcdaa197cf3f19
