### PR TITLE
Rework to avoid no longer needed test_config.TestCase

### DIFF
--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -22,7 +22,7 @@ import ranges
 import util
 
 
-class TestRelationGetOsmStreets(test_config.TestCase):
+class TestRelationGetOsmStreets(unittest.TestCase):
     """Tests Relation.get_osm_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -59,7 +59,7 @@ class TestRelationGetOsmStreets(test_config.TestCase):
         self.assertIn("Barcfa dűlő", streets)
 
 
-class TestRelationGetOsmStreetsQuery(test_config.TestCase):
+class TestRelationGetOsmStreetsQuery(unittest.TestCase):
     """Tests Relation.get_osm_streets_query()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -71,7 +71,7 @@ class TestRelationGetOsmStreetsQuery(test_config.TestCase):
         self.assertEqual(ret, 'aaa 2713748 bbb 3602713748 ccc\n')
 
 
-class TestRelationGetOsmHousenumbersQuery(test_config.TestCase):
+class TestRelationGetOsmHousenumbersQuery(unittest.TestCase):
     """Tests Relation.get_osm_housenumbers_query()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -82,7 +82,7 @@ class TestRelationGetOsmHousenumbersQuery(test_config.TestCase):
         self.assertEqual(ret, 'housenr aaa 2713748 bbb 3602713748 ccc\n')
 
 
-class TestRelationFilesWriteOsmStreets(test_config.TestCase):
+class TestRelationFilesWriteOsmStreets(unittest.TestCase):
     """Tests RelationFiles.write_osm_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -96,7 +96,7 @@ class TestRelationFilesWriteOsmStreets(test_config.TestCase):
         self.assertEqual(actual, expected)
 
 
-class TestRelationFilesWriteOsmHousenumbers(test_config.TestCase):
+class TestRelationFilesWriteOsmHousenumbers(unittest.TestCase):
     """Tests RelationFiles.write_osm_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -119,7 +119,7 @@ class TestRelationFilesWriteOsmHousenumbers(test_config.TestCase):
         self.assertEqual(actual, expected)
 
 
-class TestRelationGetStreetRanges(test_config.TestCase):
+class TestRelationGetStreetRanges(unittest.TestCase):
     """Tests Relation.get_street_ranges()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -150,7 +150,7 @@ class TestRelationGetStreetRanges(test_config.TestCase):
         self.assertEqual(filters, {})
 
 
-class TestRelationGetRefStreetFromOsmStreet(test_config.TestCase):
+class TestRelationGetRefStreetFromOsmStreet(unittest.TestCase):
     """Tests Relation.get_ref_street_from_osm_street()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -225,7 +225,7 @@ class TestRelationGetRefStreetFromOsmStreet(test_config.TestCase):
         self.assertEqual("Csiki-hegyek utca", street)
 
 
-class TestNormalize(test_config.TestCase):
+class TestNormalize(unittest.TestCase):
     """
     Tests normalize().
 
@@ -362,7 +362,7 @@ class TestNormalize(test_config.TestCase):
         self.assertEqual([i.get_number() for i in house_numbers], ["2", "6"])
 
 
-class TestRelationGetRefStreets(test_config.TestCase):
+class TestRelationGetRefStreets(unittest.TestCase):
     """Tests Relation.GetRefStreets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -378,7 +378,7 @@ class TestRelationGetRefStreets(test_config.TestCase):
                                          'Tűzkő utca'])
 
 
-class TestRelationGetOsmHouseNumbers(test_config.TestCase):
+class TestRelationGetOsmHouseNumbers(unittest.TestCase):
     """Tests Relation.get_osm_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -399,7 +399,7 @@ class TestRelationGetOsmHouseNumbers(test_config.TestCase):
         self.assertEqual([i.get_number() for i in house_numbers], ["52"])
 
 
-class TestRelationGetMissingHousenumbers(test_config.TestCase):
+class TestRelationGetMissingHousenumbers(unittest.TestCase):
     """Tests Relation.get_missing_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -543,7 +543,7 @@ class TestRelationGetMissingHousenumbers(test_config.TestCase):
         self.assertEqual(housenumber_range_names, expected)
 
 
-class TestRelationGetMissingStreets(test_config.TestCase):
+class TestRelationGetMissingStreets(unittest.TestCase):
     """Tests Relation.get_missing_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -558,7 +558,7 @@ class TestRelationGetMissingStreets(test_config.TestCase):
         self.assertEqual(in_both, ['Hamzsabégi út', 'Ref Name 1', 'Törökugrató utca', 'Tűzkő utca'])
 
 
