### PR TITLE
wsgi: fix missing error handling when the list of relation numbers is empty

### DIFF
--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -646,6 +646,15 @@ class TestMain(TestWsgi):
         # header + the two requested relations
         self.assertEqual(len(table.getchildren()), 3)
 
+    def test_filter_for_relations_empty(self) -> None:
+        """Tests if the /osm/filter-for/relations/ output is well-formed."""
+        root = self.get_dom_for_path("/filter-for/relations/")
+        results = root.findall("body/table")
+        self.assertEqual(len(results), 1)
+        table = results[0]
+        # header + no requested relations
+        self.assertEqual(len(table.getchildren()), 1)
+
     def test_application_exception(self) -> None:
         """Tests application(), exception catching case."""
         conf = test_config.make_test_config()

--- a/wsgi.py
+++ b/wsgi.py
@@ -581,7 +581,9 @@ def create_filter_for_refcounty(refcounty_filter: str) -> Callable[[bool, areas.
 
 def create_filter_for_relations(relation_filter: str) -> Callable[[bool, areas.Relation], bool]:
     """Creates a function that filters for the specified relations."""
-    relations = [int(i) for i in relation_filter.split(",")]
+    relations: List[int] = []
+    if relation_filter:
+        relations = [int(i) for i in relation_filter.split(",")]
     return lambda _complete, relation: relation.get_config().get_osmrelation() in relations
 
 


### PR DESCRIPTION
i.e. "42,43" is turned into 42 and 43, but "" can't be turned into a
number, it should be turned into an empty list.

This happens when filtering for relations based on positions, but we
found none.

Change-Id: Ic65f053c843e173d12dca53ebfbd1154fbe54dc5
