### PR TITLE
stats: eliminate python-dateutil dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ coverage==5.5
 flake8==3.9.2
 mypy==0.812
 pylint==2.8.2
-python-dateutil==2.8.1
 pyyaml==5.4.1
 unidecode==1.2.0
 yamllint==1.26.1

--- a/stats.py
+++ b/stats.py
@@ -17,8 +17,6 @@ import json
 import os
 import time
 
-import dateutil.relativedelta
-
 
 def handle_progress(src_root: str, j: Dict[str, Any]) -> None:
     """Generates stats for a global progressbar."""
@@ -128,14 +126,22 @@ def handle_daily_new(src_root: str, j: Dict[str, Any], day_range: int = 14) -> N
     j["daily"] = ret
 
 
+def get_previous_month(today: datetime.date, months: int) -> datetime.date:
+    """Returns a date that was today N months ago."""
+    month_ago = today
+    for _month in range(months):
+        first_of_current = month_ago.replace(day=1)
+        month_ago = first_of_current - datetime.timedelta(days=1)
+    return month_ago
+
+
 def handle_monthly_new(src_root: str, j: Dict[str, Any], month_range: int = 12) -> None:
     """Shows # of new housenumbers / month."""
     ret = []
     prev_count = 0
     prev_month = ""
     for month_offset in range(month_range, -1, -1):
-        # datetime.timedelta does not support months
-        month_delta = datetime.date.today() - dateutil.relativedelta.relativedelta(months=month_offset)
+        month_delta = get_previous_month(datetime.date.today(), month_offset)
         # Get the first day of each month.
         month = month_delta.replace(day=1).strftime("%Y-%m-%d")
         count_path = os.path.join(src_root, "%s.count" % month)
@@ -178,9 +184,8 @@ def handle_monthly_total(src_root: str, j: Dict[str, Any], month_range: int = 11
     """Shows # of total housenumbers / month."""
     ret = []
     for month_offset in range(month_range, -1, -1):
-        # datetime.timedelta does not support months
-        month_delta = datetime.date.today() - dateutil.relativedelta.relativedelta(months=month_offset)
-        prev_month_delta = datetime.date.today() - dateutil.relativedelta.relativedelta(months=month_offset + 1)
+        month_delta = get_previous_month(datetime.date.today(), month_offset)
+        prev_month_delta = get_previous_month(datetime.date.today(), month_offset + 1)
         # Get the first day of each past month.
         month = month_delta.replace(day=1).strftime("%Y-%m-%d")
         prev_month = prev_month_delta.replace(day=1).strftime("%Y-%m")

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -255,5 +255,17 @@ class TestHandleMonthlyTotal(unittest.TestCase):
         self.assertEqual(monthlytotal[1], ["2020-05", 254651])
 
 
+class TestGetPreviousMonth(unittest.TestCase):
+    """Tests get_previous_month()."""
+    def test_happy(self) -> None:
+        """Tests the happy path."""
+        today = MockDate.today()
+
+        actual = stats.get_previous_month(today, 2)
+
+        expected = datetime.date(2020, 3, 31)
+        self.assertEqual(actual, expected)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
A whole module for a function of 5 lines is a bit of an overkill.

Change-Id: I4d994b72d061503bc41707d02fda90284cf8a882
