### PR TITLE
accept_language: remove length check

### DIFF
--- a/accept_language.py
+++ b/accept_language.py
@@ -17,7 +17,6 @@ import re
 VALIDATE_LANG_REGEX = re.compile('^[a-z]+$', flags=re.IGNORECASE)
 QUALITY_VAL_SUB_REGEX = re.compile('^q=', flags=re.IGNORECASE)
 DEFAULT_QUALITY_VALUE = 1.0
-MAX_HEADER_LEN = 8192
 
 
 class Lang:
@@ -53,9 +52,6 @@ def parse_accept_language(accept_language_str: str, default_quality: Optional[fl
     """
     if not accept_language_str:
         return []
-
-    if len(accept_language_str) > MAX_HEADER_LEN:
-        raise ValueError('Accept-Language too long, max length is 8192')
 
     parsed_langs = []
     for accept_lang_segment in accept_language_str.split(','):

--- a/tests/test_accept_language.py
+++ b/tests/test_accept_language.py
@@ -7,7 +7,6 @@
 """The test_accept_language module covers the accept_language module."""
 
 import unittest
-import unittest.mock
 
 import accept_language
 
@@ -23,12 +22,6 @@ class TestParseAcceptLanguage(unittest.TestCase):
         """Tests empty input."""
         parsed = accept_language.parse_accept_language("")
         self.assertEqual(parsed, [])
-
-    def test_too_long(self) -> None:
-        """Tests too long input."""
-        with unittest.mock.patch('accept_language.MAX_HEADER_LEN', 3):
-            with self.assertRaises(ValueError):
-                accept_language.parse_accept_language("en-US")
 
     def test_invalid_lang(self) -> None:
         """Tests the case when a language string is invalid."""


### PR DESCRIPTION
To be in sync with e.g. https://crates.io/crates/accept_language/

Change-Id: I9b95feef81f0481f21534eaa3f67bde894afec29
