### PR TITLE
make run: change to cherry.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ check-filters-schema: $(patsubst %.yaml,%.validyaml,$(YAML_SAFE_OBJECTS))
 # Make sure that the current directory is *not* the repo root but something else to catch
 # non-absolute paths.
 run: all
-	cd $(HOME) && $(PWD)/wsgi.py
+	cd $(HOME) && $(PWD)/cherry.py
 
 deploy:
 ifeq (,$(wildcard ./deploy.sh))

--- a/cherry.py
+++ b/cherry.py
@@ -32,9 +32,6 @@ def main(conf: config.Config) -> None:
     ProxyPreserveHost On
     ProxyPass / http://127.0.0.1:8000/
     ProxyPassReverse / http://127.0.0.1:8000/
-
-    While wsgiref is part of stock Python and is ideal for local development, CherryPy supports
-    automatic reloading, which is super-handy in production.
     """
     def app(environ: Dict[str, Any], start_response: 'StartResponse') -> Iterable[bytes]:
         return wsgi.application(environ, start_response, conf)

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -652,37 +652,6 @@ class TestMain(TestWsgi):
             output = output_list[0].decode('utf-8')
             self.assertIn("ValueError", output)
 
-    def test_main(self) -> None:
-        """Tests main()."""
-        serving = False
-
-        def start_response(_status: str, _response_headers: List[Tuple[str, str]]) -> None:
-            pass
-
-        class MockServer:
-            """Mock WSGI server."""
-            def __init__(self, app: Any) -> None:
-                self.app = app
-
-            # pylint: disable=no-self-use
-            def serve_forever(self) -> None:
-                """Handles one request at a time until shutdown."""
-                self.app({}, start_response)
-                nonlocal serving
-                serving = True
-
-        def mock_make_server(_host: str, _port: int, app: Any) -> MockServer:
-            """Creates a new mock WSGI server."""
-            return MockServer(app)
-
-        conf = test_config.make_test_config()
-        with unittest.mock.patch('wsgiref.simple_server.make_server', mock_make_server):
-            # Capture standard output.
-            buf = io.StringIO()
-            with unittest.mock.patch('sys.stdout', buf):
-                wsgi.main(conf)
-        self.assertTrue(serving)
-
 
 class TestWebhooks(TestWsgi):
     """Tests /osm/webhooks/."""

--- a/wsgi.py
+++ b/wsgi.py
@@ -8,7 +8,6 @@
 """The wsgi module contains functionality specific to the web interface."""
 
 import os
-import sys
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -17,7 +16,6 @@ from typing import List
 from typing import Optional
 from typing import TYPE_CHECKING
 from typing import Tuple
-import wsgiref.simple_server
 
 import yattag
 
@@ -34,9 +32,6 @@ import wsgi_json
 if TYPE_CHECKING:
     # pylint: disable=no-name-in-module,import-error,unused-import
     from wsgiref.types import StartResponse
-
-if sys.platform.startswith("win"):
-    import _locale
 
 
 def handle_streets(conf: config.Config, relations: areas.Relations, request_uri: str) -> yattag.doc.Doc:
@@ -963,24 +958,5 @@ def application(
     except Exception:
         return webframe.handle_exception(environ, start_response)
 
-
-def main(conf: config.Config) -> None:
-    """Commandline interface to this module."""
-    if sys.platform.startswith("win"):
-        # pylint: disable=protected-access
-        _locale._getdefaultlocale = (lambda *args: ['en_US', 'utf8'])
-
-    def app(environ: Dict[str, Any], start_response: 'StartResponse') -> Iterable[bytes]:
-        return application(environ, start_response, conf)
-
-    port = conf.get_ini().get_tcp_port()
-    prefix = conf.get_ini().get_uri_prefix()
-    httpd = wsgiref.simple_server.make_server('', port, app)
-    print("Open <http://localhost:" + str(port) + prefix + "/> in your browser.")
-    httpd.serve_forever()
-
-
-if __name__ == "__main__":
-    main(config.Config(""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:


### PR DESCRIPTION
This simplifies the code, so that production and local 'make run' uses
the same codepath.

Change-Id: Id9a1258f2effeb18087f5cec4bb4e029db6adde9