-class TestRelationGetAdditionalStreets(test_config.TestCase):
+class TestRelationGetAdditionalStreets(unittest.TestCase):
     """Tests Relation.get_additional_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -581,7 +581,7 @@ class TestRelationGetAdditionalStreets(test_config.TestCase):
         self.assertEqual(relation.get_config().get_osm_street_filters(), [])
 
 
-class TestRelationGetAdditionalHousenumbers(test_config.TestCase):
+class TestRelationGetAdditionalHousenumbers(unittest.TestCase):
     """Tests Relation.get_additional_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -605,7 +605,7 @@ def table_doc_to_string(table: List[List[yattag.doc.Doc]]) -> List[List[str]]:
     return table_content
 
 
-class TestRelationWriteMissingHouseNumbers(test_config.TestCase):
+class TestRelationWriteMissingHouseNumbers(unittest.TestCase):
     """Tests Relation.write_missing_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -666,7 +666,7 @@ class TestRelationWriteMissingHouseNumbers(test_config.TestCase):
                                         ['A utca', '1', '2-10']])
 
 
-class TestRelationWriteMissingStreets(test_config.TestCase):
+class TestRelationWriteMissingStreets(unittest.TestCase):
     """Tests Relation.write_missing_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -694,7 +694,7 @@ class TestRelationWriteMissingStreets(test_config.TestCase):
         os.unlink(os.path.join(relations.get_workdir(), "empty-streets.percent"))
 
 
-class TestRelationBuildRefHousenumbers(test_config.TestCase):
+class TestRelationBuildRefHousenumbers(unittest.TestCase):
     """Tests Relation.build_ref_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -729,7 +729,7 @@ class TestRelationBuildRefHousenumbers(test_config.TestCase):
         self.assertEqual(ret, [])
 
 
-class TestRelationBuildRefStreets(test_config.TestCase):
+class TestRelationBuildRefStreets(unittest.TestCase):
     """Tests Relation.build_ref_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -748,7 +748,7 @@ class TestRelationBuildRefStreets(test_config.TestCase):
                                'Hamzsabégi út'])
 
 
-class TestRelationWriteRefHousenumbers(test_config.TestCase):
+class TestRelationWriteRefHousenumbers(unittest.TestCase):
     """Tests Relation.write_ref_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -788,7 +788,7 @@ class TestRelationWriteRefHousenumbers(test_config.TestCase):
             self.fail("write_ref_housenumbers() raised KeyError unexpectedly")
 
 
-class TestRelationWriteRefStreets(test_config.TestCase):
+class TestRelationWriteRefStreets(unittest.TestCase):
     """Tests Relation.WriteRefStreets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -803,7 +803,7 @@ class TestRelationWriteRefStreets(test_config.TestCase):
         self.assertEqual(actual, expected)
 
 
-class TestRelations(test_config.TestCase):
+class TestRelations(unittest.TestCase):
     """Tests the Relations class."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -851,7 +851,7 @@ class TestRelations(test_config.TestCase):
         self.assertTrue("nosuchrefsettlement" in relations.get_active_names())
 
 
-class TestRelationConfigMissingStreets(test_config.TestCase):
+class TestRelationConfigMissingStreets(unittest.TestCase):
     """Tests RelationConfig.should_check_missing_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -901,7 +901,7 @@ class TestRefmegyeGetName(unittest.TestCase):
         self.assertEqual(relations.refcounty_get_name("99"), "")
 
 
-class TestRefmegyeGetReftelepulesIds(test_config.TestCase):
+class TestRefmegyeGetReftelepulesIds(unittest.TestCase):
     """Tests refcounty_get_refsettlement_ids()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -911,7 +911,7 @@ class TestRefmegyeGetReftelepulesIds(test_config.TestCase):
         self.assertEqual(relations.refcounty_get_refsettlement_ids("99"), [])
 
 
-class TestReftelepulesGetName(test_config.TestCase):
+class TestReftelepulesGetName(unittest.TestCase):
     """Tests refsettlement_get_name()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -922,7 +922,7 @@ class TestReftelepulesGetName(test_config.TestCase):
         self.assertEqual(relations.refsettlement_get_name("01", "99"), "")
 
 
-class TestRelationsGetAliases(test_config.TestCase):
+class TestRelationsGetAliases(unittest.TestCase):
     """Tests Relalations.get_aliases()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -935,7 +935,7 @@ class TestRelationsGetAliases(test_config.TestCase):
         self.assertEqual(relations.get_aliases(), expected)
 
 
-class TestRelationStreetIsEvenOdd(test_config.TestCase):
+class TestRelationStreetIsEvenOdd(unittest.TestCase):
     """Tests RelationConfig.get_street_is_even_odd()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -947,7 +947,7 @@ class TestRelationStreetIsEvenOdd(test_config.TestCase):
         self.assertTrue(relation.get_config().get_street_is_even_odd("Teszt utca"))
 
 
