### PR TITLE
Rework to avoid pytz dependency

### DIFF
--- a/config.py
+++ b/config.py
@@ -58,10 +58,6 @@ class Config:
         """Gets the locale."""
         return self.__config.get("wsgi", "locale").strip()
 
-    def get_timezone(self) -> str:
-        """Gets the timezone."""
-        return self.__config.get("wsgi", "timezone").strip()
-
     def get_uri_prefix(self) -> str:
         """Gets the global URI prefix."""
         return self.__config.get("wsgi", "uri_prefix").strip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ flake8==3.9.2
 mypy==0.812
 pylint==2.8.2
 python-dateutil==2.8.1
-pytz==2021.1
 pyyaml==5.4.1
 unidecode==1.2.0
 yamllint==1.26.1

--- a/tests/test_webframe.py
+++ b/tests/test_webframe.py
@@ -10,10 +10,8 @@ from typing import List
 from typing import TYPE_CHECKING
 from typing import Tuple
 from typing import cast
-import datetime
 import unittest
 import unittest.mock
-import time
 
 # pylint: disable=unused-import
 import yattag
@@ -113,18 +111,6 @@ class TestHandleException(unittest.TestCase):
             self.assertIn("ValueError", output)
             return
         self.fail()
-
-
-class TestLocalToUiTz(unittest.TestCase):
-    """Tests local_to_ui_tz()."""
-    def test_happy(self) -> None:
-        """Tests the happy path."""
-        conf = test_config.make_test_config()
-        conf.set_value("timezone", "Europe/Budapest")
-        local_dt = datetime.datetime.fromtimestamp(0)
-        ui_dt = webframe.local_to_ui_tz(conf, local_dt)
-        if time.strftime('%Z%z') == "CEST+0200":
-            self.assertEqual(ui_dt.timestamp(), 0)
 
 
 class TestFillMissingHeaderItems(unittest.TestCase):

--- a/webframe.py
+++ b/webframe.py
@@ -22,7 +22,6 @@ import time
 import traceback
 import xmlrpc.client
 
-import pytz
 import yattag
 
 from i18n import translate as _
@@ -348,22 +347,11 @@ def handle_404() -> yattag.doc.Doc:
     return doc
 
 
-def local_to_ui_tz(conf: config.Config, local_dt: datetime.datetime) -> datetime.datetime:
-    """Converts from local date-time to UI date-time, based on config."""
-    if conf.has_value("timezone"):
-        ui_tz = pytz.timezone(conf.get_timezone())
-    else:
-        ui_tz = pytz.timezone("Europe/Budapest")
-
-    return local_dt.astimezone(ui_tz)
-
-
-def format_timestamp(conf: config.Config, timestamp: float) -> str:
+def format_timestamp(timestamp: float) -> str:
     """Formats timestamp as UI date-time."""
-    local_dt = datetime.datetime.fromtimestamp(timestamp)
-    ui_dt = local_to_ui_tz(conf, local_dt)
+    date_time = datetime.datetime.fromtimestamp(timestamp)
     fmt = '%Y-%m-%d %H:%M'
-    return ui_dt.strftime(fmt)
+    return date_time.strftime(fmt)
 
 
 def handle_stats_cityprogress(conf: config.Config, relations: areas.Relations) -> yattag.doc.Doc:

