### PR TITLE
csv reader: switch to binary IO

### DIFF
--- a/area_files.py
+++ b/area_files.py
@@ -74,23 +74,23 @@ class RelationFiles(RelationFilePaths):
         path = self.get_ref_streets_path()
         return cast(BinaryIO, open(path, mode=mode))
 
-    def __get_osm_streets_stream(self, mode: str) -> TextIO:
+    def __get_osm_streets_stream(self, mode: str) -> BinaryIO:
         """Opens the OSM street list of a relation."""
         path = self.get_osm_streets_path()
-        return cast(TextIO, open(path, mode=mode))
+        return cast(BinaryIO, open(path, mode=mode))
 
     def get_osm_streets_csv_stream(self) -> util.CsvIO:
         """Gets a CSV reader for the OSM street list."""
-        return util.CsvIO(self.__get_osm_streets_stream("r"))
+        return util.CsvIO(self.__get_osm_streets_stream("rb"))
 
-    def __get_osm_housenumbers_stream(self, mode: str) -> TextIO:
+    def __get_osm_housenumbers_stream(self, mode: str) -> BinaryIO:
         """Opens the OSM house number list of a relation."""
         path = self.get_osm_housenumbers_path()
-        return cast(TextIO, open(path, mode=mode))
+        return cast(BinaryIO, open(path, mode=mode))
 
     def get_osm_housenumbers_csv_stream(self) -> util.CsvIO:
         """Gets a CSV reader for the OSM house number list."""
-        return util.CsvIO(self.__get_osm_housenumbers_stream("r"))
+        return util.CsvIO(self.__get_osm_housenumbers_stream("rb"))
 
     def get_ref_housenumbers_stream(self, mode: str) -> TextIO:
         """Opens the reference house number list of a relation."""
@@ -122,13 +122,13 @@ class RelationFiles(RelationFilePaths):
 
     def write_osm_streets(self, result: str) -> None:
         """Writes the result for overpass of Relation.get_osm_streets_query()."""
-        with self.__get_osm_streets_stream("w") as sock:
-            sock.write(result)
+        with self.__get_osm_streets_stream("wb") as sock:
+            sock.write(util.to_bytes(result))
 
     def write_osm_housenumbers(self, result: str) -> None:
         """Writes the result for overpass of Relation.get_osm_housenumbers_query()."""
-        with self.__get_osm_housenumbers_stream(mode="w") as stream:
-            stream.write(result)
+        with self.__get_osm_housenumbers_stream(mode="wb") as stream:
+            stream.write(util.to_bytes(result))
 
     def get_additional_housenumbers_htmlcache_stream(self, mode: str) -> TextIO:
         """Opens the additional house number HTML cache file of a relation."""

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -247,7 +247,7 @@ class TestTsvToList(unittest.TestCase):
     """Tests tsv_to_list()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        sock = util.CsvIO(io.StringIO("h1\th2\n\nv1\tv2\n"))
+        sock = util.CsvIO(io.BytesIO(b"h1\th2\n\nv1\tv2\n"))
         ret = util.tsv_to_list(sock)
         self.assertEqual(len(ret), 2)
         row1 = [cell.getvalue() for cell in ret[0]]
@@ -257,7 +257,7 @@ class TestTsvToList(unittest.TestCase):
 
     def test_type(self) -> None:
         """Tests when a @type column is available."""
-        stream = util.CsvIO(io.StringIO("@id\t@type\n42\tnode\n"))
+        stream = util.CsvIO(io.BytesIO(b"@id\t@type\n42\tnode\n"))
         ret = util.tsv_to_list(stream)
         self.assertEqual(len(ret), 2)
         row1 = [cell.getvalue() for cell in ret[0]]
@@ -268,7 +268,7 @@ class TestTsvToList(unittest.TestCase):
 
     def test_escape(self) -> None:
         """Tests escaping."""
-        sock = util.CsvIO(io.StringIO("\"h,1\"\th2\n"))
+        sock = util.CsvIO(io.BytesIO(b"\"h,1\"\th2\n"))
         ret = util.tsv_to_list(sock)
         self.assertEqual(len(ret), 1)
         row1 = [cell.getvalue() for cell in ret[0]]
@@ -277,11 +277,11 @@ class TestTsvToList(unittest.TestCase):
 
     def test_sort(self) -> None:
         """Tests sorting."""
-        csv = """addr:street\taddr:housenumber
+        csv = b"""addr:street\taddr:housenumber
 A street\t1
 A street\t10
 A street\t9"""
-        sock = util.CsvIO(io.StringIO(csv))
+        sock = util.CsvIO(io.BytesIO(csv))
         ret = util.tsv_to_list(sock)
         # 0th is header
         row3 = [cell.getvalue() for cell in ret[3]]
@@ -444,7 +444,7 @@ class TestGetStreetFromHousenumber(unittest.TestCase):
     """Tests get_street_from_housenumber()."""
     def test_addr_place(self) -> None:
         """Tests the case when addr:place is used."""
-        with util.CsvIO(open("tests/workdir/street-housenumbers-gh964.csv", "r")) as stream:
+        with util.CsvIO(open("tests/workdir/street-housenumbers-gh964.csv", "rb")) as stream:
             actual = util.get_street_from_housenumber(stream)
         # This is picked up from addr:place because addr:street was empty.
         self.assertEqual(actual, [util.Street(osm_name="Tolvajos tanya")])

--- a/util.py
+++ b/util.py
@@ -8,6 +8,7 @@
 
 from enum import Enum
 from typing import Any
+from typing import BinaryIO
 from typing import Callable
 from typing import Dict
 from typing import Iterable
@@ -15,10 +16,10 @@ from typing import Iterator
 from typing import List
 from typing import Optional
 from typing import Set
-from typing import TextIO
 from typing import Tuple
 from typing import Union
 from typing import cast
+import codecs
 import csv
 import locale
 import os
@@ -259,10 +260,10 @@ NumberedStreets = List[NumberedStreet]
 
 
 class CsvIO:
-    """Like TextIO, but for CSV reading."""
-    def __init__(self, stream: TextIO) -> None:
+    """Like BinaryIO, but for CSV reading."""
+    def __init__(self, stream: BinaryIO) -> None:
         self.stream = stream
-        self.reader = csv.reader(stream, delimiter='\t', quotechar='"')
+        self.reader = csv.reader(codecs.iterdecode(stream, "utf-8"), delimiter='\t', quotechar='"')
 
     def __enter__(self) -> 'CsvIO':
         return self


### PR DESCRIPTION
For consistency. If we have to use BinaryIO somewhere, then better to
not use TextIO at all.

Change-Id: I346b61c3aaab5ce16e914915ff02e385bd542ecd