-class TestRelationShowRefstreet(test_config.TestCase):
+class TestRelationShowRefstreet(unittest.TestCase):
     """Tests RelationConfig.should_show_ref_street()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -957,7 +957,7 @@ class TestRelationShowRefstreet(test_config.TestCase):
         self.assertTrue(relation.should_show_ref_street("Hamzsabégi út"))
 
 
-class TestRelationIsActive(test_config.TestCase):
+class TestRelationIsActive(unittest.TestCase):
     """Tests RelationConfig.is_active()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -966,7 +966,7 @@ class TestRelationIsActive(test_config.TestCase):
         self.assertTrue(relation.get_config().is_active())
 
 
-class TestMakeTurboQueryForStreets(test_config.TestCase):
+class TestMakeTurboQueryForStreets(unittest.TestCase):
     """Tests make_turbo_query_for_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -16,7 +16,7 @@ import areas
 import cache
 
 
-class TestIsMissingHousenumbersHtmlCached(test_config.TestCase):
+class TestIsMissingHousenumbersHtmlCached(unittest.TestCase):
     """Tests is_missing_housenumbers_html_cached()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -95,7 +95,7 @@ class TestIsMissingHousenumbersHtmlCached(test_config.TestCase):
             self.assertFalse(cache.is_missing_housenumbers_html_cached(conf, relation))
 
 
-class TestGetAdditionalHousenumbersHtml(test_config.TestCase):
+class TestGetAdditionalHousenumbersHtml(unittest.TestCase):
     """Tests get_additional_housenumbers_html()."""
     def test_happy(self) -> None:
         """Tests the case when we find the result in cache."""
@@ -107,7 +107,7 @@ class TestGetAdditionalHousenumbersHtml(test_config.TestCase):
         self.assertEqual(first.getvalue(), second.getvalue())
 
 
-class TestIsMissingHousenumbersTxtCached(test_config.TestCase):
+class TestIsMissingHousenumbersTxtCached(unittest.TestCase):
     """Tests is_missing_housenumbers_txt_cached()."""
     def test_happy(self) -> None:
         """Tests the happy path."""

--- a/tests/test_cache_yamls.py
+++ b/tests/test_cache_yamls.py
@@ -17,7 +17,7 @@ import areas
 import cache_yamls
 
 
-class TestMain(test_config.TestCase):
+class TestMain(unittest.TestCase):
     """Tests main()."""
     def test_happy(self) -> None:
         """Tests the happy path."""

--- a/tests/test_cherry.py
+++ b/tests/test_cherry.py
@@ -19,7 +19,7 @@ import test_config
 import cherry
 
 
-class TestMain(test_config.TestCase):
+class TestMain(unittest.TestCase):
     """Tests main()."""
     def test_happy(self) -> None:
         """Tests the happy path."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,15 +6,9 @@
 
 """The test_config module covers the config module."""
 
-import unittest
-
 import config
 
 
 def make_test_config() -> config.Config:
     """Creates a Config instance that has its root as /tests."""
     return config.Config("tests")
-
-
-class TestCase(unittest.TestCase):
-    """Same as unittest.TestCase, but sets up get_abspath to use the test root."""

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -69,7 +69,7 @@ class TestOverpassSleep(unittest.TestCase):
                 self.assertEqual(captured_seconds, 42.0)
 
 
-class TestUpdateRefHousenumbers(test_config.TestCase):
+class TestUpdateRefHousenumbers(unittest.TestCase):
     """Tests update_ref_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -92,7 +92,7 @@ class TestUpdateRefHousenumbers(test_config.TestCase):
         self.assertFalse(os.path.exists(ujbuda_path))
 
 
-class TestUpdateRefStreets(test_config.TestCase):
+class TestUpdateRefStreets(unittest.TestCase):
     """Tests update_ref_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -116,7 +116,7 @@ class TestUpdateRefStreets(test_config.TestCase):
         self.assertFalse(os.path.exists(ujbuda_path))
 
 
-class TestUpdateMissingHousenumbers(test_config.TestCase):
+class TestUpdateMissingHousenumbers(unittest.TestCase):
     """Tests update_missing_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -139,7 +139,7 @@ class TestUpdateMissingHousenumbers(test_config.TestCase):
         self.assertFalse(os.path.exists(os.path.join(relations.get_workdir(), "ujbuda.percent")))
 
 
