### PR TITLE
config.FileSystem: get_relation_allowlist -> open

### DIFF
--- a/areas.py
+++ b/areas.py
@@ -713,7 +713,7 @@ class Relations:
     def __init__(self, conf: config.Config) -> None:
         self.__workdir = conf.get_workdir()
         self.__conf = conf
-        with open(os.path.join(conf.get_abspath("data"), "yamls.cache"), "rb") as stream:
+        with conf.get_file_system().open(os.path.join(conf.get_abspath("data"), "yamls.cache"), "rb") as stream:
             self.__yaml_cache: Dict[str, Any] = json.load(stream)
         self.__dict = self.__yaml_cache["relations.yaml"]
         self.__relations: Dict[str, Relation] = {}

--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ The config module contains functionality related to configuration handling.
 It intentionally doesn't import any other 'own' modules, so it can be used anywhere.
 """
 
+from typing import BinaryIO
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -36,8 +37,8 @@ class FileSystem:
         # pylint: disable=unused-argument
         ...
 
-    def get_relation_allowlist(self) -> List[str]:  # pragma: no cover
-        """Returns the list of relations which are not in relations.yaml, but are to be accepted."""
+    def open(self, path: str, mode: str) -> BinaryIO:  # pragma: no cover
+        """Opens a file with the given mode. Only binary mode is supposed."""
         # pylint: disable=no-self-use
         # pylint: disable=unused-argument
         ...
@@ -51,8 +52,8 @@ class StdFileSystem(FileSystem):
     def getmtime(self, path: str) -> float:
         return os.path.getmtime(path)
 
-    def get_relation_allowlist(self) -> List[str]:
-        return []
+    def open(self, path: str, mode: str) -> BinaryIO:
+        return cast(BinaryIO, open(path, mode))
 
 
 class Network:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,12 +6,15 @@
 
 """The test_config module covers the config module."""
 
+from typing import BinaryIO
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
+from typing import cast
 import calendar
 import datetime
+import io
 import os
 
 import config
@@ -27,7 +30,7 @@ class TestFileSystem(config.FileSystem):
     def __init__(self) -> None:
         self.__hide_paths: List[str] = []
         self.__mtimes: Dict[str, float] = {}
-        self.__relation_allowlist: List[str] = []
+        self.__files: Dict[str, io.BytesIO] = {}
 
     def set_hide_paths(self, hide_paths: List[str]) -> None:
         """Sets the hide paths."""
@@ -47,12 +50,14 @@ class TestFileSystem(config.FileSystem):
             return self.__mtimes[path]
         return os.path.getmtime(path)
 
-    def set_relation_allowlist(self, relation_allowlist: List[str]) -> None:
-        """Sets the relation allowlist."""
-        self.__relation_allowlist = relation_allowlist
+    def set_files(self, files: Dict[str, io.BytesIO]) -> None:
+        """Sets the files."""
+        self.__files = files
 
-    def get_relation_allowlist(self) -> List[str]:
-        return self.__relation_allowlist
+    def open(self, path: str, mode: str) -> BinaryIO:
+        if path in self.__files:
+            return self.__files[path]
+        return cast(BinaryIO, open(path, mode))
 
 
 class URLRoute:

--- a/tests/test_wsgi_additional.py
+++ b/tests/test_wsgi_additional.py
@@ -6,6 +6,8 @@
 
 """The test_wsgi_additional module covers the wsgi_additional module."""
 
+import io
+import json
 import unittest
 
 import test_config
@@ -146,7 +148,21 @@ class TestAdditionalStreets(test_wsgi.TestWsgi):
     def test_street_from_housenr_well_formed(self) -> None:
         """Tests if the output is well-formed when the street name comes from a housenr."""
         file_system = test_config.TestFileSystem()
-        file_system.set_relation_allowlist(["gh611"])
+        yamls_cache = {
+            "relations.yaml": {
+                "gh611": {
+                    "osmrelation": 42,
+                },
+            },
+            "refcounty-names.yaml": {
+            },
+            "refsettlement-names.yaml": {
+            },
+        }
+        yamls_cache_value = io.BytesIO()
+        yamls_cache_value.write(json.dumps(yamls_cache).encode("utf-8"))
+        yamls_cache_value.seek(0)
+        file_system.set_files({self.conf.get_abspath("data/yamls.cache"): yamls_cache_value})
         self.conf.set_file_system(file_system)
         root = self.get_dom_for_path("/additional-streets/gh611/view-result")
         results = root.findall("body/table")

--- a/webframe.py
+++ b/webframe.py
@@ -575,7 +575,7 @@ def check_existing_relation(conf: config.Config, relations: areas.Relations, req
 
     tokens = request_uri.split("/")
     relation_name = tokens[-2]
-    if relation_name in relations.get_names() or relation_name in conf.get_file_system().get_relation_allowlist():
+    if relation_name in relations.get_names():
         return doc
 
     with doc.tag("div", id="no-such-relation-error"):


### PR DESCRIPTION
The first is a very specific hook, while the later is a generic one that
we can reuse in other cases.

This moves towards in-memory files during tests. At least not writing
the real filesystem during tests will be needed if we'll want to run the
tests in parallel in the future.

Change-Id: If70d4c23ca624cdf37cab1a78c156ecb937fead5
