### PR TITLE
Fix Hungarian sort order

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,6 +8,7 @@
 
 from typing import List
 import io
+import locale
 import os
 import unittest
 import unittest.mock
@@ -494,6 +495,33 @@ class TestGetTimestamp(unittest.TestCase):
     def test_no_such_file(self) -> None:
         """Tests what happens when the file is not there."""
         self.assertEqual(util.get_timestamp(""), 0)
+
+
+class TestGetLexicalSortKey(unittest.TestCase):
+    """Tests get_lexical_sort_key()."""
+    def test_happy(self) -> None:
+        """Tests the happy path."""
+        try:
+            locale.setlocale(locale.LC_ALL, "hu_HU.UTF-8")
+        except locale.Error:
+            # Can't test, environment lacks the locale.
+            return
+
+        # This is less naive than the classic "a, "á", "b", "c" list.
+        strings = ["Kőpor", "Kórház"]
+        strings.sort(key=util.get_lexical_sort_key())
+        self.assertEqual(strings, ["Kórház", "Kőpor"])
+
+    def test_failing_locale(self) -> None:
+        """Tests the missing locale path."""
+
+        def mock_setlocale(category: int, locale_name: str) -> str:
+            raise locale.Error()
+
+        with unittest.mock.patch('locale.setlocale', mock_setlocale):
+            strings = ["a", "b"]
+            strings.sort(key=util.get_lexical_sort_key())
+            self.assertEqual(strings, ["a", "b"])
 
 
 if __name__ == '__main__':

--- a/util.py
+++ b/util.py
@@ -877,7 +877,12 @@ def get_timestamp(path: str) -> float:
 
 def get_lexical_sort_key() -> Callable[[str], str]:
     """Returns a string comparator which allows Unicode-aware lexical sorting."""
-    locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+    # This is good enough for now, English and Hungarian is all we support and this handles both.
+    try:
+        locale.setlocale(locale.LC_ALL, "hu_HU.UTF-8")
+    except locale.Error:
+        # Ignore, this happens only on the cut-down CI environment.
+        pass
     return locale.strxfrm
 
 


### PR DESCRIPTION
My hope was that en_US.UTF-8 is some generic unicode sorting that is
good enough for both English and Hungarian, but it is not, fix this.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/1408>.

Change-Id: Iab95a0ad4a66fda8e3543e774561556f7b41c00d