-class TestUpdateMissingStreets(test_config.TestCase):
+class TestUpdateMissingStreets(unittest.TestCase):
     """Tests update_missing_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -162,7 +162,7 @@ class TestUpdateMissingStreets(test_config.TestCase):
         self.assertFalse(os.path.exists(os.path.join(relations.get_workdir(), "gellerthegy-streets.percent")))
 
 
-class TestUpdateAdditionalStreets(test_config.TestCase):
+class TestUpdateAdditionalStreets(unittest.TestCase):
     """Tests update_additional_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -187,7 +187,7 @@ class TestUpdateAdditionalStreets(test_config.TestCase):
         self.assertFalse(os.path.exists(os.path.join(relations.get_workdir(), "gellerthegy-additional-streets.count")))
 
 
-class TestUpdateOsmHousenumbers(test_config.TestCase):
+class TestUpdateOsmHousenumbers(unittest.TestCase):
     """Tests update_osm_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -256,7 +256,7 @@ class TestUpdateOsmHousenumbers(test_config.TestCase):
                 self.assertEqual(actual, expected)
 
 
-class TestUpdateOsmStreets(test_config.TestCase):
+class TestUpdateOsmStreets(unittest.TestCase):
     """Tests update_osm_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -334,7 +334,7 @@ class MockDate(datetime.date):
         return cls(2020, 5, 10)
 
 
-class TestUpdateStats(test_config.TestCase):
+class TestUpdateStats(unittest.TestCase):
     """Tests update_stats()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -408,7 +408,7 @@ class TestUpdateStats(test_config.TestCase):
         self.assertFalse(mock_overpass_sleep_called)
 
 
-class TestOurMain(test_config.TestCase):
+class TestOurMain(unittest.TestCase):
     """Tests our_main()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -456,7 +456,7 @@ class TestOurMain(test_config.TestCase):
         self.assertEqual(calls, 1)
 
 
-class TestMain(test_config.TestCase):
+class TestMain(unittest.TestCase):
     """Tests main()."""
     def test_happy(self) -> None:
         """Tests the happy path."""

--- a/tests/test_get_reference_housenumbers.py
+++ b/tests/test_get_reference_housenumbers.py
@@ -9,14 +9,12 @@
 import unittest
 import unittest.mock
 
-import test_config
-
 import config
 import get_reference_housenumbers
 import util
 
 
-class TestMain(test_config.TestCase):
+class TestMain(unittest.TestCase):
     """Tests main()."""
     def test_happy(self) -> None:
         """Tests the happy path."""

--- a/tests/test_get_reference_streets.py
+++ b/tests/test_get_reference_streets.py
@@ -9,14 +9,12 @@
 import unittest
 import unittest.mock
 
-import test_config
-
 import config
 import get_reference_streets
 import util
 
 
-class TestMain(test_config.TestCase):
+class TestMain(unittest.TestCase):
     """Tests main()."""
     def test_happy(self) -> None:
         """Tests the happy path."""

--- a/tests/test_missing_housenumbers.py
+++ b/tests/test_missing_housenumbers.py
@@ -15,7 +15,7 @@ import test_config
 import missing_housenumbers
 
 
-class TestMain(test_config.TestCase):
+class TestMain(unittest.TestCase):
     """Tests main()."""
     def test_happy(self) -> None:
         """Tests the happy path."""

--- a/tests/test_missing_streets.py
+++ b/tests/test_missing_streets.py
@@ -10,13 +10,11 @@ import io
 import unittest
 import unittest.mock
 
-import test_config
-
 import config
 import missing_streets
 
 
-class TestMain(test_config.TestCase):
+class TestMain(unittest.TestCase):
     """Tests main()."""
     def test_happy(self) -> None:
         """Tests the happy path."""

--- a/tests/test_parse_access_log.py
+++ b/tests/test_parse_access_log.py
@@ -30,7 +30,7 @@ class MockDate(datetime.date):
         return cls(2020, 5, 10)
 
 
-class TestMain(test_config.TestCase):
+class TestMain(unittest.TestCase):
     """Tests main()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -72,7 +72,7 @@ author-time 1588975200
         self.assertNotIn("gyomaendrod", actual)
 
 
-class TestCheckTopEditedRelations(test_config.TestCase):
+class TestCheckTopEditedRelations(unittest.TestCase):
     """Tests check_top_edited_relations()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -100,7 +100,7 @@ class TestCheckTopEditedRelations(test_config.TestCase):
                 self.assertNotIn("baz", frequent_relations)
 
 
