### PR TITLE
i18n: change translate function from _ to tr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ else
 endif
 
 update-pot: areas.py cache.py webframe.py wsgi.py wsgi_additional.py util.py Makefile
-	xgettext --keyword=_ --language=Python --add-comments --sort-output --from-code=UTF-8 -o po/osm-gimmisn.pot $(filter %.py,$^)
+	xgettext --keyword=tr --language=Python --add-comments --sort-output --from-code=UTF-8 -o po/osm-gimmisn.pot $(filter %.py,$^)
 
 update-po: po/osm-gimmisn.pot Makefile
 	msgmerge --update po/hu/osm-gimmisn.po po/osm-gimmisn.pot

--- a/areas.py
+++ b/areas.py
@@ -16,7 +16,7 @@ from typing import cast
 import json
 import yattag
 
-from i18n import translate as _
+from i18n import translate as tr
 import area_files
 import config
 import ranges
@@ -293,7 +293,7 @@ class RelationBase:
                 street = util.Street(osm_id=int(row[0]), osm_name=row[1])
                 if len(row) > 6:
                     street.set_osm_type(row[6])
-                street.set_source(_("street"))
+                street.set_source(tr("street"))
                 ret.append(street)
         if os.path.exists(self.get_files().get_osm_housenumbers_path()):
             with self.get_files().get_osm_housenumbers_csv_stream() as sock:
@@ -579,9 +579,9 @@ class Relation(RelationBase):
         """Turns a list of numbered streets into a HTML table."""
         todo_count = 0
         table = []
-        table.append([util.html_escape(_("Street name")),
-                      util.html_escape(_("Missing count")),
-                      util.html_escape(_("House numbers"))])
+        table.append([util.html_escape(tr("Street name")),
+                      util.html_escape(tr("Missing count")),
+                      util.html_escape(tr("House numbers"))])
         rows = []
         for result in numbered_streets:
             # street, only_in_ref

--- a/cache.py
+++ b/cache.py
@@ -12,7 +12,7 @@ import os
 
 import yattag
 
-from i18n import translate as _
+from i18n import translate as tr
 import areas
 import config
 import util
@@ -76,22 +76,22 @@ def get_missing_housenumbers_html(conf: config.Config, relation: areas.Relation)
     with doc.tag("p"):
         prefix = conf.get_uri_prefix()
         relation_name = relation.get_name()
