### PR TITLE
cache_yamls: switch from pickle to json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,7 +115,7 @@ venv.bak/
 # wsgi
 wsgi.ini
 version.py
-*.pickle
+*.cache
 
 # validator
 *.validyaml

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ ifndef V
 	QUIET_YAMLLINT = @echo '   ' YAMLLINT $@;
 endif
 
-all: version.py builddir/bundle.js css wsgi.ini data/yamls.pickle locale/hu/LC_MESSAGES/osm-gimmisn.mo
+all: version.py builddir/bundle.js css wsgi.ini data/yamls.cache locale/hu/LC_MESSAGES/osm-gimmisn.mo
 
 clean:
 	rm -f version.py config.ts
@@ -124,7 +124,7 @@ workdir/osm.min.css: static/osm.css package-lock.json
 	mkdir -p workdir
 	[ -x "./node_modules/.bin/cleancss" ] && ./node_modules/.bin/cleancss -o $@ $< || cp -a $< $@
 
-testdata: tests/data/yamls.pickle tests/workdir/osm.min.css tests/favicon.ico tests/favicon.svg
+testdata: tests/data/yamls.cache tests/workdir/osm.min.css tests/favicon.ico tests/favicon.svg
 
 tests/favicon.ico: favicon.ico
 	cp -a $< $@
@@ -140,10 +140,10 @@ tests/workdir/osm.min.css: workdir/osm.min.css
 wsgi.ini:
 	cp data/wsgi.ini.template wsgi.ini
 
-data/yamls.pickle: cache_yamls.py $(YAML_OBJECTS)
+data/yamls.cache: cache_yamls.py $(YAML_OBJECTS)
 	./cache_yamls.py data workdir
 
-tests/data/yamls.pickle: cache_yamls.py $(YAML_TEST_OBJECTS)
+tests/data/yamls.cache: cache_yamls.py $(YAML_TEST_OBJECTS)
 	./cache_yamls.py tests/data tests/workdir
 
 check-filters: check-filters-syntax check-filters-schema
@@ -170,7 +170,7 @@ check-mypy: $(patsubst %.py,%.mypy,$(PYTHON_OBJECTS))
 %.flake8: %.py Makefile setup.cfg
 	$(QUIET_FLAKE8)flake8 $< && touch $@
 
-check-unit: version.py data/yamls.pickle testdata
+check-unit: version.py data/yamls.cache testdata
 	env PYTHONPATH=.:tests coverage run --branch --module unittest $(PYTHON_TEST_OBJECTS)
 	env PYTHONPATH=.:tests coverage report --show-missing --fail-under=100 $(PYTHON_SAFE_OBJECTS)
 

--- a/areas.py
+++ b/areas.py
@@ -13,7 +13,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import cast
-import pickle
+import json
 import yattag
 
 from i18n import translate as _
@@ -712,8 +712,8 @@ class Relations:
     def __init__(self, conf: config.Config) -> None:
         self.__workdir = conf.get_workdir()
         self.__conf = conf
-        with open(os.path.join(conf.get_abspath("data"), "yamls.pickle"), "rb") as stream:
-            self.__yaml_cache: Dict[str, Any] = pickle.load(stream)
+        with open(os.path.join(conf.get_abspath("data"), "yamls.cache"), "rb") as stream:
+            self.__yaml_cache: Dict[str, Any] = json.load(stream)
         self.__dict = self.__yaml_cache["relations.yaml"]
         self.__relations: Dict[str, Relation] = {}
         self.__activate_all = False

--- a/cache_yamls.py
+++ b/cache_yamls.py
@@ -12,7 +12,6 @@ from typing import Dict
 import glob
 import json
 import os
-import pickle
 import sys
 import yaml
 
@@ -29,9 +28,9 @@ def main(conf: config.Config) -> None:
             cache_key = os.path.relpath(yaml_path, datadir)
             cache[cache_key] = yaml.safe_load(yaml_stream)
 
-    cache_path = os.path.join(datadir, "yamls.pickle")
-    with open(cache_path, "wb") as cache_stream:
-        pickle.dump(cache, cache_stream)
+    cache_path = os.path.join(datadir, "yamls.cache")
+    with open(cache_path, "w") as cache_stream:
+        json.dump(cache, cache_stream)
 
     workdir = conf.get_abspath(sys.argv[2])
     yaml_path = os.path.join(datadir, "relations.yaml")

--- a/tests/test_cache_yamls.py
+++ b/tests/test_cache_yamls.py
@@ -21,7 +21,7 @@ class TestMain(unittest.TestCase):
     """Tests main()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        cache_path = "tests/data/yamls.pickle"
+        cache_path = "tests/data/yamls.cache"
         if os.path.exists(cache_path):
             os.remove(cache_path)
         argv = ["", "data", "workdir"]


### PR DESCRIPTION
Pickle is a python-specific serialization that allows quickly loading
nested dictionaries from disk.

We use yaml for the in-git filter data as it's a better markup for
manual editing: comments, etc.

Given that yaml provides nice manual editing, it's naturally slower to
load than pickle. Switch to json as the cache format: json is still
hard to edit manually (e.g. no comments possible) but it's not
python-specific and almost as fast as pickle.

(Sure, we could use some non-standard json parser that supports
comments, but that'll be probably slower than the stupid+fast built-in
one.)

Change-Id: I8c1dfc33e6cd6fc0991aaf8795b7202b72cb0fbc