--- a/wsgi.py
+++ b/wsgi.py
@@ -77,7 +77,7 @@ def handle_streets(conf: config.Config, relations: areas.Relations, request_uri:
             table = util.tsv_to_list(sock)
             doc.asis(util.html_table_from_list(table).getvalue())
 
-    doc.asis(webframe.get_footer(get_streets_last_modified(conf, relation)).getvalue())
+    doc.asis(webframe.get_footer(get_streets_last_modified(relation)).getvalue())
     return doc
 
 
@@ -115,7 +115,7 @@ def handle_street_housenumbers(conf: config.Config, relations: areas.Relations, 
             with relation.get_files().get_osm_housenumbers_csv_stream() as sock:
                 doc.asis(util.html_table_from_list(util.tsv_to_list(sock)).getvalue())
 
-    date = get_housenumbers_last_modified(conf, relation)
+    date = get_housenumbers_last_modified(relation)
     doc.asis(webframe.get_footer(date).getvalue())
     return doc
 
@@ -328,7 +328,7 @@ def handle_missing_housenumbers(conf: config.Config, relations: areas.Relations,
         with doc.tag("pre"):
             with relation.get_files().get_ref_housenumbers_stream("r") as sock:
                 doc.text(sock.read())
-        date = get_last_modified(conf, relation.get_files().get_ref_housenumbers_path())
+        date = get_last_modified(relation.get_files().get_ref_housenumbers_path())
     elif action == "update-result":
         doc.asis(missing_housenumbers_update(conf, relations, relation_name).getvalue())
     else:
@@ -336,7 +336,7 @@ def handle_missing_housenumbers(conf: config.Config, relations: areas.Relations,
         doc.asis(missing_housenumbers_view_res(conf, relations, request_uri).getvalue())
 
     if not date:
-        date = ref_housenumbers_last_modified(conf, relations, relation_name)
+        date = ref_housenumbers_last_modified(relations, relation_name)
     doc.asis(webframe.get_footer(date).getvalue())
     return doc
 
@@ -384,7 +384,7 @@ def handle_missing_streets(conf: config.Config, relations: areas.Relations, requ
         # assume view-result
         doc.asis(missing_streets_view_result(conf, relations, request_uri).getvalue())
 
-    date = streets_diff_last_modified(conf, relation)
+    date = streets_diff_last_modified(relation)
     doc.asis(webframe.get_footer(date).getvalue())
     return doc
 
@@ -407,7 +407,7 @@ def handle_additional_streets(conf: config.Config, relations: areas.Relations, r
         # assume view-result
         doc.asis(wsgi_additional.additional_streets_view_result(conf, relations, request_uri).getvalue())
 
-    date = streets_diff_last_modified(conf, relation)
+    date = streets_diff_last_modified(relation)
     doc.asis(webframe.get_footer(date).getvalue())
     return doc
 
@@ -431,46 +431,46 @@ def handle_additional_housenumbers(
     # assume action is view-result
     doc.asis(wsgi_additional.additional_housenumbers_view_result(conf, relations, request_uri).getvalue())
 
-    date = housenumbers_diff_last_modified(conf, relation)
+    date = housenumbers_diff_last_modified(relation)
     doc.asis(webframe.get_footer(date).getvalue())
     return doc
 
 
-def get_last_modified(conf: config.Config, path: str) -> str:
+def get_last_modified(path: str) -> str:
     """Gets the update date string of a file."""
-    return webframe.format_timestamp(conf, util.get_timestamp(path))
+    return webframe.format_timestamp(util.get_timestamp(path))
 
 
-def ref_housenumbers_last_modified(conf: config.Config, relations: areas.Relations, name: str) -> str:
+def ref_housenumbers_last_modified(relations: areas.Relations, name: str) -> str:
     """Gets the update date for missing house numbers."""
     relation = relations.get_relation(name)
     t_ref = util.get_timestamp(relation.get_files().get_ref_housenumbers_path())
     t_housenumbers = util.get_timestamp(relation.get_files().get_osm_housenumbers_path())
-    return webframe.format_timestamp(conf, max(t_ref, t_housenumbers))
+    return webframe.format_timestamp(max(t_ref, t_housenumbers))
 
 
-def streets_diff_last_modified(conf: config.Config, relation: areas.Relation) -> str:
+def streets_diff_last_modified(relation: areas.Relation) -> str:
     """Gets the update date for missing/additional streets."""
     t_ref = util.get_timestamp(relation.get_files().get_ref_streets_path())
     t_osm = util.get_timestamp(relation.get_files().get_osm_streets_path())
-    return webframe.format_timestamp(conf, max(t_ref, t_osm))
+    return webframe.format_timestamp(max(t_ref, t_osm))
 
 
-def housenumbers_diff_last_modified(conf: config.Config, relation: areas.Relation) -> str:
+def housenumbers_diff_last_modified(relation: areas.Relation) -> str:
     """Gets the update date for missing/additional housenumbers."""
     t_ref = util.get_timestamp(relation.get_files().get_ref_housenumbers_path())
     t_osm = util.get_timestamp(relation.get_files().get_osm_housenumbers_path())
-    return webframe.format_timestamp(conf, max(t_ref, t_osm))
+    return webframe.format_timestamp(max(t_ref, t_osm))
 
 
-def get_housenumbers_last_modified(conf: config.Config, relation: areas.Relation) -> str:
+def get_housenumbers_last_modified(relation: areas.Relation) -> str:
     """Gets the update date of house numbers for a relation."""
-    return get_last_modified(conf, relation.get_files().get_osm_housenumbers_path())
+    return get_last_modified(relation.get_files().get_osm_housenumbers_path())
 
 
-def get_streets_last_modified(conf: config.Config, relation: areas.Relation) -> str:
+def get_streets_last_modified(relation: areas.Relation) -> str:
     """Gets the update date of streets for a relation."""
-    return get_last_modified(conf, relation.get_files().get_osm_streets_path())
+    return get_last_modified(relation.get_files().get_osm_streets_path())
 
 
 def handle_main_housenr_percent(conf: config.Config, relation: areas.Relation) -> Tuple[yattag.doc.Doc, str]:
@@ -483,7 +483,7 @@ def handle_main_housenr_percent(conf: config.Config, relation: areas.Relation) -
 
     doc = yattag.doc.Doc()
     if percent != "N/A":
-        date = get_last_modified(conf, relation.get_files().get_housenumbers_percent_path())
+        date = get_last_modified(relation.get_files().get_housenumbers_percent_path())
         with doc.tag("strong"):
             with doc.tag("a", href=url, title=_("updated") + " " + date):
                 doc.text(util.format_percent(percent))
@@ -505,7 +505,7 @@ def handle_main_street_percent(conf: config.Config, relation: areas.Relation) ->
 
     doc = yattag.doc.Doc()
     if percent != "N/A":
-        date = get_last_modified(conf, relation.get_files().get_streets_percent_path())
+        date = get_last_modified(relation.get_files().get_streets_percent_path())
         with doc.tag("strong"):
             with doc.tag("a", href=url, title=_("updated") + " " + date):
                 doc.text(util.format_percent(percent))
@@ -527,7 +527,7 @@ def handle_main_street_additional_count(conf: config.Config, relation: areas.Rel
 
     doc = yattag.doc.Doc()
     if additional_count:
-        date = get_last_modified(conf, relation.get_files().get_streets_additional_count_path())
+        date = get_last_modified(relation.get_files().get_streets_additional_count_path())
         with doc.tag("strong"):
             with doc.tag("a", href=url, title=_("updated") + " " + date):
                 doc.text(_("{} streets").format(additional_count))
@@ -553,7 +553,7 @@ def handle_main_housenr_additional_count(conf: config.Config, relation: areas.Re
 
     doc = yattag.doc.Doc()
     if additional_count:
-        date = get_last_modified(conf, relation.get_files().get_housenumbers_additional_count_path())
+        date = get_last_modified(relation.get_files().get_housenumbers_additional_count_path())
         with doc.tag("strong"):
             with doc.tag("a", href=url, title=_("updated") + " " + date):
                 doc.text(_("{} house numbers").format(additional_count))


### PR DESCRIPTION
This was only needed when the server and the client timezone was
different, which is not the case currently, so avoid this complexity.

Change-Id: I56476194562d74b6a023dc8afa09285a0deea529