-        doc.text(_("OpenStreetMap is possibly missing the below {0} house numbers for {1} streets.")
+        doc.text(tr("OpenStreetMap is possibly missing the below {0} house numbers for {1} streets.")
                  .format(str(todo_count), str(todo_street_count)))
-        doc.text(_(" (existing: {0}, ready: {1}).").format(str(done_count), util.format_percent(str(percent))))
+        doc.text(tr(" (existing: {0}, ready: {1}).").format(str(done_count), util.format_percent(str(percent))))
         doc.stag("br")
         with doc.tag("a", href="https://github.com/vmiklos/osm-gimmisn/tree/master/doc"):
-            doc.text(_("Filter incorrect information"))
+            doc.text(tr("Filter incorrect information"))
         doc.text(".")
         doc.stag("br")
         with doc.tag("a", href=prefix + "/missing-housenumbers/{}/view-turbo".format(relation_name)):
-            doc.text(_("Overpass turbo query for the below streets"))
+            doc.text(tr("Overpass turbo query for the below streets"))
         doc.stag("br")
         with doc.tag("a", href=prefix + "/missing-housenumbers/{}/view-result.txt".format(relation_name)):
-            doc.text(_("Plain text format"))
+            doc.text(tr("Plain text format"))
         doc.stag("br")
         with doc.tag("a", href=prefix + "/missing-housenumbers/{}/view-result.chkl".format(relation_name)):
-            doc.text(_("Checklist format"))
+            doc.text(tr("Checklist format"))
 
     doc.asis(util.html_table_from_list(table).getvalue())
     doc.asis(util.invalid_refstreets_to_html(relation.get_invalid_refstreets()).getvalue())
@@ -115,11 +115,11 @@ def get_additional_housenumbers_html(conf: config.Config, relation: areas.Relati
     todo_street_count, todo_count, table = ret
 
     with doc.tag("p"):
-        doc.text(_("OpenStreetMap additionally has the below {0} house numbers for {1} streets.")
+        doc.text(tr("OpenStreetMap additionally has the below {0} house numbers for {1} streets.")
                  .format(str(todo_count), str(todo_street_count)))
         doc.stag("br")
         with doc.tag("a", href="https://github.com/vmiklos/osm-gimmisn/tree/master/doc"):
-            doc.text(_("Filter incorrect information"))
+            doc.text(tr("Filter incorrect information"))
 
     doc.asis(util.html_table_from_list(table).getvalue())
     doc.asis(util.invalid_refstreets_to_html(relation.get_invalid_refstreets()).getvalue())

--- a/po/hu/osm-gimmisn.po
+++ b/po/hu/osm-gimmisn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: osm-gimmisn\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-28 22:59+0200\n"
+"POT-Creation-Date: 2021-07-02 21:40+0200\n"
 "PO-Revision-Date: 2021-05-28 22:59+0200\n"
 "Last-Translator: Miklos Vajna <osm-gimmisn@vmiklos.hu>\n"
 "Language-Team: Hungarian\n"
@@ -17,311 +17,311 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: cache.py:80 wsgi.py:188
+#: cache.py:81 wsgi.py:187
 #, python-brace-format
 msgid " (existing: {0}, ready: {1})."
 msgstr " (meglévő: {0}, készültség: {1})."
 
-#: webframe.py:476
+#: webframe.py:470
 msgid "(empty)"
 msgstr "(üres)"
 
-#: webframe.py:477
+#: webframe.py:471
 msgid "(invalid)"
 msgstr "(hibás)"
 
-#: util.py:574
+#: util.py:578
 msgid "A reference name is invalid if it's in the OSM database."
 msgstr "Egy referencia név érvénytelen ha szerepel az OSM adatbázisban."
 
-#: wsgi.py:787
+#: wsgi.py:790
 msgid "Add new area"
 msgstr "Új terület hozzáadása"
 
-#: webframe.py:129 wsgi.py:776
+#: webframe.py:128 wsgi.py:779
 msgid "Additional house numbers"
 msgstr "További házszámok"
 
-#: webframe.py:138 wsgi.py:778
+#: webframe.py:137 wsgi.py:781
 msgid "Additional streets"
 msgstr "További utcák"
 
-#: webframe.py:479
+#: webframe.py:473
 msgid "All editors"
 msgstr "Összes szerkesztő"
 
-#: webframe.py:499
+#: webframe.py:493
 msgid "All house number editors"
 msgstr "Összes házszám szerkesztő"
 
-#: webframe.py:466 webframe.py:469 webframe.py:494
+#: webframe.py:460 webframe.py:463 webframe.py:488
 msgid "All house numbers"
 msgstr "Minden házszám"
 
-#: webframe.py:467
+#: webframe.py:461
 msgid "All house numbers, last 2 weeks, as of {}"
 msgstr "Összes házszám, utolsó 2 hét, frissítve: {}"
 
-#: webframe.py:464
+#: webframe.py:458
 msgid "All house numbers, last year, as of {}"
 msgstr "Összes házszám, elmúlt év, frissítve: {}"
 
-#: webframe.py:496
+#: webframe.py:490
 msgid "All house numbers, monthly"
 msgstr "Minden házszám, havonta"
 
-#: wsgi.py:774
+#: wsgi.py:777
 msgid "Area"
 msgstr "Terület"
 
-#: webframe.py:210 wsgi.py:779
+#: webframe.py:215 wsgi.py:782
 msgid "Area boundary"
 msgstr "Terület határa"
 
-#: webframe.py:175
+#: webframe.py:180
 msgid "Area list"
 msgstr "Területek listája"
 
-#: webframe.py:468
+#: webframe.py:462
 msgid "At the start of this day"
 msgstr "Ennek a napnak a kezdetén"
 
-#: wsgi.py:643
+#: wsgi.py:645
 msgid "Based on position"
 msgstr "Pozíció alapján"
 
-#: webframe.py:94 webframe.py:104
+#: webframe.py:92 webframe.py:102
 msgid "Call Overpass to update"
 msgstr "Frissítés Overpass hívásával"
 
-#: cache.py:93 wsgi.py:197 wsgi_additional.py:87
+#: cache.py:94 wsgi.py:196 wsgi_additional.py:92
 msgid "Checklist format"
 msgstr "Csekklista formátum"
 
-#: webframe.py:393 webframe.py:474
+#: webframe.py:387 webframe.py:468
 msgid "City name"
 msgstr "Város neve"
 
-#: webframe.py:500
+#: webframe.py:494
 msgid "Coverage"
 msgstr "Lefedettség"
 
-#: webframe.py:481
+#: webframe.py:475
 #, python-brace-format
 msgid "Coverage is {1}%, as of {2}"
 msgstr "A lefedettség {1}%, frissítve: {2}"
 
-#: webframe.py:193
+#: webframe.py:198
 msgid "Creating from reference..."
 msgstr "Létrehozás referenciából..."
 
-#: webframe.py:483
+#: webframe.py:477
 msgid "Data source"
 msgstr "Adatforrás"
 
-#: webframe.py:221
+#: webframe.py:226
 msgid "Documentation"
 msgstr "Dokumentáció"
 
-#: webframe.py:459
+#: webframe.py:453
 msgid "During this day"
 msgstr "E nap folyamán"
 
-#: webframe.py:462
+#: webframe.py:456
 msgid "During this month"
 msgstr "E hónap folyamán"
 
-#: wsgi.py:669
+#: wsgi.py:671
 msgid "Error from GPS: "
 msgstr "GPS hiba: "
 
-#: webframe.py:192 webframe.py:602 webframe.py:624 wsgi.py:671
+#: webframe.py:197 webframe.py:596 webframe.py:618 wsgi.py:673
 msgid "Error from Overpass: "
 msgstr "Overpass hiba: "
 
-#: webframe.py:194 webframe.py:646 webframe.py:668
+#: webframe.py:199 webframe.py:640 webframe.py:662
 msgid "Error from reference: "
 msgstr "Hiba a referenciától: "
 
-#: wsgi.py:673
+#: wsgi.py:675
 msgid "Error from relations: "
 msgstr "Hiba a relációktól: "
 
-#: webframe.py:148
+#: webframe.py:152
 msgid "Existing house numbers"
 msgstr "Meglévő házszámok"
 
-#: webframe.py:153
+#: webframe.py:157
 msgid "Existing streets"
 msgstr "Meglévő utcák"
 
-#: cache.py:83 cache.py:121
+#: cache.py:84 cache.py:122
 msgid "Filter incorrect information"
 msgstr "Téves információ szűrése"
 
-#: wsgi.py:659
+#: wsgi.py:661
 msgid "Filters:"
 msgstr "Szűrők:"
 
-#: webframe.py:394 wsgi.py:775
+#: webframe.py:388 wsgi.py:778
 msgid "House number coverage"
 msgstr "Házszám lefedettség"
 
-#: areas.py:579
+#: areas.py:584
 msgid "House numbers"
 msgstr "Házszámok"
 
-#: wsgi_additional.py:63
+#: wsgi_additional.py:68
 msgid "Identifier"
 msgstr "Azonosító"
 
-#: webframe.py:325
+#: webframe.py:330
 #, python-brace-format
 msgid "Internal error when serving {0}"
 msgstr "Belső hiba a {0} kiszolgálása során"
 
-#: webframe.py:502
+#: webframe.py:496
 msgid "Invalid relation settings"
 msgstr "Érvénytelen területi beállítások"
 
-#: webframe.py:48
+#: webframe.py:46
 msgid "Last update: "
 msgstr "Utolsó frissítés: "
 
-#: webframe.py:465
+#: webframe.py:459
 msgid "Latest for this month"
 msgstr "Legutóbbi erre a hónapra"
 
-#: areas.py:578
+#: areas.py:583
 msgid "Missing count"
 msgstr "Hiányzik db"
 
-#: webframe.py:123
+#: webframe.py:122
 msgid "Missing house numbers"
 msgstr "Hiányzó házszámok"
 
-#: webframe.py:134
+#: webframe.py:133
 msgid "Missing streets"
 msgstr "Hiányzó utcák"
 
-#: webframe.py:460 webframe.py:463 webframe.py:493
+#: webframe.py:454 webframe.py:457 webframe.py:487
 msgid "New house numbers"
 msgstr "Új házszámok"
 
-#: webframe.py:458
+#: webframe.py:452
 msgid "New house numbers, last 2 weeks, as of {}"
 msgstr "Új házszámok, utolsó 2 hét, frissítve: {}"
 
-#: webframe.py:461
+#: webframe.py:455
 msgid "New house numbers, last year, as of {}"
 msgstr "Új házszámok, elmúlt év, frissítve: {}"
 
-#: webframe.py:495
+#: webframe.py:489
 msgid "New house numbers, monthly"
 msgstr "Új házszámok, havonta"
 
-#: wsgi.py:114 wsgi.py:216 wsgi.py:240
+#: wsgi.py:114 wsgi.py:215 wsgi.py:239
 msgid "No existing house numbers"
 msgstr "Nincsenek meglévő házszámok"
 
-#: webframe.py:619
+#: webframe.py:613
 msgid "No existing house numbers: call Overpass to create..."
 msgstr "Nincsenek meglévő házszámok: létrehozás Overpass hívásával..."
 
-#: webframe.py:623
+#: webframe.py:617
 msgid "No existing house numbers: waiting for Overpass..."
 msgstr "Nincsenek meglévő házszámok: Overpass: várakozás..."
 
-#: wsgi.py:214 wsgi.py:238 wsgi.py:277 wsgi_additional.py:32
+#: wsgi.py:213 wsgi.py:237 wsgi.py:276 wsgi_additional.py:31
 msgid "No existing streets"
 msgstr "Nincsenek meglévő utcák"
 
-#: webframe.py:597
+#: webframe.py:591
 msgid "No existing streets: call Overpass to create..."
 msgstr "Nincsenek meglévő utcák: létrehozás Overpass hívásával..."
 
-#: webframe.py:601
+#: webframe.py:595
 msgid "No existing streets: waiting for Overpass..."
 msgstr "Nincsenek meglévő utcák: Overpass: várakozás..."
 
-#: wsgi.py:218 wsgi.py:242
+#: wsgi.py:217 wsgi.py:241
 msgid "No reference house numbers"
 msgstr "Nincsenek referencia házszámok"
 
-#: webframe.py:641
+#: webframe.py:635
 msgid "No reference house numbers: create from reference..."
 msgstr "Nincsenek referencia házszámok: létrehozás referenciából..."
 
-#: webframe.py:645
+#: webframe.py:639
 msgid "No reference house numbers: creating from reference..."
 msgstr "Nincsenek referencia házszámok: létrehozás referenciából..."
 
-#: wsgi.py:279 wsgi_additional.py:34
+#: wsgi.py:278 wsgi_additional.py:33
 msgid "No reference streets"
 msgstr "Nincsenek referencia utcák"
 
-#: webframe.py:667
+#: webframe.py:661
 msgid "No reference streets: creating from reference..."
 msgstr "Nincsenek referencia utcák: létrehozás referenciából..."
 
-#: webframe.py:663
+#: webframe.py:657
 msgid "No street list: create from reference..."
 msgstr "Nincsenek referencia utcák: létrehozás referenciából..."
 
-#: webframe.py:587
+#: webframe.py:581
 #, python-brace-format
 msgid "No such relation: {0}"
 msgstr "Nincs ilyen reláció: {0}"
 
-#: webframe.py:338
+#: webframe.py:343
 msgid "Not Found"
 msgstr "Nem található"
 
-#: webframe.py:408 webframe.py:530
+#: webframe.py:402 webframe.py:524
 msgid "Note"
 msgstr "Megjegyzés"
 
-#: util.py:573
+#: util.py:577
 msgid "Note: an OSM name is invalid if it's not in the OSM database."
 msgstr ""
 "Megjegyzés: egy OSM név érvénytelen ha nem szerepel az OSM adatbázisban."
 
-#: util.py:469
+#: util.py:473
 msgid "Note: wait for {} seconds"
 msgstr "Megjegyzés: {} másodperc várakozás szükséges"
 
-#: webframe.py:480
+#: webframe.py:474
 msgid ""
 "Number of editors, at least one housenumber is last changed by these users"
 msgstr ""
 "Szerkesztők száma, legalább egy házszámot ezek a szerkesztők változtattak "
 "meg utoljára"
 
-#: webframe.py:478
+#: webframe.py:472
 msgid "Number of house number editors, as of {}"
 msgstr "Házszám szerkesztők száma, frissítve: {}"
 
-#: webframe.py:475
+#: webframe.py:469
 msgid "Number of house numbers added in the past 30 days"
 msgstr "Az elmúlt 30 napban hozzáadott házszámok száma"
 
-#: webframe.py:482
+#: webframe.py:476
 msgid "Number of house numbers in database"
 msgstr "Adatbázisban szereplő házszámok száma"
 
-#: webframe.py:472
+#: webframe.py:466
 msgid "Number of house numbers last changed by this user"
 msgstr "Felhasználó által utoljára módosított házszámok száma"
 
-#: webframe.py:395
+#: webframe.py:389
 msgid "OSM count"
 msgstr "OSM szám"
 
-#: webframe.py:46
+#: webframe.py:44
 msgid "OSM data © OpenStreetMap contributors."
 msgstr "OSM adatok © OpenStreetMap közreműködők."
 
-#: cache.py:117
+#: cache.py:118
 #, python-brace-format
 msgid ""
 "OpenStreetMap additionally has the below {0} house numbers for {1} streets."
@@ -329,12 +329,12 @@ msgstr ""
 "Az OpenStreetmap tartalmazza a lenti {1} utcához tartozó további {0} "
 "házszámot."
 
-#: wsgi_additional.py:81
+#: wsgi_additional.py:86
 #, python-brace-format
 msgid "OpenStreetMap additionally has the below {0} streets."
 msgstr "Az OpenStreetMap tartalmazza a lenti {0} további utcát."
 
-#: cache.py:78
+#: cache.py:79
 #, python-brace-format
 msgid ""
 "OpenStreetMap is possibly missing the below {0} house numbers for {1} "
@@ -343,65 +343,65 @@ msgstr ""
 "Elképzelhető, hogy az OpenStreetMap nem tartalmazza a lenti {1} utcához "
 "tartozó {0} házszámot."
 
-#: wsgi.py:187
+#: wsgi.py:186
 #, python-brace-format
 msgid "OpenStreetMap is possibly missing the below {0} streets."
 msgstr "Elképzelhető, hogy az OpenStreetMap nem tartalmazza a lenti {0} utcát."
 
-#: util.py:465
+#: util.py:469
 #, python-brace-format
 msgid "Overpass error: {0}"
 msgstr "Overpass error: {0}"
 
-#: webframe.py:204
+#: webframe.py:209
 msgid "Overpass turbo"
 msgstr "Overpass turbo"
 
-#: wsgi.py:191
+#: wsgi.py:190
 msgid "Overpass turbo query for streets with questionable names"
 msgstr "Overpass lekérdezés a kérdéses nevű utcákra"
 
-#: cache.py:87 wsgi_additional.py:90
+#: cache.py:88 wsgi_additional.py:95
 msgid "Overpass turbo query for the below streets"
 msgstr "Overpass lekérdezés a lenti utcákra"
 
-#: webframe.py:501
+#: webframe.py:495
 msgid "Per-city coverage"
 msgstr "Városonkénti lefedettség"
 
-#: cache.py:90 wsgi.py:194 wsgi_additional.py:84
+#: cache.py:91 wsgi.py:193 wsgi_additional.py:89
 msgid "Plain text format"
 msgstr "Egyszerű szöveg formátum"
 
-#: webframe.py:396
+#: webframe.py:390
 msgid "Reference count"
 msgstr "Referencia szám"
 
-#: wsgi.py:649
+#: wsgi.py:651
 msgid "Show complete areas"
 msgstr "Kész területek mutatása"
 
-#: wsgi_additional.py:65
+#: wsgi_additional.py:70
 msgid "Source"
 msgstr "Forrás"
 
-#: webframe.py:216
+#: webframe.py:221
 msgid "Statistics"
 msgstr "Statisztikák"
 
-#: wsgi.py:777
+#: wsgi.py:780
 msgid "Street coverage"
 msgstr "Utca lefedettség"
 
-#: areas.py:577 wsgi.py:182 wsgi_additional.py:66
+#: areas.py:582 wsgi.py:181 wsgi_additional.py:71
 msgid "Street name"
 msgstr "Utcanév"
 
-#: webframe.py:340
+#: webframe.py:345
 msgid "The requested URL was not found on this server."
 msgstr "A kért URL nem található ezen a kiszolgálón."
 
-#: webframe.py:410
+#: webframe.py:404
 msgid ""
 "These statistics are estimates, not taking house number filters into "
 "account.\n"
@@ -410,7 +410,7 @@ msgstr ""
 "Ezek a statisztikák becslések, nem véve figyelembe a házszám szűrőket.\n"
 "Csak olyan városok szerepelnek benne, amiknek van az OSM-ben házszámuk."
 
-#: webframe.py:532
+#: webframe.py:526
 msgid ""
 "These statistics are provided purely for interested editors, and are not\n"
 "intended to reflect quality of work done by any given editor in OSM. If you "
@@ -424,75 +424,75 @@ msgstr ""
 "használni, hogy motiváljad magad, az rendben van, de ne felejtsd, hogy "
 "kevesebb hasznos munka többet ér, mint sok haszontalan munka."
 
-#: webframe.py:498
+#: webframe.py:492
 msgid "Top edited cities"
 msgstr "Legaktívabb városok"
 
-#: webframe.py:473
+#: webframe.py:467
 msgid "Top edited cities, as of {}"
 msgstr "Legaktívabb városok, frissítve: {}"
 
-#: webframe.py:497
+#: webframe.py:491
 msgid "Top house number editors"
 msgstr "Legaktívabb házszám szerkesztők"
 
-#: webframe.py:470
+#: webframe.py:464
 msgid "Top house number editors, as of {}"
 msgstr "Legaktívabb házszám szerkesztők, frissítve: {}"
 
-#: wsgi_additional.py:64
+#: wsgi_additional.py:69
 msgid "Type"
 msgstr "Típus"
 
-#: webframe.py:68 webframe.py:82
+#: webframe.py:66 webframe.py:80
 msgid "Update from OSM"
 msgstr "Frissítés OSM-ből"
 
-#: webframe.py:74 webframe.py:88
+#: webframe.py:72 webframe.py:86
 msgid "Update from reference"
 msgstr "Frissítés referenciából"
 
-#: wsgi.py:72 wsgi.py:311
+#: wsgi.py:73 wsgi.py:310
 msgid "Update successful."
 msgstr "Frissítés sikeres."
 
-#: wsgi.py:68 wsgi.py:105 wsgi.py:297
+#: wsgi.py:69 wsgi.py:107 wsgi.py:296
 msgid "Update successful: "
 msgstr "Frissítés sikeres: "
 
-#: webframe.py:471
+#: webframe.py:465
 msgid "User name"
 msgstr "Felhasználó neve"
 
-#: webframe.py:43
+#: webframe.py:41
 msgid "Version: "
 msgstr "Verzió: "
 
-#: wsgi.py:70 wsgi.py:107 wsgi.py:300
+#: wsgi.py:71 wsgi.py:109 wsgi.py:299
 msgid "View missing house numbers"
 msgstr "Hiányzó házszámok megtekintése"
 
-#: webframe.py:98 webframe.py:108
+#: webframe.py:96 webframe.py:106
 msgid "View query"
 msgstr "Lekérdezés megtekintése"
 
-#: wsgi.py:668
+#: wsgi.py:670
 msgid "Waiting for GPS..."
 msgstr "GPS: várakozás..."
 
-#: webframe.py:191 wsgi.py:670
+#: webframe.py:196 wsgi.py:672
 msgid "Waiting for Overpass..."
 msgstr "Overpass: várakozás..."
 
-#: wsgi.py:674
+#: wsgi.py:676
 msgid "Waiting for redirect..."
 msgstr "Átirányítás: várakozás..."
 
-#: wsgi.py:672
+#: wsgi.py:674
 msgid "Waiting for relations..."
 msgstr "Területek: várakozás..."
 
-#: util.py:558
+#: util.py:562
 msgid ""
 "Warning: broken OSM <-> reference mapping, the following OSM names are "
 "invalid:"
@@ -500,7 +500,7 @@ msgstr ""
 "Figyelem: sérült OSM <-> referencia hozzárendelés, a következő OSM nevek "
 "érvénytelenek:"
 
-#: util.py:566
+#: util.py:570
 msgid ""
 "Warning: broken OSM <-> reference mapping, the following reference names are "
 "invalid:"
@@ -508,45 +508,45 @@ msgstr ""
 "Figyelem: sérült OSM <-> referencia hozzárendelés, a következő referencia "
 "nevek érvénytelenek:"
 
-#: util.py:584
+#: util.py:588
 msgid ""
 "Warning: broken filter key name, the following key names are not OSM names:"
 msgstr ""
 "Figyelem: sérült szűrő kulcs név, a következő kulcs nevek nem OSM nevek:"
 
-#: wsgi.py:657 wsgi.py:820
+#: wsgi.py:659 wsgi.py:823
 msgid "Where to map?"
 msgstr "Hol térképezzek?"
 
-#: wsgi.py:570
+#: wsgi.py:565
 msgid "additional house numbers"
 msgstr "további házszámok"
 
-#: wsgi.py:544
+#: wsgi.py:539
 msgid "additional streets"
 msgstr "további utcák"
 
-#: wsgi.py:754
+#: wsgi.py:757
 msgid "area boundary"
 msgstr "terület határa"
 
-#: wsgi.py:807
+#: wsgi.py:810
 msgid "existing house numbers"
 msgstr "meglévő házszámok"
 
-#: wsgi.py:809
+#: wsgi.py:812
 msgid "existing streets"
 msgstr "meglévő utcák"
 
-#: util.py:685
+#: util.py:689
 msgid "housenumber"
 msgstr "házszám"
 
-#: wsgi.py:500
+#: wsgi.py:495
 msgid "missing house numbers"
 msgstr "hiányzó házszámok"
 
-#: wsgi.py:522 wsgi.py:805
+#: wsgi.py:517 wsgi.py:808
 msgid "missing streets"
 msgstr "hiányzó utcák"
 
@@ -554,19 +554,19 @@ msgstr "hiányzó utcák"
 msgid "street"
 msgstr "utca"
 
-#: wsgi.py:494 wsgi.py:516 wsgi.py:538 wsgi.py:564
+#: wsgi.py:489 wsgi.py:511 wsgi.py:533 wsgi.py:559
 msgid "updated"
 msgstr "frissítve"
 
-#: wsgi.py:803
+#: wsgi.py:806
 #, python-brace-format
 msgid "{0} missing house numbers"
 msgstr "{0} hiányzó házszámok"
 
-#: wsgi.py:565
+#: wsgi.py:560
 msgid "{} house numbers"
 msgstr "{} házszám"
 
-#: wsgi.py:539
+#: wsgi.py:534
 msgid "{} streets"
 msgstr "{} utca"

--- a/po/osm-gimmisn.pot
+++ b/po/osm-gimmisn.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-28 22:59+0200\n"
+"POT-Creation-Date: 2021-07-02 21:40+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,391 +17,391 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: cache.py:80 wsgi.py:188
+#: cache.py:81 wsgi.py:187
 #, python-brace-format
 msgid " (existing: {0}, ready: {1})."
 msgstr ""
 
-#: webframe.py:476
+#: webframe.py:470
 msgid "(empty)"
 msgstr ""
 
-#: webframe.py:477
+#: webframe.py:471
 msgid "(invalid)"
 msgstr ""
 
-#: util.py:574
+#: util.py:578
 msgid "A reference name is invalid if it's in the OSM database."
 msgstr ""
 
-#: wsgi.py:787
+#: wsgi.py:790
 msgid "Add new area"
 msgstr ""
 
-#: webframe.py:129 wsgi.py:776
+#: webframe.py:128 wsgi.py:779
 msgid "Additional house numbers"
 msgstr ""
 
-#: webframe.py:138 wsgi.py:778
+#: webframe.py:137 wsgi.py:781
 msgid "Additional streets"
 msgstr ""
 
-#: webframe.py:479
+#: webframe.py:473
 msgid "All editors"
 msgstr ""
 
-#: webframe.py:499
+#: webframe.py:493
 msgid "All house number editors"
 msgstr ""
 
-#: webframe.py:466 webframe.py:469 webframe.py:494
+#: webframe.py:460 webframe.py:463 webframe.py:488
 msgid "All house numbers"
 msgstr ""
 
-#: webframe.py:467
+#: webframe.py:461
 msgid "All house numbers, last 2 weeks, as of {}"
 msgstr ""
 
-#: webframe.py:464
+#: webframe.py:458
 msgid "All house numbers, last year, as of {}"
 msgstr ""
 
-#: webframe.py:496
+#: webframe.py:490
 msgid "All house numbers, monthly"
 msgstr ""
 
-#: wsgi.py:774
+#: wsgi.py:777
 msgid "Area"
 msgstr ""
 
-#: webframe.py:210 wsgi.py:779
+#: webframe.py:215 wsgi.py:782
 msgid "Area boundary"
 msgstr ""
 
-#: webframe.py:175
+#: webframe.py:180
 msgid "Area list"
 msgstr ""
 
-#: webframe.py:468
+#: webframe.py:462
 msgid "At the start of this day"
 msgstr ""
 
-#: wsgi.py:643
+#: wsgi.py:645
 msgid "Based on position"
 msgstr ""
 
-#: webframe.py:94 webframe.py:104
+#: webframe.py:92 webframe.py:102
 msgid "Call Overpass to update"
 msgstr ""
 
-#: cache.py:93 wsgi.py:197 wsgi_additional.py:87
+#: cache.py:94 wsgi.py:196 wsgi_additional.py:92
 msgid "Checklist format"
 msgstr ""
 
-#: webframe.py:393 webframe.py:474
+#: webframe.py:387 webframe.py:468
 msgid "City name"
 msgstr ""
 
-#: webframe.py:500
+#: webframe.py:494
 msgid "Coverage"
 msgstr ""
 
-#: webframe.py:481
+#: webframe.py:475
 #, python-brace-format
 msgid "Coverage is {1}%, as of {2}"
 msgstr ""
 
-#: webframe.py:193
+#: webframe.py:198
 msgid "Creating from reference..."
 msgstr ""
 
-#: webframe.py:483
+#: webframe.py:477
 msgid "Data source"
 msgstr ""
 
-#: webframe.py:221
+#: webframe.py:226
 msgid "Documentation"
 msgstr ""
 
-#: webframe.py:459
+#: webframe.py:453
 msgid "During this day"
 msgstr ""
 
-#: webframe.py:462
+#: webframe.py:456
 msgid "During this month"
 msgstr ""
 
-#: wsgi.py:669
+#: wsgi.py:671
 msgid "Error from GPS: "
 msgstr ""
 
-#: webframe.py:192 webframe.py:602 webframe.py:624 wsgi.py:671
+#: webframe.py:197 webframe.py:596 webframe.py:618 wsgi.py:673
 msgid "Error from Overpass: "
 msgstr ""
 
-#: webframe.py:194 webframe.py:646 webframe.py:668
+#: webframe.py:199 webframe.py:640 webframe.py:662
 msgid "Error from reference: "
 msgstr ""
 
-#: wsgi.py:673
+#: wsgi.py:675
 msgid "Error from relations: "
 msgstr ""
 
-#: webframe.py:148
+#: webframe.py:152
 msgid "Existing house numbers"
 msgstr ""
 
-#: webframe.py:153
+#: webframe.py:157
 msgid "Existing streets"
 msgstr ""
 
-#: cache.py:83 cache.py:121
+#: cache.py:84 cache.py:122
 msgid "Filter incorrect information"
 msgstr ""
 
-#: wsgi.py:659
+#: wsgi.py:661
 msgid "Filters:"
 msgstr ""
 
-#: webframe.py:394 wsgi.py:775
+#: webframe.py:388 wsgi.py:778
 msgid "House number coverage"
 msgstr ""
 
-#: areas.py:579
+#: areas.py:584
 msgid "House numbers"
 msgstr ""
 
-#: wsgi_additional.py:63
+#: wsgi_additional.py:68
 msgid "Identifier"
 msgstr ""
 
-#: webframe.py:325
+#: webframe.py:330
 #, python-brace-format
 msgid "Internal error when serving {0}"
 msgstr ""
 
-#: webframe.py:502
+#: webframe.py:496
 msgid "Invalid relation settings"
 msgstr ""
 
-#: webframe.py:48
+#: webframe.py:46
 msgid "Last update: "
 msgstr ""
 
-#: webframe.py:465
+#: webframe.py:459
 msgid "Latest for this month"
 msgstr ""
 
-#: areas.py:578
+#: areas.py:583
 msgid "Missing count"
 msgstr ""
 
-#: webframe.py:123
+#: webframe.py:122
 msgid "Missing house numbers"
 msgstr ""
 
-#: webframe.py:134
+#: webframe.py:133
 msgid "Missing streets"
 msgstr ""
 
-#: webframe.py:460 webframe.py:463 webframe.py:493
+#: webframe.py:454 webframe.py:457 webframe.py:487
 msgid "New house numbers"
 msgstr ""
 
-#: webframe.py:458
+#: webframe.py:452
 msgid "New house numbers, last 2 weeks, as of {}"
 msgstr ""
 
-#: webframe.py:461
+#: webframe.py:455
 msgid "New house numbers, last year, as of {}"
 msgstr ""
 
-#: webframe.py:495
+#: webframe.py:489
 msgid "New house numbers, monthly"
 msgstr ""
 
-#: wsgi.py:114 wsgi.py:216 wsgi.py:240
+#: wsgi.py:114 wsgi.py:215 wsgi.py:239
 msgid "No existing house numbers"
 msgstr ""
 
-#: webframe.py:619
+#: webframe.py:613
 msgid "No existing house numbers: call Overpass to create..."
 msgstr ""
 
-#: webframe.py:623
+#: webframe.py:617
 msgid "No existing house numbers: waiting for Overpass..."
 msgstr ""
 
-#: wsgi.py:214 wsgi.py:238 wsgi.py:277 wsgi_additional.py:32
+#: wsgi.py:213 wsgi.py:237 wsgi.py:276 wsgi_additional.py:31
 msgid "No existing streets"
 msgstr ""
 
-#: webframe.py:597
+#: webframe.py:591
 msgid "No existing streets: call Overpass to create..."
 msgstr ""
 
-#: webframe.py:601
+#: webframe.py:595
 msgid "No existing streets: waiting for Overpass..."
 msgstr ""
 
-#: wsgi.py:218 wsgi.py:242
+#: wsgi.py:217 wsgi.py:241
 msgid "No reference house numbers"
 msgstr ""
 
-#: webframe.py:641
+#: webframe.py:635
 msgid "No reference house numbers: create from reference..."
 msgstr ""
 
-#: webframe.py:645
+#: webframe.py:639
 msgid "No reference house numbers: creating from reference..."
 msgstr ""
 
-#: wsgi.py:279 wsgi_additional.py:34
+#: wsgi.py:278 wsgi_additional.py:33
 msgid "No reference streets"
 msgstr ""
 
-#: webframe.py:667
+#: webframe.py:661
 msgid "No reference streets: creating from reference..."
 msgstr ""
 
-#: webframe.py:663
+#: webframe.py:657
 msgid "No street list: create from reference..."
 msgstr ""
 
-#: webframe.py:587
+#: webframe.py:581
 #, python-brace-format
 msgid "No such relation: {0}"
 msgstr ""
 
-#: webframe.py:338
+#: webframe.py:343
 msgid "Not Found"
 msgstr ""
 
-#: webframe.py:408 webframe.py:530
+#: webframe.py:402 webframe.py:524
 msgid "Note"
 msgstr ""
 
-#: util.py:573
+#: util.py:577
 msgid "Note: an OSM name is invalid if it's not in the OSM database."
 msgstr ""
 
-#: util.py:469
+#: util.py:473
 msgid "Note: wait for {} seconds"
 msgstr ""
 
-#: webframe.py:480
+#: webframe.py:474
 msgid ""
 "Number of editors, at least one housenumber is last changed by these users"
 msgstr ""
 
-#: webframe.py:478
+#: webframe.py:472
 msgid "Number of house number editors, as of {}"
 msgstr ""
 
-#: webframe.py:475
+#: webframe.py:469
 msgid "Number of house numbers added in the past 30 days"
 msgstr ""
 
-#: webframe.py:482
+#: webframe.py:476
 msgid "Number of house numbers in database"
 msgstr ""
 
-#: webframe.py:472
+#: webframe.py:466
 msgid "Number of house numbers last changed by this user"
 msgstr ""
 
-#: webframe.py:395
+#: webframe.py:389
 msgid "OSM count"
 msgstr ""
 
-#: webframe.py:46
+#: webframe.py:44
 msgid "OSM data © OpenStreetMap contributors."
 msgstr ""
 
-#: cache.py:117
+#: cache.py:118
 #, python-brace-format
 msgid ""
 "OpenStreetMap additionally has the below {0} house numbers for {1} streets."
 msgstr ""
 
-#: wsgi_additional.py:81
+#: wsgi_additional.py:86
 #, python-brace-format
 msgid "OpenStreetMap additionally has the below {0} streets."
 msgstr ""
 
-#: cache.py:78
+#: cache.py:79
 #, python-brace-format
 msgid ""
 "OpenStreetMap is possibly missing the below {0} house numbers for {1} "
 "streets."
 msgstr ""
 
-#: wsgi.py:187
+#: wsgi.py:186
 #, python-brace-format
 msgid "OpenStreetMap is possibly missing the below {0} streets."
 msgstr ""
 
-#: util.py:465
+#: util.py:469
 #, python-brace-format
 msgid "Overpass error: {0}"
 msgstr ""
 
-#: webframe.py:204
+#: webframe.py:209
 msgid "Overpass turbo"
 msgstr ""
 
-#: wsgi.py:191
+#: wsgi.py:190
 msgid "Overpass turbo query for streets with questionable names"
 msgstr ""
 
-#: cache.py:87 wsgi_additional.py:90
+#: cache.py:88 wsgi_additional.py:95
 msgid "Overpass turbo query for the below streets"
 msgstr ""
 
-#: webframe.py:501
+#: webframe.py:495
 msgid "Per-city coverage"
 msgstr ""
 
-#: cache.py:90 wsgi.py:194 wsgi_additional.py:84
+#: cache.py:91 wsgi.py:193 wsgi_additional.py:89
 msgid "Plain text format"
 msgstr ""
 
-#: webframe.py:396
+#: webframe.py:390
 msgid "Reference count"
 msgstr ""
 
-#: wsgi.py:649
+#: wsgi.py:651
 msgid "Show complete areas"
 msgstr ""
 
-#: wsgi_additional.py:65
+#: wsgi_additional.py:70
 msgid "Source"
 msgstr ""
 
-#: webframe.py:216
+#: webframe.py:221
 msgid "Statistics"
 msgstr ""
 
-#: wsgi.py:777
+#: wsgi.py:780
 msgid "Street coverage"
 msgstr ""
 
-#: areas.py:577 wsgi.py:182 wsgi_additional.py:66
+#: areas.py:582 wsgi.py:181 wsgi_additional.py:71
 msgid "Street name"
 msgstr ""
 
-#: webframe.py:340
+#: webframe.py:345
 msgid "The requested URL was not found on this server."
 msgstr ""
 
-#: webframe.py:410
+#: webframe.py:404
 msgid ""
 "These statistics are estimates, not taking house number filters into "
 "account.\n"
 "Only cities with house numbers in OSM are considered."
 msgstr ""
 
-#: webframe.py:532
+#: webframe.py:526
 msgid ""
 "These statistics are provided purely for interested editors, and are not\n"
 "intended to reflect quality of work done by any given editor in OSM. If you "
@@ -411,124 +411,124 @@ msgid ""
 "more meaningful than a lot of useless work."
 msgstr ""
 
-#: webframe.py:498
+#: webframe.py:492
 msgid "Top edited cities"
 msgstr ""
 
-#: webframe.py:473
+#: webframe.py:467
 msgid "Top edited cities, as of {}"
 msgstr ""
 
-#: webframe.py:497
+#: webframe.py:491
 msgid "Top house number editors"
 msgstr ""
 
-#: webframe.py:470
+#: webframe.py:464
 msgid "Top house number editors, as of {}"
 msgstr ""
 
-#: wsgi_additional.py:64
+#: wsgi_additional.py:69
 msgid "Type"
 msgstr ""
 
-#: webframe.py:68 webframe.py:82
+#: webframe.py:66 webframe.py:80
 msgid "Update from OSM"
 msgstr ""
 
-#: webframe.py:74 webframe.py:88
+#: webframe.py:72 webframe.py:86
 msgid "Update from reference"
 msgstr ""
 
-#: wsgi.py:72 wsgi.py:311
+#: wsgi.py:73 wsgi.py:310
 msgid "Update successful."
 msgstr ""
 
-#: wsgi.py:68 wsgi.py:105 wsgi.py:297
+#: wsgi.py:69 wsgi.py:107 wsgi.py:296
 msgid "Update successful: "
 msgstr ""
 
-#: webframe.py:471
+#: webframe.py:465
 msgid "User name"
 msgstr ""
 
-#: webframe.py:43
+#: webframe.py:41
 msgid "Version: "
 msgstr ""
 
-#: wsgi.py:70 wsgi.py:107 wsgi.py:300
+#: wsgi.py:71 wsgi.py:109 wsgi.py:299
 msgid "View missing house numbers"
 msgstr ""
 
-#: webframe.py:98 webframe.py:108
+#: webframe.py:96 webframe.py:106
 msgid "View query"
 msgstr ""
 
-#: wsgi.py:668
+#: wsgi.py:670
 msgid "Waiting for GPS..."
 msgstr ""
 
-#: webframe.py:191 wsgi.py:670
+#: webframe.py:196 wsgi.py:672
 msgid "Waiting for Overpass..."
 msgstr ""
 
-#: wsgi.py:674
+#: wsgi.py:676
 msgid "Waiting for redirect..."
 msgstr ""
 
-#: wsgi.py:672
+#: wsgi.py:674
 msgid "Waiting for relations..."
 msgstr ""
 
-#: util.py:558
+#: util.py:562
 msgid ""
 "Warning: broken OSM <-> reference mapping, the following OSM names are "
 "invalid:"
 msgstr ""
 
-#: util.py:566
+#: util.py:570
 msgid ""
 "Warning: broken OSM <-> reference mapping, the following reference names are "
 "invalid:"
 msgstr ""
 
-#: util.py:584
+#: util.py:588
 msgid ""
 "Warning: broken filter key name, the following key names are not OSM names:"
 msgstr ""
 
-#: wsgi.py:657 wsgi.py:820
+#: wsgi.py:659 wsgi.py:823
 msgid "Where to map?"
 msgstr ""
 
-#: wsgi.py:570
+#: wsgi.py:565
 msgid "additional house numbers"
 msgstr ""
 
-#: wsgi.py:544
+#: wsgi.py:539
 msgid "additional streets"
 msgstr ""
 
-#: wsgi.py:754
+#: wsgi.py:757
 msgid "area boundary"
 msgstr ""
 
-#: wsgi.py:807
+#: wsgi.py:810
 msgid "existing house numbers"
 msgstr ""
 
-#: wsgi.py:809
+#: wsgi.py:812
 msgid "existing streets"
 msgstr ""
 
-#: util.py:685
+#: util.py:689
 msgid "housenumber"
 msgstr ""
 
-#: wsgi.py:500
+#: wsgi.py:495
 msgid "missing house numbers"
 msgstr ""
 
-#: wsgi.py:522 wsgi.py:805
+#: wsgi.py:517 wsgi.py:808
 msgid "missing streets"
 msgstr ""
 
@@ -536,19 +536,19 @@ msgstr ""
 msgid "street"
 msgstr ""
 
-#: wsgi.py:494 wsgi.py:516 wsgi.py:538 wsgi.py:564
+#: wsgi.py:489 wsgi.py:511 wsgi.py:533 wsgi.py:559
 msgid "updated"
 msgstr ""
 
-#: wsgi.py:803
+#: wsgi.py:806
 #, python-brace-format
 msgid "{0} missing house numbers"
 msgstr ""
 
-#: wsgi.py:565
+#: wsgi.py:560
 msgid "{} house numbers"
 msgstr ""
 
-#: wsgi.py:539
+#: wsgi.py:534
 msgid "{} streets"
 msgstr ""

--- a/util.py
+++ b/util.py
@@ -28,7 +28,7 @@ import email.utils
 
 import yattag
 
-from i18n import translate as _
+from i18n import translate as tr
 import accept_language
 import config
 import i18n
@@ -466,11 +466,11 @@ def handle_overpass_error(conf: config.Config, http_error: str) -> yattag.doc.Do
     """Handles a HTTP error from Overpass."""
     doc = yattag.doc.Doc()
     with doc.tag("div", id="overpass-error"):
-        doc.text(_("Overpass error: {0}").format(http_error))
+        doc.text(tr("Overpass error: {0}").format(http_error))
         sleep = overpass_query.overpass_query_need_sleep(conf)
         if sleep:
             doc.stag("br")
-            doc.text(_("Note: wait for {} seconds").format(sleep))
+            doc.text(tr("Note: wait for {} seconds").format(sleep))
     return doc
 
 
@@ -559,7 +559,7 @@ def invalid_refstreets_to_html(invalids: Tuple[List[str], List[str]]) -> yattag.
     if osm_invalids:
         doc.stag("br")
         with doc.tag("div", id="osm-invalids-container"):
-            doc.text(_("Warning: broken OSM <-> reference mapping, the following OSM names are invalid:"))
+            doc.text(tr("Warning: broken OSM <-> reference mapping, the following OSM names are invalid:"))
             with doc.tag("ul"):
                 for osm_invalid in osm_invalids:
                     with doc.tag("li"):
@@ -567,15 +567,15 @@ def invalid_refstreets_to_html(invalids: Tuple[List[str], List[str]]) -> yattag.
     if ref_invalids:
         doc.stag("br")
         with doc.tag("div", id="ref-invalids-container"):
-            doc.text(_("Warning: broken OSM <-> reference mapping, the following reference names are invalid:"))
+            doc.text(tr("Warning: broken OSM <-> reference mapping, the following reference names are invalid:"))
             with doc.tag("ul"):
                 for ref_invalid in ref_invalids:
                     with doc.tag("li"):
                         doc.text(ref_invalid)
     if osm_invalids or ref_invalids:
         doc.stag("br")
-        doc.text(_("Note: an OSM name is invalid if it's not in the OSM database."))
-        doc.text(_("A reference name is invalid if it's in the OSM database."))
+        doc.text(tr("Note: an OSM name is invalid if it's not in the OSM database."))
+        doc.text(tr("A reference name is invalid if it's in the OSM database."))
     return doc
 
 
@@ -585,7 +585,7 @@ def invalid_filter_keys_to_html(invalids: List[str]) -> yattag.doc.Doc:
     if invalids:
         doc.stag("br")
         with doc.tag("div", id="osm-filter-key-invalids-container"):
-            doc.text(_("Warning: broken filter key name, the following key names are not OSM names:"))
+            doc.text(tr("Warning: broken filter key name, the following key names are not OSM names:"))
             with doc.tag("ul"):
                 for invalid in invalids:
                     with doc.tag("li"):
@@ -686,7 +686,7 @@ def get_street_from_housenumber(sock: CsvIO) -> List[Street]:
             osm_id = 0
         street = Street(osm_id=osm_id, osm_name=street_name)
         street.set_osm_type(osm_type)
-        street.set_source(_("housenumber"))
+        street.set_source(tr("housenumber"))
         ret.append(street)
 
     return ret

--- a/webframe.py
+++ b/webframe.py
@@ -23,7 +23,7 @@ import xmlrpc.client
 
 import yattag
 
-from i18n import translate as _
+from i18n import translate as tr
 import areas
 import config
 import util
@@ -38,12 +38,12 @@ def get_footer(last_updated: str = "") -> yattag.doc.Doc:
     """Produces the end of the page."""
     items: List[yattag.doc.Doc] = []
     doc = yattag.doc.Doc()
-    doc.text(_("Version: "))
+    doc.text(tr("Version: "))
     doc.asis(util.git_link(version.VERSION, "https://github.com/vmiklos/osm-gimmisn/commit/").getvalue())
     items.append(doc)
-    items.append(util.html_escape(_("OSM data © OpenStreetMap contributors.")))
+    items.append(util.html_escape(tr("OSM data © OpenStreetMap contributors.")))
     if last_updated:
-        items.append(util.html_escape(_("Last update: ") + last_updated))
+        items.append(util.html_escape(tr("Last update: ") + last_updated))
     doc = yattag.doc.Doc()
     doc.stag("hr")
     with doc.tag("div"):
@@ -63,13 +63,13 @@ def fill_header_function(conf: config.Config, function: str, relation_name: str,
         doc = yattag.doc.Doc()
         with doc.tag("span", id="trigger-street-housenumbers-update"):
             with doc.tag("a", href=prefix + "/street-housenumbers/" + relation_name + "/update-result"):
-                doc.text(_("Update from OSM"))
+                doc.text(tr("Update from OSM"))
         items.append(doc)
 
         doc = yattag.doc.Doc()
         with doc.tag("span", id="trigger-missing-housenumbers-update"):
             with doc.tag("a", href=prefix + "/missing-housenumbers/" + relation_name + "/update-result"):
-                doc.text(_("Update from reference"))
+                doc.text(tr("Update from reference"))
         items.append(doc)
     elif function in ("missing-streets", "additional-streets"):
         # The OSM data source changes much more frequently than the ref one, so add a dedicated link
@@ -77,33 +77,33 @@ def fill_header_function(conf: config.Config, function: str, relation_name: str,
         doc = yattag.doc.Doc()
         with doc.tag("span", id="trigger-streets-update"):
             with doc.tag("a", href=prefix + "/streets/" + relation_name + "/update-result"):
-                doc.text(_("Update from OSM"))
+                doc.text(tr("Update from OSM"))
         items.append(doc)
 
         doc = yattag.doc.Doc()
         with doc.tag("span", id="trigger-missing-streets-update"):
             with doc.tag("a", href=prefix + "/missing-streets/" + relation_name + "/update-result"):
-                doc.text(_("Update from reference"))
+                doc.text(tr("Update from reference"))
         items.append(doc)
     elif function == "street-housenumbers":
         doc = yattag.doc.Doc()
         with doc.tag("span", id="trigger-street-housenumbers-update"):
             with doc.tag("a", href=prefix + "/street-housenumbers/" + relation_name + "/update-result"):
-                doc.text(_("Call Overpass to update"))
+                doc.text(tr("Call Overpass to update"))
         items.append(doc)
         doc = yattag.doc.Doc()
         with doc.tag("a", href=prefix + "/street-housenumbers/" + relation_name + "/view-query"):
-            doc.text(_("View query"))
+            doc.text(tr("View query"))
         items.append(doc)
     elif function == "streets":
         doc = yattag.doc.Doc()
         with doc.tag("span", id="trigger-streets-update"):
             with doc.tag("a", href=prefix + "/streets/" + relation_name + "/update-result"):
-                doc.text(_("Call Overpass to update"))
+                doc.text(tr("Call Overpass to update"))
         items.append(doc)
         doc = yattag.doc.Doc()
         with doc.tag("a", href=prefix + "/streets/" + relation_name + "/view-query"):
-            doc.text(_("View query"))
+            doc.text(tr("View query"))
         items.append(doc)
 
 
@@ -119,22 +119,22 @@ def fill_missing_header_items(
     if streets != "only":
         doc = yattag.doc.Doc()
         with doc.tag("a", href=prefix + "/missing-housenumbers/" + relation_name + "/view-result"):
-            doc.text(_("Missing house numbers"))
+            doc.text(tr("Missing house numbers"))
         items.append(doc)
 
         if additional_housenumbers:
             doc = yattag.doc.Doc()
             with doc.tag("a", href=prefix + "/additional-housenumbers/" + relation_name + "/view-result"):
-                doc.text(_("Additional house numbers"))
+                doc.text(tr("Additional house numbers"))
             items.append(doc)
     if streets != "no":
         doc = yattag.doc.Doc()
         with doc.tag("a", href=prefix + "/missing-streets/" + relation_name + "/view-result"):
-            doc.text(_("Missing streets"))
+            doc.text(tr("Missing streets"))
         items.append(doc)
         doc = yattag.doc.Doc()
         with doc.tag("a", href=prefix + "/additional-streets/" + relation_name + "/view-result"):
-            doc.text(_("Additional streets"))
+            doc.text(tr("Additional streets"))
         items.append(doc)
 
 
@@ -149,12 +149,12 @@ def fill_existing_header_items(
     if streets != "only":
         doc = yattag.doc.Doc()
         with doc.tag("a", href=prefix + "/street-housenumbers/" + relation_name + "/view-result"):
-            doc.text(_("Existing house numbers"))
+            doc.text(tr("Existing house numbers"))
         items.append(doc)
 
     doc = yattag.doc.Doc()
     with doc.tag("a", href=prefix + "/streets/" + relation_name + "/view-result"):
-        doc.text(_("Existing streets"))
+        doc.text(tr("Existing streets"))
     items.append(doc)
 
 
@@ -177,7 +177,7 @@ def get_toolbar(
 
     doc = yattag.doc.Doc()
     with doc.tag("a", href=conf.get_uri_prefix() + "/"):
-        doc.text(_("Area list"))
+        doc.text(tr("Area list"))
     items.append(doc)
 
     if relation_name:
@@ -193,10 +193,10 @@ def get_toolbar(
     # Emit localized strings for JS purposes.
     with doc.tag("div", style="display: none;"):
         string_pairs = [
-            ("str-toolbar-overpass-wait", _("Waiting for Overpass...")),
-            ("str-toolbar-overpass-error", _("Error from Overpass: ")),
-            ("str-toolbar-reference-wait", _("Creating from reference...")),
-            ("str-toolbar-reference-error", _("Error from reference: ")),
+            ("str-toolbar-overpass-wait", tr("Waiting for Overpass...")),
+            ("str-toolbar-overpass-error", tr("Error from Overpass: ")),
+            ("str-toolbar-reference-wait", tr("Creating from reference...")),
+            ("str-toolbar-reference-error", tr("Error from reference: ")),
         ]
         for key, value in string_pairs:
             kwargs: Dict[str, str] = {}
@@ -206,24 +206,24 @@ def get_toolbar(
                 pass
 
     with doc.tag("a", href="https://overpass-turbo.eu/"):
-        doc.text(_("Overpass turbo"))
+        doc.text(tr("Overpass turbo"))
     items.append(doc)
 
     if relation_osmid:
         doc = yattag.doc.Doc()
         with doc.tag("a", href="https://www.openstreetmap.org/relation/" + str(relation_osmid)):
-            doc.text(_("Area boundary"))
+            doc.text(tr("Area boundary"))
         items.append(doc)
     else:
         # These are on the main page only.
         doc = yattag.doc.Doc()
         with doc.tag("a", href=conf.get_uri_prefix() + "/housenumber-stats/hungary/"):
-            doc.text(_("Statistics"))
+            doc.text(tr("Statistics"))
         items.append(doc)
 
         doc = yattag.doc.Doc()
         with doc.tag("a", href="https://github.com/vmiklos/osm-gimmisn/tree/master/doc"):
-            doc.text(_("Documentation"))
+            doc.text(tr("Documentation"))
         items.append(doc)
 
     doc = yattag.doc.Doc()
@@ -327,7 +327,7 @@ def handle_exception(
     doc = yattag.doc.Doc()
     util.write_html_header(doc)
     with doc.tag("pre"):
-        doc.text(_("Internal error when serving {0}").format(request_uri) + "\n")
+        doc.text(tr("Internal error when serving {0}").format(request_uri) + "\n")
         doc.text(traceback.format_exc())
     response_properties = Response("text/html", status, doc.getvalue().encode("utf-8"), [])
     return send_response(environ, start_response, response_properties)
@@ -340,9 +340,9 @@ def handle_404() -> yattag.doc.Doc:
     with doc.tag("html"):
         with doc.tag("body"):
             with doc.tag("h1"):
-                doc.text(_("Not Found"))
+                doc.text(tr("Not Found"))
             with doc.tag("p"):
-                doc.text(_("The requested URL was not found on this server."))
+                doc.text(tr("The requested URL was not found on this server."))
     return doc
 
 
@@ -384,10 +384,10 @@ def handle_stats_cityprogress(conf: config.Config, relations: areas.Relations) -
     cities = util.get_in_both(list(ref_citycounts.keys()), list(osm_citycounts.keys()))
     cities.sort(key=util.get_lexical_sort_key())
     table = []
-    table.append([util.html_escape(_("City name")),
-                  util.html_escape(_("House number coverage")),
-                  util.html_escape(_("OSM count")),
-                  util.html_escape(_("Reference count"))])
+    table.append([util.html_escape(tr("City name")),
+                  util.html_escape(tr("House number coverage")),
+                  util.html_escape(tr("OSM count")),
+                  util.html_escape(tr("Reference count"))])
     for city in cities:
         percent = "100.00"
         if ref_citycounts[city] > 0 and osm_citycounts[city] < ref_citycounts[city]:
@@ -399,9 +399,9 @@ def handle_stats_cityprogress(conf: config.Config, relations: areas.Relations) -
     doc.asis(util.html_table_from_list(table).getvalue())
 
     with doc.tag("h2"):
-        doc.text(_("Note"))
+        doc.text(tr("Note"))
     with doc.tag("div"):
-        doc.text(_("""These statistics are estimates, not taking house number filters into account.
+        doc.text(tr("""These statistics are estimates, not taking house number filters into account.
 Only cities with house numbers in OSM are considered."""))
 
     doc.asis(get_footer().getvalue())
@@ -449,32 +449,32 @@ def handle_stats(conf: config.Config, relations: areas.Relations, request_uri: s
     # Emit localized strings for JS purposes.
     with doc.tag("div", style="display: none;"):
         string_pairs = [
-            ("str-daily-title", _("New house numbers, last 2 weeks, as of {}")),
-            ("str-daily-x-axis", _("During this day")),
-            ("str-daily-y-axis", _("New house numbers")),
-            ("str-monthly-title", _("New house numbers, last year, as of {}")),
-            ("str-monthly-x-axis", _("During this month")),
-            ("str-monthly-y-axis", _("New house numbers")),
-            ("str-monthlytotal-title", _("All house numbers, last year, as of {}")),
-            ("str-monthlytotal-x-axis", _("Latest for this month")),
-            ("str-monthlytotal-y-axis", _("All house numbers")),
-            ("str-dailytotal-title", _("All house numbers, last 2 weeks, as of {}")),
-            ("str-dailytotal-x-axis", _("At the start of this day")),
-            ("str-dailytotal-y-axis", _("All house numbers")),
-            ("str-topusers-title", _("Top house number editors, as of {}")),
-            ("str-topusers-x-axis", _("User name")),
-            ("str-topusers-y-axis", _("Number of house numbers last changed by this user")),
-            ("str-topcities-title", _("Top edited cities, as of {}")),
-            ("str-topcities-x-axis", _("City name")),
-            ("str-topcities-y-axis", _("Number of house numbers added in the past 30 days")),
-            ("str-topcities-empty", _("(empty)")),
-            ("str-topcities-invalid", _("(invalid)")),
-            ("str-usertotal-title", _("Number of house number editors, as of {}")),
-            ("str-usertotal-x-axis", _("All editors")),
-            ("str-usertotal-y-axis", _("Number of editors, at least one housenumber is last changed by these users")),
-            ("str-progress-title", _("Coverage is {1}%, as of {2}")),
-            ("str-progress-x-axis", _("Number of house numbers in database")),
-            ("str-progress-y-axis", _("Data source")),
+            ("str-daily-title", tr("New house numbers, last 2 weeks, as of {}")),
+            ("str-daily-x-axis", tr("During this day")),
+            ("str-daily-y-axis", tr("New house numbers")),
+            ("str-monthly-title", tr("New house numbers, last year, as of {}")),
+            ("str-monthly-x-axis", tr("During this month")),
+            ("str-monthly-y-axis", tr("New house numbers")),
+            ("str-monthlytotal-title", tr("All house numbers, last year, as of {}")),
+            ("str-monthlytotal-x-axis", tr("Latest for this month")),
+            ("str-monthlytotal-y-axis", tr("All house numbers")),
+            ("str-dailytotal-title", tr("All house numbers, last 2 weeks, as of {}")),
+            ("str-dailytotal-x-axis", tr("At the start of this day")),
+            ("str-dailytotal-y-axis", tr("All house numbers")),
+            ("str-topusers-title", tr("Top house number editors, as of {}")),
+            ("str-topusers-x-axis", tr("User name")),
+            ("str-topusers-y-axis", tr("Number of house numbers last changed by this user")),
+            ("str-topcities-title", tr("Top edited cities, as of {}")),
+            ("str-topcities-x-axis", tr("City name")),
+            ("str-topcities-y-axis", tr("Number of house numbers added in the past 30 days")),
+            ("str-topcities-empty", tr("(empty)")),
+            ("str-topcities-invalid", tr("(invalid)")),
+            ("str-usertotal-title", tr("Number of house number editors, as of {}")),
+            ("str-usertotal-x-axis", tr("All editors")),
+            ("str-usertotal-y-axis", tr("Number of editors, at least one housenumber is last changed by these users")),
+            ("str-progress-title", tr("Coverage is {1}%, as of {2}")),
+            ("str-progress-x-axis", tr("Number of house numbers in database")),
+            ("str-progress-y-axis", tr("Data source")),
         ]
         for key, value in string_pairs:
             kwargs: Dict[str, str] = {}
@@ -484,16 +484,16 @@ def handle_stats(conf: config.Config, relations: areas.Relations, request_uri: s
                 pass
 
     title_ids = [
-        (_("New house numbers"), "daily"),
-        (_("All house numbers"), "dailytotal"),
-        (_("New house numbers, monthly"), "monthly"),
-        (_("All house numbers, monthly"), "monthlytotal"),
-        (_("Top house number editors"), "topusers"),
-        (_("Top edited cities"), "topcities"),
-        (_("All house number editors"), "usertotal"),
-        (_("Coverage"), "progress"),
-        (_("Per-city coverage"), "cityprogress"),
-        (_("Invalid relation settings"), "invalid-relations"),
+        (tr("New house numbers"), "daily"),
+        (tr("All house numbers"), "dailytotal"),
+        (tr("New house numbers, monthly"), "monthly"),
+        (tr("All house numbers, monthly"), "monthlytotal"),
+        (tr("Top house number editors"), "topusers"),
+        (tr("Top edited cities"), "topcities"),
+        (tr("All house number editors"), "usertotal"),
+        (tr("Coverage"), "progress"),
+        (tr("Per-city coverage"), "cityprogress"),
+        (tr("Invalid relation settings"), "invalid-relations"),
     ]
 
     with doc.tag("ul"):
@@ -521,9 +521,9 @@ def handle_stats(conf: config.Config, relations: areas.Relations, request_uri: s
                 pass
 
     with doc.tag("h2"):
-        doc.text(_("Note"))
+        doc.text(tr("Note"))
     with doc.tag("div"):
-        doc.text(_("""These statistics are provided purely for interested editors, and are not
+        doc.text(tr("""These statistics are provided purely for interested editors, and are not
 intended to reflect quality of work done by any given editor in OSM. If you want to use
 them to motivate yourself, that's fine, but keep in mind that a bit of useful work is
 more meaningful than a lot of useless work."""))
@@ -578,7 +578,7 @@ def check_existing_relation(conf: config.Config, relations: areas.Relations, req
         return doc
 
     with doc.tag("div", id="no-such-relation-error"):
-        doc.text(_("No such relation: {0}").format(relation_name))
+        doc.text(tr("No such relation: {0}").format(relation_name))
     return doc
 
 
@@ -588,12 +588,12 @@ def handle_no_osm_streets(prefix: str, relation_name: str) -> yattag.doc.Doc:
     link = prefix + "/streets/" + relation_name + "/update-result"
     with doc.tag("div", id="no-osm-streets"):
         with doc.tag("a", href=link):
-            doc.text(_("No existing streets: call Overpass to create..."))
+            doc.text(tr("No existing streets: call Overpass to create..."))
     # Emit localized strings for JS purposes.
     with doc.tag("div", style="display: none;"):
         string_pairs = [
-            ("str-overpass-wait", _("No existing streets: waiting for Overpass...")),
-            ("str-overpass-error", _("Error from Overpass: ")),
+            ("str-overpass-wait", tr("No existing streets: waiting for Overpass...")),
+            ("str-overpass-error", tr("Error from Overpass: ")),
         ]
         for key, value in string_pairs:
             kwargs: Dict[str, str] = {}
@@ -610,12 +610,12 @@ def handle_no_osm_housenumbers(prefix: str, relation_name: str) -> yattag.doc.Do
     link = prefix + "/street-housenumbers/" + relation_name + "/update-result"
     with doc.tag("div", id="no-osm-housenumbers"):
         with doc.tag("a", href=link):
-            doc.text(_("No existing house numbers: call Overpass to create..."))
+            doc.text(tr("No existing house numbers: call Overpass to create..."))
     # Emit localized strings for JS purposes.
     with doc.tag("div", style="display: none;"):
         string_pairs = [
-            ("str-overpass-wait", _("No existing house numbers: waiting for Overpass...")),
-            ("str-overpass-error", _("Error from Overpass: ")),
+            ("str-overpass-wait", tr("No existing house numbers: waiting for Overpass...")),
+            ("str-overpass-error", tr("Error from Overpass: ")),
         ]
         for key, value in string_pairs:
             kwargs: Dict[str, str] = {}
@@ -632,12 +632,12 @@ def handle_no_ref_housenumbers(prefix: str, relation_name: str) -> yattag.doc.Do
     link = prefix + "/missing-housenumbers/" + relation_name + "/update-result"
     with doc.tag("div", id="no-ref-housenumbers"):
         with doc.tag("a", href=link):
-            doc.text(_("No reference house numbers: create from reference..."))
+            doc.text(tr("No reference house numbers: create from reference..."))
     # Emit localized strings for JS purposes.
     with doc.tag("div", style="display: none;"):
         string_pairs = [
-            ("str-reference-wait", _("No reference house numbers: creating from reference...")),
-            ("str-reference-error", _("Error from reference: ")),
+            ("str-reference-wait", tr("No reference house numbers: creating from reference...")),
+            ("str-reference-error", tr("Error from reference: ")),
         ]
         for key, value in string_pairs:
             kwargs: Dict[str, str] = {}
@@ -654,12 +654,12 @@ def handle_no_ref_streets(prefix: str, relation_name: str) -> yattag.doc.Doc:
     link = prefix + "/missing-streets/" + relation_name + "/update-result"
     with doc.tag("div", id="no-ref-streets"):
         with doc.tag("a", href=link):
-            doc.text(_("No street list: create from reference..."))
+            doc.text(tr("No street list: create from reference..."))
     # Emit localized strings for JS purposes.
     with doc.tag("div", style="display: none;"):
         string_pairs = [
-            ("str-reference-wait", _("No reference streets: creating from reference...")),
-            ("str-reference-error", _("Error from reference: ")),
+            ("str-reference-wait", tr("No reference streets: creating from reference...")),
+            ("str-reference-error", tr("Error from reference: ")),
         ]
         for key, value in string_pairs:
             kwargs: Dict[str, str] = {}

--- a/wsgi.py
+++ b/wsgi.py
@@ -24,7 +24,7 @@ import wsgiref.simple_server
 
 import yattag
 
-from i18n import translate as _
+from i18n import translate as tr
 import areas
 import cache
 import config
@@ -66,11 +66,11 @@ def handle_streets(conf: config.Config, relations: areas.Relations, request_uri:
             relation.get_files().write_osm_streets(buf)
             streets = relation.get_config().should_check_missing_streets()
             if streets != "only":
-                doc.text(_("Update successful: "))
+                doc.text(tr("Update successful: "))
                 link = conf.get_uri_prefix() + "/missing-housenumbers/" + relation_name + "/view-result"
-                doc.asis(util.gen_link(link, _("View missing house numbers")).getvalue())
+                doc.asis(util.gen_link(link, tr("View missing house numbers")).getvalue())
             else:
-                doc.text(_("Update successful."))
+                doc.text(tr("Update successful."))
     else:
         # assume view-result
         with relation.get_files().get_osm_streets_csv_stream() as sock:
@@ -104,14 +104,14 @@ def handle_street_housenumbers(conf: config.Config, relations: areas.Relations, 
             doc.asis(util.handle_overpass_error(conf, err).getvalue())
         else:
             relation.get_files().write_osm_housenumbers(buf)
-            doc.text(_("Update successful: "))
+            doc.text(tr("Update successful: "))
             link = prefix + "/missing-housenumbers/" + relation_name + "/view-result"
-            doc.asis(util.gen_link(link, _("View missing house numbers")).getvalue())
+            doc.asis(util.gen_link(link, tr("View missing house numbers")).getvalue())
     else:
         # assume view-result
         if not os.path.exists(relation.get_files().get_osm_housenumbers_path()):
             with doc.tag("div", id="no-osm-housenumbers"):
-                doc.text(_("No existing house numbers"))
+                doc.text(tr("No existing house numbers"))
         else:
             with relation.get_files().get_osm_housenumbers_csv_stream() as sock:
                 doc.asis(util.html_table_from_list(util.tsv_to_list(sock)).getvalue())
@@ -178,22 +178,22 @@ def missing_streets_view_result(conf: config.Config, relations: areas.Relations,
     ret = relation.write_missing_streets()
     todo_count, done_count, percent, streets = ret
     streets.sort(key=util.get_lexical_sort_key())
-    table = [[util.html_escape(_("Street name"))]]
+    table = [[util.html_escape(tr("Street name"))]]
     for street in streets:
         table.append([util.html_escape(street)])
 
     with doc.tag("p"):
-        doc.text(_("OpenStreetMap is possibly missing the below {0} streets.").format(str(todo_count)))
-        doc.text(_(" (existing: {0}, ready: {1}).").format(str(done_count), util.format_percent(str(percent))))
+        doc.text(tr("OpenStreetMap is possibly missing the below {0} streets.").format(str(todo_count)))
+        doc.text(tr(" (existing: {0}, ready: {1}).").format(str(done_count), util.format_percent(str(percent))))
         doc.stag("br")
         with doc.tag("a", href=prefix + "/missing-streets/{}/view-turbo".format(relation_name)):
-            doc.text(_("Overpass turbo query for streets with questionable names"))
+            doc.text(tr("Overpass turbo query for streets with questionable names"))
         doc.stag("br")
         with doc.tag("a", href=prefix + "/missing-streets/" + relation_name + "/view-result.txt"):
-            doc.text(_("Plain text format"))
+            doc.text(tr("Plain text format"))
         doc.stag("br")
         with doc.tag("a", href=prefix + "/missing-streets/" + relation_name + "/view-result.chkl"):
-            doc.text(_("Checklist format"))
+            doc.text(tr("Checklist format"))
 
     doc.asis(util.html_table_from_list(table).getvalue())
     doc.asis(util.invalid_refstreets_to_html(relation.get_invalid_refstreets()).getvalue())
@@ -210,11 +210,11 @@ def missing_housenumbers_view_txt(conf: config.Config, relations: areas.Relation
 
     output = ""
     if not os.path.exists(relation.get_files().get_osm_streets_path()):
-        output += _("No existing streets")
+        output += tr("No existing streets")
     elif not os.path.exists(relation.get_files().get_osm_housenumbers_path()):
-        output += _("No existing house numbers")
+        output += tr("No existing house numbers")
     elif not os.path.exists(relation.get_files().get_ref_housenumbers_path()):
-        output += _("No reference house numbers")
+        output += tr("No reference house numbers")
     else:
         output = cache.get_missing_housenumbers_txt(conf, relation)
     return output
@@ -234,11 +234,11 @@ def missing_housenumbers_view_chkl(relations: areas.Relations, request_uri: str)
 
     output = ""
     if not os.path.exists(relation.get_files().get_osm_streets_path()):
-        output += _("No existing streets")
+        output += tr("No existing streets")
     elif not os.path.exists(relation.get_files().get_osm_housenumbers_path()):
-        output += _("No existing house numbers")
+        output += tr("No existing house numbers")
     elif not os.path.exists(relation.get_files().get_ref_housenumbers_path()):
-        output += _("No reference house numbers")
+        output += tr("No reference house numbers")
     else:
         ongoing_streets, _ignore = relation.get_missing_housenumbers()
 
@@ -273,9 +273,9 @@ def missing_streets_view_txt(relations: areas.Relations, request_uri: str, chkl:
 
     output = ""
     if not os.path.exists(relation.get_files().get_osm_streets_path()):
-        output += _("No existing streets")
+        output += tr("No existing streets")
     elif not os.path.exists(relation.get_files().get_ref_streets_path()):
-        output += _("No reference streets")
+        output += tr("No reference streets")
     else:
         todo_streets, _ignore = relation.get_missing_streets()
         todo_streets.sort(key=util.get_lexical_sort_key())
@@ -293,10 +293,10 @@ def missing_housenumbers_update(conf: config.Config, relations: areas.Relations,
     relation = relations.get_relation(relation_name)
     relation.write_ref_housenumbers(references)
     doc = yattag.doc.Doc()
-    doc.text(_("Update successful: "))
+    doc.text(tr("Update successful: "))
     prefix = conf.get_uri_prefix()
     link = prefix + "/missing-housenumbers/" + relation_name + "/view-result"
-    doc.asis(util.gen_link(link, _("View missing house numbers")).getvalue())
+    doc.asis(util.gen_link(link, tr("View missing house numbers")).getvalue())
     return doc
 
 
@@ -307,7 +307,7 @@ def missing_streets_update(conf: config.Config, relations: areas.Relations, rela
     relation.write_ref_streets(reference)
     doc = yattag.doc.Doc()
     with doc.tag("div", id="update-success"):
-        doc.text(_("Update successful."))
+        doc.text(tr("Update successful."))
     return doc
 
 
@@ -486,13 +486,13 @@ def handle_main_housenr_percent(conf: config.Config, relation: areas.Relation) -
     if percent != "N/A":
         date = get_last_modified(relation.get_files().get_housenumbers_percent_path())
         with doc.tag("strong"):
-            with doc.tag("a", href=url, title=_("updated") + " " + date):
+            with doc.tag("a", href=url, title=tr("updated") + " " + date):
                 doc.text(util.format_percent(percent))
         return doc, percent
 
     with doc.tag("strong"):
         with doc.tag("a", href=url):
-            doc.text(_("missing house numbers"))
+            doc.text(tr("missing house numbers"))
     return doc, "0"
 
 
@@ -508,13 +508,13 @@ def handle_main_street_percent(conf: config.Config, relation: areas.Relation) ->
     if percent != "N/A":
         date = get_last_modified(relation.get_files().get_streets_percent_path())
         with doc.tag("strong"):
-            with doc.tag("a", href=url, title=_("updated") + " " + date):
+            with doc.tag("a", href=url, title=tr("updated") + " " + date):
                 doc.text(util.format_percent(percent))
         return doc, percent
 
     with doc.tag("strong"):
         with doc.tag("a", href=url):
-            doc.text(_("missing streets"))
+            doc.text(tr("missing streets"))
     return doc, "0"
 
 
@@ -530,13 +530,13 @@ def handle_main_street_additional_count(conf: config.Config, relation: areas.Rel
     if additional_count:
         date = get_last_modified(relation.get_files().get_streets_additional_count_path())
         with doc.tag("strong"):
-            with doc.tag("a", href=url, title=_("updated") + " " + date):
-                doc.text(_("{} streets").format(additional_count))
+            with doc.tag("a", href=url, title=tr("updated") + " " + date):
+                doc.text(tr("{} streets").format(additional_count))
         return doc
 
     with doc.tag("strong"):
         with doc.tag("a", href=url):
-            doc.text(_("additional streets"))
+            doc.text(tr("additional streets"))
     return doc
 
 
@@ -556,13 +556,13 @@ def handle_main_housenr_additional_count(conf: config.Config, relation: areas.Re
     if additional_count:
         date = get_last_modified(relation.get_files().get_housenumbers_additional_count_path())
         with doc.tag("strong"):
-            with doc.tag("a", href=url, title=_("updated") + " " + date):
-                doc.text(_("{} house numbers").format(additional_count))
+            with doc.tag("a", href=url, title=tr("updated") + " " + date):
+                doc.text(tr("{} house numbers").format(additional_count))
         return doc
 
     with doc.tag("strong"):
         with doc.tag("a", href=url):
-            doc.text(_("additional house numbers"))
+            doc.text(tr("additional house numbers"))
     return doc
 
 
@@ -642,13 +642,13 @@ def handle_main_filters(conf: config.Config, relations: areas.Relations, refcoun
     doc = yattag.doc.Doc()
     with doc.tag("span", id="filter-based-on-position"):
         with doc.tag("a", href="#"):
-            doc.text(_("Based on position"))
+            doc.text(tr("Based on position"))
     items.append(doc)
 
     doc = yattag.doc.Doc()
     prefix = conf.get_uri_prefix()
     with doc.tag("a", href=prefix + "/filter-for/everything"):
-        doc.text(_("Show complete areas"))
+        doc.text(tr("Show complete areas"))
     items.append(doc)
 
     # Sorted set of refcounty values of all relations.
@@ -656,9 +656,9 @@ def handle_main_filters(conf: config.Config, relations: areas.Relations, refcoun
         items.append(handle_main_filters_refcounty(conf, relations, refcounty_id, refcounty))
     doc = yattag.doc.Doc()
     with doc.tag("h1"):
-        doc.text(_("Where to map?"))
+        doc.text(tr("Where to map?"))
     with doc.tag("p"):
-        doc.text(_("Filters:") + " ")
+        doc.text(tr("Filters:") + " ")
         for index, item in enumerate(items):
             if index:
                 doc.text(" ¦ ")
@@ -667,13 +667,13 @@ def handle_main_filters(conf: config.Config, relations: areas.Relations, refcoun
     # Emit localized strings for JS purposes.
     with doc.tag("div", style="display: none;"):
         string_pairs = [
-            ("str-gps-wait", _("Waiting for GPS...")),
-            ("str-gps-error", _("Error from GPS: ")),
-            ("str-overpass-wait", _("Waiting for Overpass...")),
-            ("str-overpass-error", _("Error from Overpass: ")),
-            ("str-relations-wait", _("Waiting for relations...")),
-            ("str-relations-error", _("Error from relations: ")),
-            ("str-redirect-wait", _("Waiting for redirect...")),
+            ("str-gps-wait", tr("Waiting for GPS...")),
+            ("str-gps-error", tr("Error from GPS: ")),
+            ("str-overpass-wait", tr("Waiting for Overpass...")),
+            ("str-overpass-error", tr("Error from Overpass: ")),
+            ("str-relations-wait", tr("Waiting for relations...")),
+            ("str-relations-error", tr("Error from relations: ")),
+            ("str-redirect-wait", tr("Waiting for redirect...")),
         ]
         for key, value in string_pairs:
             kwargs: Dict[str, str] = {}
@@ -754,7 +754,7 @@ def handle_main_relation(
 
     doc = yattag.doc.Doc()
     with doc.tag("a", href="https://www.openstreetmap.org/relation/" + str(relation.get_config().get_osmrelation())):
-        doc.text(_("area boundary"))
+        doc.text(tr("area boundary"))
     row.append(doc)
 
     if not filter_for(complete, relation):
@@ -774,12 +774,12 @@ def handle_main(request_uri: str, conf: config.Config, relations: areas.Relation
 
     doc.asis(handle_main_filters(conf, relations, refcounty).getvalue())
     table = []
-    table.append([util.html_escape(_("Area")),
-                  util.html_escape(_("House number coverage")),
-                  util.html_escape(_("Additional house numbers")),
-                  util.html_escape(_("Street coverage")),
-                  util.html_escape(_("Additional streets")),
-                  util.html_escape(_("Area boundary"))])
+    table.append([util.html_escape(tr("Area")),
+                  util.html_escape(tr("House number coverage")),
+                  util.html_escape(tr("Additional house numbers")),
+                  util.html_escape(tr("Street coverage")),
+                  util.html_escape(tr("Additional streets")),
+                  util.html_escape(tr("Area boundary"))])
     for relation_name in relations.get_names():
         row = handle_main_relation(conf, relations, filter_for, relation_name)
         if row:
@@ -787,7 +787,7 @@ def handle_main(request_uri: str, conf: config.Config, relations: areas.Relation
     doc.asis(util.html_table_from_list(table).getvalue())
     with doc.tag("p"):
         with doc.tag("a", href="https://github.com/vmiklos/osm-gimmisn/tree/master/doc"):
-            doc.text(_("Add new area"))
+            doc.text(tr("Add new area"))
 
     doc.asis(webframe.get_footer().getvalue())
     return doc
@@ -803,13 +803,13 @@ def get_html_title(request_uri: str) -> str:
         relation_name = tokens[3]
     title = ""
     if function == "missing-housenumbers":
-        title = " - " + _("{0} missing house numbers").format(relation_name)
+        title = " - " + tr("{0} missing house numbers").format(relation_name)
     elif function == "missing-streets":
-        title = " - " + relation_name + " " + _("missing streets")
+        title = " - " + relation_name + " " + tr("missing streets")
     elif function == "street-housenumbers":
-        title = " - " + relation_name + " " + _("existing house numbers")
+        title = " - " + relation_name + " " + tr("existing house numbers")
     elif function == "streets":
-        title = " - " + relation_name + " " + _("existing streets")
+        title = " - " + relation_name + " " + tr("existing streets")
     return title
 
 
@@ -820,7 +820,7 @@ def write_html_head(conf: config.Config, doc: yattag.doc.Doc, title: str) -> Non
         doc.stag("meta", charset="UTF-8")
         doc.stag("meta", name="viewport", content="width=device-width, initial-scale=1")
         with doc.tag("title"):
-            doc.text(_("Where to map?") + title)
+            doc.text(tr("Where to map?") + title)
         doc.stag("link", rel="icon", type="image/vnd.microsoft.icon", sizes="16x12", href=prefix + "/favicon.ico")
         doc.stag("link", rel="icon", type="image/svg+xml", sizes="any", href=prefix + "/favicon.svg")
 

--- a/wsgi_additional.py
+++ b/wsgi_additional.py
@@ -12,7 +12,7 @@ from typing import Tuple
 
 import yattag
 
-from i18n import translate as _
+from i18n import translate as tr
 import areas
 import cache
 import config
@@ -28,9 +28,9 @@ def additional_streets_view_txt(relations: areas.Relations, request_uri: str, ch
 
     output = ""
     if not os.path.exists(relation.get_files().get_osm_streets_path()):
-        output += _("No existing streets")
+        output += tr("No existing streets")
     elif not os.path.exists(relation.get_files().get_ref_streets_path()):
-        output += _("No reference streets")
+        output += tr("No reference streets")
     else:
         streets = relation.get_additional_streets()
         lexical_sort_key = util.get_lexical_sort_key()
@@ -65,10 +65,10 @@ def additional_streets_view_result(
         count = len(streets)
         lexical_sort_key = util.get_lexical_sort_key()
         streets.sort(key=lambda street: lexical_sort_key(street.get_osm_name()))
-        table = [[util.html_escape(_("Identifier")),
-                  util.html_escape(_("Type")),
-                  util.html_escape(_("Source")),
-                  util.html_escape(_("Street name"))]]
+        table = [[util.html_escape(tr("Identifier")),
+                  util.html_escape(tr("Type")),
+                  util.html_escape(tr("Source")),
+                  util.html_escape(tr("Street name"))]]
         for street in streets:
             cell = yattag.doc.Doc()
             href = "https://www.openstreetmap.org/{}/{}".format(street.get_osm_type(), street.get_osm_id())
@@ -83,16 +83,16 @@ def additional_streets_view_result(
             table.append(cells)
 
         with doc.tag("p"):
-            doc.text(_("OpenStreetMap additionally has the below {0} streets.").format(str(count)))
+            doc.text(tr("OpenStreetMap additionally has the below {0} streets.").format(str(count)))
             doc.stag("br")
             with doc.tag("a", href=prefix + "/additional-streets/" + relation_name + "/view-result.txt"):
-                doc.text(_("Plain text format"))
+                doc.text(tr("Plain text format"))
             doc.stag("br")
             with doc.tag("a", href=prefix + "/additional-streets/" + relation_name + "/view-result.chkl"):
-                doc.text(_("Checklist format"))
+                doc.text(tr("Checklist format"))
             doc.stag("br")
             with doc.tag("a", href=prefix + "/additional-streets/{}/view-turbo".format(relation_name)):
-                doc.text(_("Overpass turbo query for the below streets"))
+                doc.text(tr("Overpass turbo query for the below streets"))
 
         doc.asis(util.html_table_from_list(table).getvalue())
         doc.asis(util.invalid_refstreets_to_html(relation.get_invalid_refstreets()).getvalue())


### PR DESCRIPTION
Mostly because _ is a reserved identifier in Rust, which blocks
incremental porting.

Change-Id: I7dc5d5415c0b758c5c9becb6c0b69105c3fe21d6
