### PR TITLE
Use icu instead of locale.setlocale()

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -8,7 +8,6 @@
 """The cache module accelerates some functions of the areas module."""
 
 from typing import List
-import locale
 import os
 
 import yattag
@@ -165,7 +164,7 @@ def get_missing_housenumbers_txt(conf: config.Config, relation: areas.Relation) 
             elements = util.format_even_odd(range_list, doc=None)
             row = result[0].get_osm_name() + "\t[" + "], [".join(elements) + "]"
         table.append(row)
-    table.sort(key=locale.strxfrm)
+    table.sort(key=util.get_lexical_sort_key())
     output += "\n".join(table)
 
     with relation.get_files().get_housenumbers_txtcache_stream("w") as stream:

--- a/config.py
+++ b/config.py
@@ -23,10 +23,6 @@ class Config:
         config_path = self.get_abspath("wsgi.ini")
         self.__config.read(config_path)
 
-    def has_value(self, key: str) -> bool:
-        """Determines if key is set in the config."""
-        return self.__config.has_option("wsgi", key)
-
     def set_value(self, key: str, value: str) -> None:
         """Sets key to value in the in-memory config."""
         self.__config.read_dict({"wsgi": {key: value}})
@@ -53,10 +49,6 @@ class Config:
         """Gets the abs path of ref citycounts."""
         relpath = self.__config.get("wsgi", "reference_citycounts").strip()
         return self.get_abspath(relpath)
-
-    def get_locale(self) -> str:
-        """Gets the locale."""
-        return self.__config.get("wsgi", "locale").strip()
 
     def get_uri_prefix(self) -> str:
         """Gets the global URI prefix."""

--- a/cron.py
+++ b/cron.py
@@ -15,7 +15,6 @@ from typing import cast
 import argparse
 import datetime
 import glob
-import locale
 import logging
 import os
 import time
@@ -199,7 +198,8 @@ def write_city_count_path(city_count_path: str, cities: Dict[str, Set[str]]) -> 
     """Writes a daily .citycount file."""
     with open(city_count_path, "w") as stream:
         # Locale-aware sort, by key.
-        for key, value in sorted(cities.items(), key=lambda item: locale.strxfrm(item[0])):
+        lexical_sort_key = util.get_lexical_sort_key()
+        for key, value in sorted(cities.items(), key=lambda item: lexical_sort_key(item[0])):
             stream.write(key + "\t" + str(len(value)) + "\n")
 
 
@@ -350,8 +350,6 @@ def our_main(conf: config.Config, relations: areas.Relations, mode: str, update:
 
 def main(conf: config.Config) -> None:
     """Commandline interface to this module."""
-
-    util.set_locale(conf)
 
     workdir = conf.get_workdir()
     relations = areas.Relations(conf)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+PyICU==2.7.3
 cherrypy==18.6.0
 coverage==5.5
 flake8==3.9.2

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -18,7 +18,6 @@ from typing import Tuple
 from typing import cast
 import io
 import json
-import locale
 import os
 import unittest
 import unittest.mock
@@ -653,17 +652,6 @@ class TestMain(TestWsgi):
         root = self.get_dom_for_path("")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
-
-    def test_failing_locale(self) -> None:
-        """Tests the main page with a failing locale."""
-
-        def mock_setlocale(category: int, locale_name: str) -> str:
-            raise locale.Error()
-
-        with unittest.mock.patch('locale.setlocale', mock_setlocale):
-            root = self.get_dom_for_path("")
-            results = root.findall("body/table")
-            self.assertEqual(len(results), 1)
 
     def test_application_exception(self) -> None:
         """Tests application(), exception catching case."""

--- a/webframe.py
+++ b/webframe.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING
 from typing import Tuple
 from typing import cast
 import datetime
-import locale
 import os
 import time
 import traceback
@@ -383,7 +382,7 @@ def handle_stats_cityprogress(conf: config.Config, relations: areas.Relations) -
             count = int(cells[1])
             osm_citycounts[city] = count
     cities = util.get_in_both(list(ref_citycounts.keys()), list(osm_citycounts.keys()))
-    cities.sort(key=locale.strxfrm)
+    cities.sort(key=util.get_lexical_sort_key())
     table = []
     table.append([util.html_escape(_("City name")),
                   util.html_escape(_("House number coverage")),

--- a/wsgi.py
+++ b/wsgi.py
@@ -8,7 +8,6 @@
 """The wsgi module contains functionality specific to the web interface."""
 
 import json
-import locale
 import os
 import subprocess
 import sys
@@ -176,7 +175,7 @@ def missing_streets_view_result(conf: config.Config, relations: areas.Relations,
 
     ret = relation.write_missing_streets()
     todo_count, done_count, percent, streets = ret
-    streets.sort(key=locale.strxfrm)
+    streets.sort(key=util.get_lexical_sort_key())
     table = [[util.html_escape(_("Street name"))]]
     for street in streets:
         table.append([util.html_escape(street)])
@@ -259,7 +258,7 @@ def missing_housenumbers_view_chkl(relations: areas.Relations, request_uri: str)
                 else:
                     row += result[0].get_osm_name() + " [" + "], [".join(elements) + "]"
                     table.append(row)
-        table.sort(key=locale.strxfrm)
+        table.sort(key=util.get_lexical_sort_key())
         output += "\n".join(table)
     return output, relation_name
 
@@ -277,7 +276,7 @@ def missing_streets_view_txt(relations: areas.Relations, request_uri: str, chkl:
         output += _("No reference streets")
     else:
         todo_streets, _ignore = relation.get_missing_streets()
-        todo_streets.sort(key=locale.strxfrm)
+        todo_streets.sort(key=util.get_lexical_sort_key())
         for street in todo_streets:
             if chkl:
                 output += "[ ] {}\n".format(street)
@@ -915,8 +914,6 @@ def our_application(
         conf: config.Config
 ) -> Iterable[bytes]:
     """Dispatches the request based on its URI."""
-    util.set_locale(conf)
-
     language = util.setup_localization(environ, conf)
 
     relations = areas.Relations(conf)

--- a/wsgi_additional.py
+++ b/wsgi_additional.py
@@ -7,7 +7,6 @@
 
 """The wsgi_additional module contains functionality for additional streets."""
 
-import locale
 import os
 from typing import Tuple
 
@@ -34,7 +33,8 @@ def additional_streets_view_txt(relations: areas.Relations, request_uri: str, ch
         output += _("No reference streets")
     else:
         streets = relation.get_additional_streets()
-        streets.sort(key=lambda street: locale.strxfrm(street.get_osm_name()))
+        lexical_sort_key = util.get_lexical_sort_key()
+        streets.sort(key=lambda street: lexical_sort_key(street.get_osm_name()))
         for street in streets:
             if chkl:
                 output += "[ ] {}\n".format(street.get_osm_name())
@@ -63,7 +63,8 @@ def additional_streets_view_result(
         # Get "only in OSM" streets.
         streets = relation.write_additional_streets()
         count = len(streets)
-        streets.sort(key=lambda street: locale.strxfrm(street.get_osm_name()))
+        lexical_sort_key = util.get_lexical_sort_key()
+        streets.sort(key=lambda street: lexical_sort_key(street.get_osm_name()))
         table = [[util.html_escape(_("Identifier")),
                   util.html_escape(_("Type")),
                   util.html_escape(_("Source")),


### PR DESCRIPTION
The problem with locale.setlocale() is that it's not thread-safe. And it
turns out the generic Unicode-aware rules are enough from ICU, no need
to track the specific locale precisely.

Change-Id: I1f00b17b81aaa31a741c6c3be612a9ecae6a745c