-class TestIsCompleteRelation(test_config.TestCase):
+class TestIsCompleteRelation(unittest.TestCase):
     """Tests is_complete_relation()."""
     def test_happy(self) -> None:
         """Tests the happy path."""

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -37,7 +37,7 @@ class MockDate(datetime.date):
         return cls(2020, 5, 10)
 
 
-class TestHandleProgress(test_config.TestCase):
+class TestHandleProgress(unittest.TestCase):
     """Tests handle_progress()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -62,7 +62,7 @@ class TestHandleProgress(test_config.TestCase):
         self.assertEqual(progress["date"], "1970-01-01")
 
 
-class TestHandleTopusers(test_config.TestCase):
+class TestHandleTopusers(unittest.TestCase):
     """Tests handle_topusers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -86,7 +86,7 @@ class TestHandleTopusers(test_config.TestCase):
         self.assertFalse(topusers)
 
 
-class TestHandleTopcities(test_config.TestCase):
+class TestHandleTopcities(unittest.TestCase):
     """Tests handle_topcities()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -101,7 +101,7 @@ class TestHandleTopcities(test_config.TestCase):
         self.assertEqual(topcities[1], ("budapest_01", 90))
 
 
-class TestHandleDailyNew(test_config.TestCase):
+class TestHandleDailyNew(unittest.TestCase):
     """Tests handle_daily_new()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -126,7 +126,7 @@ class TestHandleDailyNew(test_config.TestCase):
         self.assertFalse(daily)
 
 
-class TestHandleMonthlyNew(test_config.TestCase):
+class TestHandleMonthlyNew(unittest.TestCase):
     """Tests handle_monthly_new()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -174,7 +174,7 @@ class TestHandleMonthlyNew(test_config.TestCase):
         self.assertEqual(monthly[0], ["2019-05", 3799])
 
 
-class TestHandleDailyTotal(test_config.TestCase):
+class TestHandleDailyTotal(unittest.TestCase):
     """Tests handle_daily_total()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -197,7 +197,7 @@ class TestHandleDailyTotal(test_config.TestCase):
         self.assertFalse(dailytotal)
 
 
-class TestHandleUserTotal(test_config.TestCase):
+class TestHandleUserTotal(unittest.TestCase):
     """Tests handle_user_total()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
@@ -220,7 +220,7 @@ class TestHandleUserTotal(test_config.TestCase):
         self.assertFalse(usertotal)
 
 
-class TestHandleMonthlyTotal(test_config.TestCase):
+class TestHandleMonthlyTotal(unittest.TestCase):
     """Tests handle_monthly_total()."""
     def test_happy(self) -> None:
         """Tests the happy path."""

--- a/tests/test_webframe.py
+++ b/tests/test_webframe.py
@@ -18,8 +18,6 @@ import time
 # pylint: disable=unused-import
 import yattag
 
-import test_config
-
 import config
 import webframe
 
@@ -28,7 +26,7 @@ if TYPE_CHECKING:
     from wsgiref.types import StartResponse  # noqa: F401
 
 
-class TestHandleStatic(test_config.TestCase):
+class TestHandleStatic(unittest.TestCase):
     """Tests handle_static()."""
     def test_happy(self) -> None:
         """Tests the happy path: css case."""
@@ -116,7 +114,7 @@ class TestHandleException(unittest.TestCase):
         self.fail()
 
 
-class TestLocalToUiTz(test_config.TestCase):
+class TestLocalToUiTz(unittest.TestCase):
     """Tests local_to_ui_tz()."""
     def test_happy(self) -> None:
         """Tests the happy path."""

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -41,10 +41,10 @@ if TYPE_CHECKING:
     from wsgiref.types import StartResponse
 
 
-class TestWsgi(test_config.TestCase):
+class TestWsgi(unittest.TestCase):
     """Base class for wsgi tests."""
     def __init__(self, method_name: str) -> None:
-        test_config.TestCase.__init__(self, method_name)
+        unittest.TestCase.__init__(self, method_name)
         self.gzip_compress = False
         self.conf = test_config.make_test_config()
 

--- a/tests/test_wsgi_json.py
+++ b/tests/test_wsgi_json.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from wsgiref.types import StartResponse
 
 
-class TestWsgiJson(test_config.TestCase):
+class TestWsgiJson(unittest.TestCase):
     """Base class for wsgi_json tests."""
 
     def get_json_for_path(self, conf: config.Config, path: str) -> Dict[str, Any]:


### PR DESCRIPTION
We pass around config.Config already, no need to mock it.

Change-Id: I727a5ae32423de009d66ab6e771e38a56575a556
