### PR TITLE
Rename config to context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON_TEST_OBJECTS = \
 	tests/test_areas.py \
 	tests/test_cache.py \
 	tests/test_cache_yamls.py \
-	tests/test_config.py \
+	tests/test_context.py \
 	tests/test_cron.py \
 	tests/test_i18n.py \
 	tests/test_missing_housenumbers.py \
@@ -25,7 +25,7 @@ PYTHON_SAFE_OBJECTS = \
 	areas.py \
 	cache.py \
 	cache_yamls.py \
-	config.py \
+	context.py \
 	cron.py \
 	i18n.py \
 	missing_housenumbers.py \

--- a/area_files.py
+++ b/area_files.py
@@ -10,7 +10,7 @@ import os
 from typing import BinaryIO
 from typing import cast
 
-import config
+import context
 import i18n
 import util
 
@@ -92,9 +92,9 @@ class RelationFiles(RelationFilePaths):
         """Gets a CSV reader for the OSM house number list."""
         return util.CsvIO(self.__get_osm_housenumbers_stream("rb"))
 
-    def get_ref_housenumbers_stream(self, conf: config.Config, mode: str) -> BinaryIO:
+    def get_ref_housenumbers_stream(self, ctx: context.Context, mode: str) -> BinaryIO:
         """Opens the reference house number list of a relation."""
-        return conf.get_file_system().open(self.get_ref_housenumbers_path(), mode=mode)
+        return ctx.get_file_system().open(self.get_ref_housenumbers_path(), mode=mode)
 
     def get_housenumbers_percent_stream(self, mode: str) -> BinaryIO:
         """Opens the house number percent file of a relation."""

--- a/cache.py
+++ b/cache.py
@@ -14,14 +14,14 @@ import yattag
 
 from i18n import translate as tr
 import areas
-import config
+import context
 import util
 
 
-def is_cache_outdated(conf: config.Config, cache_path: str, dependencies: List[str]) -> bool:
+def is_cache_outdated(ctx: context.Context, cache_path: str, dependencies: List[str]) -> bool:
     """Decides if we have an up to date cache entry or not."""
-    path_exists = conf.get_file_system().path_exists
-    getmtime = conf.get_file_system().getmtime
+    path_exists = ctx.get_file_system().path_exists
+    getmtime = ctx.get_file_system().getmtime
     if not path_exists(cache_path):
         return False
 
@@ -34,10 +34,10 @@ def is_cache_outdated(conf: config.Config, cache_path: str, dependencies: List[s
     return True
 
 
-def is_missing_housenumbers_html_cached(conf: config.Config, relation: areas.Relation) -> bool:
+def is_missing_housenumbers_html_cached(ctx: context.Context, relation: areas.Relation) -> bool:
     """Decides if we have an up to date HTML cache entry or not."""
     cache_path = relation.get_files().get_housenumbers_htmlcache_path()
-    datadir = conf.get_abspath("data")
+    datadir = ctx.get_abspath("data")
     relation_path = os.path.join(datadir, "relation-%s.yaml" % relation.get_name())
     dependencies = [
         relation.get_files().get_osm_streets_path(),
@@ -45,13 +45,13 @@ def is_missing_housenumbers_html_cached(conf: config.Config, relation: areas.Rel
         relation.get_files().get_ref_housenumbers_path(),
         relation_path
     ]
-    return is_cache_outdated(conf, cache_path, dependencies)
+    return is_cache_outdated(ctx, cache_path, dependencies)
 
 
-def is_additional_housenumbers_html_cached(conf: config.Config, relation: areas.Relation) -> bool:
+def is_additional_housenumbers_html_cached(ctx: context.Context, relation: areas.Relation) -> bool:
     """Decides if we have an up to date HTML cache entry for additional house numbers or not."""
     cache_path = relation.get_files().get_additional_housenumbers_htmlcache_path()
-    datadir = conf.get_abspath("data")
+    datadir = ctx.get_abspath("data")
     relation_path = os.path.join(datadir, "relation-%s.yaml" % relation.get_name())
     dependencies = [
         relation.get_files().get_osm_streets_path(),
@@ -59,13 +59,13 @@ def is_additional_housenumbers_html_cached(conf: config.Config, relation: areas.
         relation.get_files().get_ref_housenumbers_path(),
         relation_path
     ]
-    return is_cache_outdated(conf, cache_path, dependencies)
+    return is_cache_outdated(ctx, cache_path, dependencies)
 
 
-def get_missing_housenumbers_html(conf: config.Config, relation: areas.Relation) -> yattag.doc.Doc:
+def get_missing_housenumbers_html(ctx: context.Context, relation: areas.Relation) -> yattag.doc.Doc:
     """Gets the cached HTML of the missing housenumbers for a relation."""
     doc = yattag.doc.Doc()
-    if is_missing_housenumbers_html_cached(conf, relation):
+    if is_missing_housenumbers_html_cached(ctx, relation):
         with relation.get_files().get_housenumbers_htmlcache_stream("rb") as stream:
             doc.asis(util.from_bytes(stream.read()))
         return doc
@@ -74,7 +74,7 @@ def get_missing_housenumbers_html(conf: config.Config, relation: areas.Relation)
     todo_street_count, todo_count, done_count, percent, table = ret
 
     with doc.tag("p"):
-        prefix = conf.get_ini().get_uri_prefix()
+        prefix = ctx.get_ini().get_uri_prefix()
         relation_name = relation.get_name()
         doc.text(tr("OpenStreetMap is possibly missing the below {0} house numbers for {1} streets.")
                  .format(str(todo_count), str(todo_street_count)))
@@ -103,10 +103,10 @@ def get_missing_housenumbers_html(conf: config.Config, relation: areas.Relation)
     return doc
 
 
-def get_additional_housenumbers_html(conf: config.Config, relation: areas.Relation) -> yattag.doc.Doc:
+def get_additional_housenumbers_html(ctx: context.Context, relation: areas.Relation) -> yattag.doc.Doc:
     """Gets the cached HTML of the additional housenumbers for a relation."""
     doc = yattag.doc.Doc()
-    if is_additional_housenumbers_html_cached(conf, relation):
+    if is_additional_housenumbers_html_cached(ctx, relation):
         with relation.get_files().get_additional_housenumbers_htmlcache_stream("rb") as stream:
             doc.asis(util.from_bytes(stream.read()))
         return doc
@@ -131,10 +131,10 @@ def get_additional_housenumbers_html(conf: config.Config, relation: areas.Relati
     return doc
 
 
-def is_missing_housenumbers_txt_cached(conf: config.Config, relation: areas.Relation) -> bool:
+def is_missing_housenumbers_txt_cached(ctx: context.Context, relation: areas.Relation) -> bool:
     """Decides if we have an up to date plain text cache entry or not."""
     cache_path = relation.get_files().get_housenumbers_txtcache_path()
-    datadir = conf.get_abspath("data")
+    datadir = ctx.get_abspath("data")
     relation_path = os.path.join(datadir, "relation-%s.yaml" % relation.get_name())
     dependencies = [
         relation.get_files().get_osm_streets_path(),
@@ -142,13 +142,13 @@ def is_missing_housenumbers_txt_cached(conf: config.Config, relation: areas.Rela
         relation.get_files().get_ref_housenumbers_path(),
         relation_path
     ]
-    return is_cache_outdated(conf, cache_path, dependencies)
+    return is_cache_outdated(ctx, cache_path, dependencies)
 
 
-def get_missing_housenumbers_txt(conf: config.Config, relation: areas.Relation) -> str:
+def get_missing_housenumbers_txt(ctx: context.Context, relation: areas.Relation) -> str:
     """Gets the cached plain text of the missing housenumbers for a relation."""
     output = ""
-    if is_missing_housenumbers_txt_cached(conf, relation):
+    if is_missing_housenumbers_txt_cached(ctx, relation):
         with relation.get_files().get_housenumbers_txtcache_stream("rb") as stream:
             output = util.from_bytes(stream.read())
         return output

--- a/cache_yamls.py
+++ b/cache_yamls.py
@@ -16,14 +16,14 @@ import os
 import sys
 import yaml
 
-import config
+import context
 
 
-def main(argv: List[str], conf: config.Config) -> None:
+def main(argv: List[str], ctx: context.Context) -> None:
     """Commandline interface to this module."""
 
     cache: Dict[str, Any] = {}
-    datadir = conf.get_abspath(argv[1])
+    datadir = ctx.get_abspath(argv[1])
     for yaml_path in glob.glob(os.path.join(datadir, "*.yaml")):
         with open(yaml_path) as yaml_stream:
             cache_key = os.path.relpath(yaml_path, datadir)
@@ -33,7 +33,7 @@ def main(argv: List[str], conf: config.Config) -> None:
     with open(cache_path, "w") as cache_stream:
         json.dump(cache, cache_stream)
 
-    workdir = conf.get_abspath(argv[2])
+    workdir = ctx.get_abspath(argv[2])
     yaml_path = os.path.join(datadir, "relations.yaml")
     relation_ids = []
     with open(yaml_path) as stream:
@@ -48,6 +48,6 @@ def main(argv: List[str], conf: config.Config) -> None:
 
 
 if __name__ == "__main__":
-    main(sys.argv, config.Config(""))
+    main(sys.argv, context.Context(""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/cherry.py
+++ b/cherry.py
@@ -15,14 +15,14 @@ from typing import TYPE_CHECKING
 import cherrypy  # type: ignore
 
 import wsgi
-import config
+import context
 
 if TYPE_CHECKING:
     # pylint: disable=no-name-in-module,import-error,unused-import
     from wsgiref.types import StartResponse
 
 
-def main(conf: config.Config) -> None:
+def main(ctx: context.Context) -> None:
     """
     Commandline interface to this module.
 
@@ -34,14 +34,14 @@ def main(conf: config.Config) -> None:
     ProxyPassReverse / http://127.0.0.1:8000/
     """
     def app(environ: Dict[str, Any], start_response: 'StartResponse') -> Iterable[bytes]:
-        return wsgi.application(environ, start_response, conf)
+        return wsgi.application(environ, start_response, ctx)
     cherrypy.tree.graft(app, "/")
     cherrypy.server.unsubscribe()
     # This is documented at <https://docs.cherrypy.org/en/latest/advanced.html>, so:
     # pylint: disable=protected-access
     server = cherrypy._cpserver.Server()
     server.socket_host = "127.0.0.1"
-    server.socket_port = conf.get_ini().get_tcp_port()
+    server.socket_port = ctx.get_ini().get_tcp_port()
     server.thread_pool = 8
     server.subscribe()
     cherrypy.engine.start()
@@ -49,6 +49,6 @@ def main(conf: config.Config) -> None:
 
 
 if __name__ == "__main__":
-    main(config.Config(""))
+    main(context.Context(""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/context.py
+++ b/context.py
@@ -153,8 +153,8 @@ class Ini:
         return self.__config.get("wsgi", "cron_update_inactive", fallback="False").strip() == "True"
 
 
-class Config:
-    """Config replacement without static state."""
+class Context:
+    """Context owns global state which is set up once and then read everywhere."""
     def __init__(self, prefix: str) -> None:
         root_dir = os.path.abspath(os.path.dirname(__file__))
         self.root = os.path.join(root_dir, prefix)

--- a/i18n.py
+++ b/i18n.py
@@ -11,13 +11,13 @@ from typing import cast
 import gettext
 import threading
 
-import config
+import context
 
 
-def set_language(conf: config.Config, language: str) -> None:
+def set_language(ctx: context.Context, language: str) -> None:
     """Sets the language of the current thread."""
     tls = threading.current_thread.__dict__
-    localedir = conf.get_abspath("locale")
+    localedir = ctx.get_abspath("locale")
     tls["translations"] = gettext.translation("osm-gimmisn", localedir=localedir, languages=[language], fallback=True)
     tls["language"] = language
 

--- a/missing_housenumbers.py
+++ b/missing_housenumbers.py
@@ -12,16 +12,16 @@ from typing import TextIO
 import sys
 
 import areas
-import config
+import context
 import util
 
 
-def main(argv: List[str], stdout: TextIO, conf: config.Config) -> None:
+def main(argv: List[str], stdout: TextIO, ctx: context.Context) -> None:
     """Commandline interface."""
 
     relation_name = argv[1]
 
-    relations = areas.Relations(conf)
+    relations = areas.Relations(ctx)
     relation = relations.get_relation(relation_name)
     ongoing_streets, _ = relation.get_missing_housenumbers()
 
@@ -36,6 +36,6 @@ def main(argv: List[str], stdout: TextIO, conf: config.Config) -> None:
 
 
 if __name__ == '__main__':
-    main(sys.argv, sys.stdout, config.Config(""))
+    main(sys.argv, sys.stdout, context.Context(""))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/overpass_query.py
+++ b/overpass_query.py
@@ -10,23 +10,23 @@
 from typing import Tuple
 import re
 
-import config
+import context
 
 
-def overpass_query(conf: config.Config, query: str) -> Tuple[str, str]:
+def overpass_query(ctx: context.Context, query: str) -> Tuple[str, str]:
     """Posts the query string to the overpass API and returns the result string."""
-    url = conf.get_ini().get_overpass_uri() + "/api/interpreter"
+    url = ctx.get_ini().get_overpass_uri() + "/api/interpreter"
 
-    urlopen = conf.get_network().urlopen
+    urlopen = ctx.get_network().urlopen
     buf, err = urlopen(url, bytes(query, "utf-8"))
 
     return (buf.decode('utf-8'), err)
 
 
-def overpass_query_need_sleep(conf: config.Config) -> int:
+def overpass_query_need_sleep(ctx: context.Context) -> int:
     """Checks if we need to sleep before executing an overpass query."""
-    urlopen = conf.get_network().urlopen
-    buf, err = urlopen(conf.get_ini().get_overpass_uri() + "/api/status")
+    urlopen = ctx.get_network().urlopen
+    buf, err = urlopen(ctx.get_ini().get_overpass_uri() + "/api/status")
     if err:
         return 0
     status = buf.decode('utf-8')

--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -14,7 +14,7 @@ import unittest
 
 import yattag
 
-import test_config
+import test_context
 
 import areas
 import ranges
@@ -25,7 +25,7 @@ class TestRelationGetOsmStreets(unittest.TestCase):
     """Tests Relation.get_osm_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("test")
         actual = [i.get_osm_name() for i in relation.get_osm_streets()]
         expected = ['B1', 'B2', 'HB1', 'HB2']
@@ -33,7 +33,7 @@ class TestRelationGetOsmStreets(unittest.TestCase):
 
     def test_street_is_node(self) -> None:
         """Tests the case when the street name is coming from a house number (node)."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gh830")
         actual = relation.get_osm_streets()
         self.assertEqual(len(actual), 1)
@@ -41,7 +41,7 @@ class TestRelationGetOsmStreets(unittest.TestCase):
 
     def test_no_house_number(self) -> None:
         """Tests the case when we have streets, but no house numbers."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("ujbuda")
         actual = [i.get_osm_name() for i in relation.get_osm_streets()]
         expected = ['OSM Name 1', 'Törökugrató utca', 'Tűzkő utca']
@@ -49,7 +49,7 @@ class TestRelationGetOsmStreets(unittest.TestCase):
 
     def test_conscriptionnumber(self) -> None:
         """Tests when there is only an addr:conscriptionnumber."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gh754"
         relation = relations.get_relation(relation_name)
         streets = [i.get_osm_name() for i in relation.get_osm_streets()]
@@ -62,7 +62,7 @@ class TestRelationGetOsmStreetsQuery(unittest.TestCase):
     """Tests Relation.get_osm_streets_query()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         self.assertEqual(os.path.join(os.path.dirname(__file__), "workdir"), relations.get_workdir())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -74,7 +74,7 @@ class TestRelationGetOsmHousenumbersQuery(unittest.TestCase):
     """Tests Relation.get_osm_housenumbers_query()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         ret = relation.get_osm_housenumbers_query()
@@ -85,7 +85,7 @@ class TestRelationFilesWriteOsmStreets(unittest.TestCase):
     """Tests RelationFiles.write_osm_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         result_from_overpass = "@id\tname\n1\tTűzkő utca\n2\tTörökugrató utca\n3\tOSM Name 1\n4\tHamzsabégi út\n"
@@ -99,7 +99,7 @@ class TestRelationFilesWriteOsmHousenumbers(unittest.TestCase):
     """Tests RelationFiles.write_osm_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gazdagret"
         result_from_overpass = "@id\taddr:street\taddr:housenumber\taddr:postcode\taddr:housename\t"
         result_from_overpass += "addr:conscriptionnumber\taddr:flats\taddr:floor\taddr:door\taddr:unit\tname\t@type\n\n"
@@ -127,7 +127,7 @@ class TestRelationGetStreetRanges(unittest.TestCase):
     """Tests Relation.get_street_ranges()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         filters = relation.get_street_ranges()
         expected_filters = {
@@ -141,14 +141,14 @@ class TestRelationGetStreetRanges(unittest.TestCase):
             'OSM Name 2': 'Ref Name 2',
             'Misspelled OSM Name 1': 'OSM Name 1',
         }
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         self.assertEqual(relations.get_relation("gazdagret").get_config().get_refstreets(), expected_streets)
         street_blacklist = relations.get_relation("gazdagret").get_config().get_street_filters()
         self.assertEqual(street_blacklist, ['Only In Ref Nonsense utca'])
 
     def test_empty(self) -> None:
         """Tests when the filter file is empty."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("empty")
         filters = relation.get_street_ranges()
         self.assertEqual(filters, {})
@@ -158,7 +158,7 @@ class TestRelationGetRefStreetFromOsmStreet(unittest.TestCase):
     """Tests Relation.get_ref_street_from_osm_street()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         street = "Budaörsi út"
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -170,7 +170,7 @@ class TestRelationGetRefStreetFromOsmStreet(unittest.TestCase):
 
     def test_refsettlement_override(self) -> None:
         """Tests street-specific refsettlement override."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         street = "Teszt utca"
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -182,7 +182,7 @@ class TestRelationGetRefStreetFromOsmStreet(unittest.TestCase):
 
     def test_refstreets(self) -> None:
         """Tests OSM -> ref name mapping."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         street = "OSM Name 1"
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -194,7 +194,7 @@ class TestRelationGetRefStreetFromOsmStreet(unittest.TestCase):
 
     def test_nosuchrelation(self) -> None:
         """Tests a relation without a filter file."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         street = "OSM Name 1"
         relation_name = "nosuchrelation"
         relation = relations.get_relation(relation_name)
@@ -206,7 +206,7 @@ class TestRelationGetRefStreetFromOsmStreet(unittest.TestCase):
 
     def test_emptyrelation(self) -> None:
         """Tests a relation with an empty filter file."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         street = "OSM Name 1"
         relation_name = "empty"
         relation = relations.get_relation(relation_name)
@@ -218,7 +218,7 @@ class TestRelationGetRefStreetFromOsmStreet(unittest.TestCase):
 
     def test_range_level_override(self) -> None:
         """Tests the refsettlement range-level override."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         street = "Csiki-hegyek utca"
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
@@ -237,7 +237,7 @@ class TestNormalize(unittest.TestCase):
     """
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "139", "Budaörsi út", normalizers)
@@ -245,7 +245,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_not_in_range(self) -> None:
         """Tests when the number is not in range."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "999", "Budaörsi út", normalizers)
@@ -253,7 +253,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_not_a_number(self) -> None:
         """Tests the case when the house number is not a number."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "x", "Budaörsi út", normalizers)
@@ -261,7 +261,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_nofilter(self) -> None:
         """Tests the case when there is no filter for this street."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "1", "Budaörs út", normalizers)
@@ -269,7 +269,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_separator_semicolon(self) -> None:
         """Tests the case when ';' is a separator."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "1;2", "Budaörs út", normalizers)
@@ -277,7 +277,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_separator_interval(self) -> None:
         """Tests the 2-6 case: means implicit 4."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "2-6", "Budaörs út", normalizers)
@@ -285,7 +285,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_separator_interval_parity(self) -> None:
         """Tests the 5-8 case: means just 5 and 8 as the parity doesn't match."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "5-8", "Budaörs út", normalizers)
@@ -293,7 +293,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_separator_interval_interp_all(self) -> None:
         """Tests the 2-5 case: means implicit 3 and 4."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = [i.get_number() for i in areas.normalize(relation, "2-5", "Hamzsabégi út", normalizers)]
@@ -301,7 +301,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_separator_interval_filter(self) -> None:
         """Tests the case where x-y is partially filtered out."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         # filter is 137-165
@@ -311,7 +311,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_separator_interval_block(self) -> None:
         """Tests the case where x-y is nonsense: y is too large."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "2-2000", "Budaörs út", normalizers)
@@ -321,7 +321,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_separator_interval_block2(self) -> None:
         """Tests the case where x-y is nonsense: y-x is too large."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "2-56", "Budaörs út", normalizers)
@@ -330,7 +330,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_separator_interval_block3(self) -> None:
         """Tests the case where x-y is nonsense: x is 0."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "0-42", "Budaörs út", normalizers)
@@ -339,7 +339,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_separator_interval_block4(self) -> None:
         """Tests the case where x-y is only partially useful: x is OK, but y is a suffix."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "42-1", "Budaörs út", normalizers)
@@ -348,7 +348,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_keep_suffix(self) -> None:
         """Tests that the * suffix is preserved."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_number = areas.normalize(relation, "1*", "Budaörs út", normalizers)
@@ -358,7 +358,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_separator_comma(self) -> None:
         """Tests the case when ',' is a separator."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         normalizers = relation.get_street_ranges()
         house_numbers = areas.normalize(relation, "2,6", "Budaörs út", normalizers)
@@ -371,7 +371,7 @@ class TestRelationGetRefStreets(unittest.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         relation_name = "gazdagret"
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation(relation_name)
         house_numbers = relation.get_ref_streets()
         self.assertEqual(house_numbers, ['Hamzsabégi út',
@@ -388,7 +388,7 @@ class TestRelationGetOsmHouseNumbers(unittest.TestCase):
         """Tests the happy path."""
         relation_name = "gazdagret"
         street_name = "Törökugrató utca"
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation(relation_name)
         house_numbers = relation.get_osm_housenumbers(street_name)
         self.assertEqual([i.get_number() for i in house_numbers], ["1", "2"])
@@ -396,7 +396,7 @@ class TestRelationGetOsmHouseNumbers(unittest.TestCase):
     def test_addr_place(self) -> None:
         """Tests the case when addr:place is used instead of addr:street."""
         relation_name = "gh964"
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation(relation_name)
         street_name = "Tolvajos tanya"
         house_numbers = relation.get_osm_housenumbers(street_name)
@@ -407,7 +407,7 @@ class TestRelationGetMissingHousenumbers(unittest.TestCase):
     """Tests Relation.get_missing_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         ongoing_streets, done_streets = relation.get_missing_housenumbers()
@@ -424,7 +424,7 @@ class TestRelationGetMissingHousenumbers(unittest.TestCase):
 
     def test_letter_suffix(self) -> None:
         """Tests that 7/A is detected when 7/B is already mapped."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gh267"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -440,7 +440,7 @@ class TestRelationGetMissingHousenumbers(unittest.TestCase):
 
     def test_letter_suffix_invalid(self) -> None:
         """Tests how 'invalid' interacts with normalization."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gh296"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -464,7 +464,7 @@ class TestRelationGetMissingHousenumbers(unittest.TestCase):
 
     def test_invalid_simplify(self) -> None:
         """Tests how 'invalid' interacts with housenumber-letters: true or false."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gh385"
         relation = relations.get_relation(relation_name)
 
@@ -505,7 +505,7 @@ class TestRelationGetMissingHousenumbers(unittest.TestCase):
 
     def test_letter_suffix_normalize(self) -> None:
         """Tests that '42 A' vs '42/A' is recognized as a match."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gh286"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -521,7 +521,7 @@ class TestRelationGetMissingHousenumbers(unittest.TestCase):
 
     def test_letter_suffix_source_suffix(self) -> None:
         """Tests that '42/A*' and '42/a' matches."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gh299"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -532,7 +532,7 @@ class TestRelationGetMissingHousenumbers(unittest.TestCase):
 
     def test_letter_suffix_normalize_semicolon(self) -> None:
         """Tests that 'a' is not stripped from '1;3a'."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gh303"
         relation = relations.get_relation(relation_name)
         # Opt-in, this is not the default behavior.
@@ -551,7 +551,7 @@ class TestRelationGetMissingStreets(unittest.TestCase):
     """Tests Relation.get_missing_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         only_in_reference, in_both = relation.get_missing_streets()
@@ -566,7 +566,7 @@ class TestRelationGetAdditionalStreets(unittest.TestCase):
     """Tests Relation.get_additional_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         only_in_osm = relation.get_additional_streets()
@@ -579,7 +579,7 @@ class TestRelationGetAdditionalStreets(unittest.TestCase):
 
     def test_no_osm_street_filters(self) -> None:
         """Tests when the osm-street-filters key is missing."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gh385"
         relation = relations.get_relation(relation_name)
         self.assertEqual(relation.get_config().get_osm_street_filters(), [])
@@ -589,7 +589,7 @@ class TestRelationGetAdditionalHousenumbers(unittest.TestCase):
     """Tests Relation.get_additional_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         only_in_osm = relation.get_additional_housenumbers()
@@ -613,7 +613,7 @@ class TestRelationWriteMissingHouseNumbers(unittest.TestCase):
     """Tests Relation.write_missing_housenumbers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         expected = util.get_content(relations.get_workdir(), "gazdagret.percent")
@@ -633,7 +633,7 @@ class TestRelationWriteMissingHouseNumbers(unittest.TestCase):
 
     def test_empty(self) -> None:
         """Tests the case when percent can't be determined."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "empty"
         relation = relations.get_relation(relation_name)
         ret = relation.write_missing_housenumbers()
@@ -644,7 +644,7 @@ class TestRelationWriteMissingHouseNumbers(unittest.TestCase):
 
     def test_interpolation_all(self) -> None:
         """Tests the case when the street is interpolation=all and coloring is wanted."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "budafok"
         relation = relations.get_relation(relation_name)
         ret = relation.write_missing_housenumbers()
@@ -657,7 +657,7 @@ class TestRelationWriteMissingHouseNumbers(unittest.TestCase):
 
     def test_sorting(self) -> None:
         """Tests that sorting is performed after range reduction."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gh414"
         relation = relations.get_relation(relation_name)
         ret = relation.write_missing_housenumbers()
@@ -674,7 +674,7 @@ class TestRelationWriteMissingStreets(unittest.TestCase):
     """Tests Relation.write_missing_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         expected = util.get_content(relations.get_workdir(), "gazdagret-streets.percent")
@@ -689,7 +689,7 @@ class TestRelationWriteMissingStreets(unittest.TestCase):
 
     def test_empty(self) -> None:
         """Tests the case when percent can't be determined."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "empty"
         relation = relations.get_relation(relation_name)
         ret = relation.write_missing_streets()
@@ -703,7 +703,7 @@ class TestRelationBuildRefHousenumbers(unittest.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
         memory_cache = util.build_reference_cache(refpath, "01")
         relation_name = "gazdagret"
@@ -722,7 +722,7 @@ class TestRelationBuildRefHousenumbers(unittest.TestCase):
 
     def test_missing(self) -> None:
         """Tests the case when the street is not in the reference."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
         memory_cache = util.build_reference_cache(refpath, "01")
@@ -741,7 +741,7 @@ class TestRelationBuildRefStreets(unittest.TestCase):
         refpath = os.path.join(refdir, "utcak_20190514.tsv")
         memory_cache = util.build_street_reference_cache(refpath)
         relation_name = "gazdagret"
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation(relation_name)
         ret = relation.get_config().build_ref_streets(memory_cache)
         self.assertEqual(ret, ['Törökugrató utca',
@@ -759,7 +759,7 @@ class TestRelationWriteRefHousenumbers(unittest.TestCase):
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
         refpath2 = os.path.join(refdir, "hazszamok_kieg_20190808.tsv")
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gazdagret"
         expected = util.get_content(relations.get_workdir(), "street-housenumbers-reference-gazdagret.lst")
         relation = relations.get_relation(relation_name)
@@ -771,7 +771,7 @@ class TestRelationWriteRefHousenumbers(unittest.TestCase):
         """Tests the case when the refcounty code is missing in the reference."""
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "nosuchrefcounty"
         relation = relations.get_relation(relation_name)
         try:
@@ -783,7 +783,7 @@ class TestRelationWriteRefHousenumbers(unittest.TestCase):
         """Tests the case when the refsettlement code is missing in the reference."""
         refdir = os.path.join(os.path.dirname(__file__), "refdir")
         refpath = os.path.join(refdir, "hazszamok_20190511.tsv")
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "nosuchrefsettlement"
         relation = relations.get_relation(relation_name)
         try:
@@ -796,9 +796,9 @@ class TestRelationWriteRefStreets(unittest.TestCase):
     """Tests Relation.WriteRefStreets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        refpath = conf.get_abspath(os.path.join("refdir", "utcak_20190514.tsv"))
-        relations = areas.Relations(test_config.make_test_config())
+        ctx = test_context.make_test_context()
+        refpath = ctx.get_abspath(os.path.join("refdir", "utcak_20190514.tsv"))
+        relations = areas.Relations(test_context.make_test_context())
         relation_name = "gazdagret"
         relation = relations.get_relation(relation_name)
         expected = util.get_content(relations.get_workdir(), "streets-reference-gazdagret.lst")
@@ -811,7 +811,7 @@ class TestRelations(unittest.TestCase):
     """Tests the Relations class."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         expected_relation_names = [
             "budafok",
             "empty",
@@ -860,7 +860,7 @@ class TestRelationConfigMissingStreets(unittest.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         relation_name = "ujbuda"
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation(relation_name)
         ret = relation.get_config().should_check_missing_streets()
         self.assertEqual(ret, "only")
@@ -868,7 +868,7 @@ class TestRelationConfigMissingStreets(unittest.TestCase):
     def test_empty(self) -> None:
         """Tests the default value."""
         relation_name = "empty"
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation(relation_name)
         self.assertEqual(relation.get_name(), "empty")
         ret = relation.get_config().should_check_missing_streets()
@@ -877,7 +877,7 @@ class TestRelationConfigMissingStreets(unittest.TestCase):
     def test_nosuchrelation(self) -> None:
         """Tests a relation without a filter file."""
         relation_name = "nosuchrelation"
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation(relation_name)
         ret = relation.get_config().should_check_missing_streets()
         self.assertEqual(ret, "yes")
@@ -888,7 +888,7 @@ class TestRelationConfigLetterSuffixStyle(unittest.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         relation_name = "empty"
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation(relation_name)
         self.assertEqual(relation.get_config().get_letter_suffix_style(), util.LetterSuffixStyle.UPPER)
         relation.get_config().set_letter_suffix_style(util.LetterSuffixStyle.LOWER)
@@ -899,8 +899,8 @@ class TestRefmegyeGetName(unittest.TestCase):
     """Tests refcounty_get_name()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         self.assertEqual(relations.refcounty_get_name("01"), "Budapest")
         self.assertEqual(relations.refcounty_get_name("99"), "")
 
@@ -909,8 +909,8 @@ class TestRefmegyeGetReftelepulesIds(unittest.TestCase):
     """Tests refcounty_get_refsettlement_ids()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         self.assertEqual(relations.refcounty_get_refsettlement_ids("01"), ["011", "012"])
         self.assertEqual(relations.refcounty_get_refsettlement_ids("99"), [])
 
@@ -919,8 +919,8 @@ class TestReftelepulesGetName(unittest.TestCase):
     """Tests refsettlement_get_name()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         self.assertEqual(relations.refsettlement_get_name("01", "011"), "Újbuda")
         self.assertEqual(relations.refsettlement_get_name("99", ""), "")
         self.assertEqual(relations.refsettlement_get_name("01", "99"), "")
@@ -930,8 +930,8 @@ class TestRelationsGetAliases(unittest.TestCase):
     """Tests Relalations.get_aliases()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         # Expect an alias -> canonicalname map.
         expected = {
             "budapest_22": "budafok"
@@ -943,8 +943,8 @@ class TestRelationStreetIsEvenOdd(unittest.TestCase):
     """Tests RelationConfig.get_street_is_even_odd()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("gazdagret")
         self.assertFalse(relation.get_config().get_street_is_even_odd("Hamzsabégi út"))
 
@@ -955,7 +955,7 @@ class TestRelationShowRefstreet(unittest.TestCase):
     """Tests RelationConfig.should_show_ref_street()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         self.assertFalse(relation.should_show_ref_street("Törökugrató utca"))
         self.assertTrue(relation.should_show_ref_street("Hamzsabégi út"))
@@ -965,7 +965,7 @@ class TestRelationIsActive(unittest.TestCase):
     """Tests RelationConfig.is_active()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         self.assertTrue(relation.get_config().is_active())
 
@@ -974,7 +974,7 @@ class TestMakeTurboQueryForStreets(unittest.TestCase):
     """Tests make_turbo_query_for_streets()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         fro = ["A2"]
         ret = areas.make_turbo_query_for_streets(relation, fro)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -9,7 +9,7 @@
 import os
 import unittest
 
-import test_config
+import test_context
 
 import areas
 import cache
@@ -19,87 +19,87 @@ class TestIsMissingHousenumbersHtmlCached(unittest.TestCase):
     """Tests is_missing_housenumbers_html_cached()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("gazdagret")
-        cache.get_missing_housenumbers_html(conf, relation)
-        self.assertTrue(cache.is_missing_housenumbers_html_cached(conf, relation))
+        cache.get_missing_housenumbers_html(ctx, relation)
+        self.assertTrue(cache.is_missing_housenumbers_html_cached(ctx, relation))
 
     def test_no_cache(self) -> None:
         """Tests the case when there is no cache."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("gazdagret")
-        cache.get_missing_housenumbers_html(conf, relation)
+        cache.get_missing_housenumbers_html(ctx, relation)
         cache_path = relation.get_files().get_housenumbers_htmlcache_path()
 
-        file_system = test_config.TestFileSystem()
+        file_system = test_context.TestFileSystem()
         file_system.set_hide_paths([cache_path])
-        conf.set_file_system(file_system)
-        self.assertFalse(cache.is_missing_housenumbers_html_cached(conf, relation))
+        ctx.set_file_system(file_system)
+        self.assertFalse(cache.is_missing_housenumbers_html_cached(ctx, relation))
 
     def test_osm_housenumbers_new(self) -> None:
         """Tests the case when osm_housenumbers is new, so the cache entry is old."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("gazdagret")
-        cache.get_missing_housenumbers_html(conf, relation)
+        cache.get_missing_housenumbers_html(ctx, relation)
         cache_path = relation.get_files().get_housenumbers_htmlcache_path()
         osm_housenumbers_path = relation.get_files().get_osm_housenumbers_path()
 
-        file_system = test_config.TestFileSystem()
+        file_system = test_context.TestFileSystem()
         mtimes = {
             osm_housenumbers_path: os.path.getmtime(cache_path) + 1,
         }
         file_system.set_mtimes(mtimes)
-        conf.set_file_system(file_system)
-        self.assertFalse(cache.is_missing_housenumbers_html_cached(conf, relation))
+        ctx.set_file_system(file_system)
+        self.assertFalse(cache.is_missing_housenumbers_html_cached(ctx, relation))
 
     def test_ref_housenumbers_new(self) -> None:
         """Tests the case when ref_housenumbers is new, so the cache entry is old."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("gazdagret")
-        cache.get_missing_housenumbers_html(conf, relation)
+        cache.get_missing_housenumbers_html(ctx, relation)
         cache_path = relation.get_files().get_housenumbers_htmlcache_path()
         ref_housenumbers_path = relation.get_files().get_ref_housenumbers_path()
 
-        file_system = test_config.TestFileSystem()
+        file_system = test_context.TestFileSystem()
         mtimes = {
             ref_housenumbers_path: os.path.getmtime(cache_path) + 1,
         }
         file_system.set_mtimes(mtimes)
-        conf.set_file_system(file_system)
-        self.assertFalse(cache.is_missing_housenumbers_html_cached(conf, relation))
+        ctx.set_file_system(file_system)
+        self.assertFalse(cache.is_missing_housenumbers_html_cached(ctx, relation))
 
     def test_relation_new(self) -> None:
         """Tests the case when relation is new, so the cache entry is old."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("gazdagret")
-        cache.get_missing_housenumbers_html(conf, relation)
+        cache.get_missing_housenumbers_html(ctx, relation)
         cache_path = relation.get_files().get_housenumbers_htmlcache_path()
-        datadir = conf.get_abspath("data")
+        datadir = ctx.get_abspath("data")
         relation_path = os.path.join(datadir, "relation-%s.yaml" % relation.get_name())
 
-        file_system = test_config.TestFileSystem()
+        file_system = test_context.TestFileSystem()
         mtimes = {
             relation_path: os.path.getmtime(cache_path) + 1,
         }
         file_system.set_mtimes(mtimes)
-        conf.set_file_system(file_system)
-        self.assertFalse(cache.is_missing_housenumbers_html_cached(conf, relation))
+        ctx.set_file_system(file_system)
+        self.assertFalse(cache.is_missing_housenumbers_html_cached(ctx, relation))
 
 
 class TestGetAdditionalHousenumbersHtml(unittest.TestCase):
     """Tests get_additional_housenumbers_html()."""
     def test_happy(self) -> None:
         """Tests the case when we find the result in cache."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("gazdagret")
-        first = cache.get_additional_housenumbers_html(conf, relation)
-        second = cache.get_additional_housenumbers_html(conf, relation)
+        first = cache.get_additional_housenumbers_html(ctx, relation)
+        second = cache.get_additional_housenumbers_html(ctx, relation)
         self.assertEqual(first.getvalue(), second.getvalue())
 
 
@@ -107,10 +107,10 @@ class TestIsMissingHousenumbersTxtCached(unittest.TestCase):
     """Tests is_missing_housenumbers_txt_cached()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("gazdagret")
-        cache.get_missing_housenumbers_txt(conf, relation)
-        self.assertTrue(cache.is_missing_housenumbers_txt_cached(conf, relation))
+        cache.get_missing_housenumbers_txt(ctx, relation)
+        self.assertTrue(cache.is_missing_housenumbers_txt_cached(ctx, relation))
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/tests/test_cache_yamls.py
+++ b/tests/test_cache_yamls.py
@@ -10,7 +10,7 @@ import json
 import os
 import unittest
 
-import test_config
+import test_context
 
 import areas
 import cache_yamls
@@ -24,8 +24,8 @@ class TestMain(unittest.TestCase):
         if os.path.exists(cache_path):
             os.remove(cache_path)
         argv = ["", "data", "workdir"]
-        conf = test_config.make_test_config()
-        cache_yamls.main(argv, conf)
+        ctx = test_context.make_test_context()
+        cache_yamls.main(argv, ctx)
         # Just assert that the result is created, the actual content is validated by the other
         # tests.
         self.assertTrue(os.path.exists(cache_path))
@@ -34,7 +34,7 @@ class TestMain(unittest.TestCase):
         relation_ids = []
         with open(relation_ids_path) as stream:
             relation_ids = json.load(stream)
-        relations = areas.Relations(conf)
+        relations = areas.Relations(ctx)
         osmids = sorted([relation.get_config().get_osmrelation() for relation in relations.get_relations()])
         self.assertEqual(relation_ids, sorted(set(osmids)))
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -18,15 +18,15 @@ import io
 import os
 import unittest
 
-import config
+import context
 
 
-def make_test_config() -> config.Config:
-    """Creates a Config instance that has its root as /tests."""
-    return config.Config("tests")
+def make_test_context() -> context.Context:
+    """Creates a Context instance for text purposes."""
+    return context.Context("tests")
 
 
-class TestFileSystem(config.FileSystem):
+class TestFileSystem(context.FileSystem):
     """File system implementation, for test purposes."""
     def __init__(self) -> None:
         self.__hide_paths: List[str] = []
@@ -76,7 +76,7 @@ class URLRoute:
         self.result_path = result_path
 
 
-class TestNetwork(config.Network):
+class TestNetwork(context.Network):
     """Network implementation, for test purposes."""
     def __init__(self, routes: List[URLRoute]) -> None:
         self.__routes = routes
@@ -103,7 +103,7 @@ class TestNetwork(config.Network):
         return (bytes(), "url missing from route list: '" + url + "'")
 
 
-class TestTime(config.Time):
+class TestTime(context.Time):
     """Time implementation, for test purposes."""
     def __init__(self, now: float) -> None:
         self.__now = now
@@ -112,7 +112,7 @@ class TestTime(config.Time):
         return self.__now
 
 
-class TestSubprocess(config.Subprocess):
+class TestSubprocess(context.Subprocess):
     """Subprocess implementation, for test purposes."""
     def __init__(self, outputs: Dict[str, bytes]) -> None:
         self.__outputs = outputs
@@ -134,7 +134,7 @@ class TestSubprocess(config.Subprocess):
         return self.__outputs[key]
 
 
-def make_test_time() -> config.Time:
+def make_test_time() -> context.Time:
     """Generates unix timestamp for 2020-05-10."""
     return TestTime(calendar.timegm(datetime.date(2020, 5, 10).timetuple()))
 
@@ -143,5 +143,5 @@ class TestIniGetTcpPort(unittest.TestCase):
     """Tests Ini.get_tcp_port()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = make_test_config()
-        self.assertEqual(conf.get_ini().get_tcp_port(), 8000)
+        ctx = make_test_context()
+        self.assertEqual(ctx.get_ini().get_tcp_port(), 8000)

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -9,27 +9,27 @@
 from typing import Any
 import unittest
 
-import test_config
+import test_context
 
-import config
+import context
 import i18n
 
 
 class LanguageContext:
     """Context manager for i18n.translate()."""
-    def __init__(self, conf: config.Config, language: str) -> None:
+    def __init__(self, ctx: context.Context, language: str) -> None:
         """Remembers what should be the new language."""
-        self.conf = conf
+        self.ctx = ctx
         self.language = language
 
     def __enter__(self) -> 'LanguageContext':
         """Switches to the new language."""
-        i18n.set_language(self.conf, self.language)
+        i18n.set_language(self.ctx, self.language)
         return self
 
     def __exit__(self, _exc_type: Any, _exc_value: Any, _exc_traceback: Any) -> bool:
         """Switches back to the old language."""
-        i18n.set_language(self.conf, "en")
+        i18n.set_language(self.ctx, "en")
         return True
 
 
@@ -37,8 +37,8 @@ class TestTranslate(unittest.TestCase):
     """Tests translate()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        with LanguageContext(conf, "hu"):
+        ctx = test_context.make_test_context()
+        with LanguageContext(ctx, "hu"):
             self.assertEqual(i18n.translate("Area"), "Terület")
 
 

--- a/tests/test_missing_housenumbers.py
+++ b/tests/test_missing_housenumbers.py
@@ -9,7 +9,7 @@
 import io
 import unittest
 
-import test_config
+import test_context
 
 import missing_housenumbers
 
@@ -20,8 +20,8 @@ class TestMain(unittest.TestCase):
         """Tests the happy path."""
         argv = ["", "gh195"]
         buf = io.StringIO()
-        conf = test_config.make_test_config()
-        missing_housenumbers.main(argv, buf, conf)
+        ctx = test_context.make_test_context()
+        missing_housenumbers.main(argv, buf, ctx)
 
         buf.seek(0)
         self.assertEqual(buf.read(), "Kalotaszeg utca\t3\n['25', '27-37', '31*']\n")

--- a/tests/test_overpass_query.py
+++ b/tests/test_overpass_query.py
@@ -9,7 +9,7 @@
 from typing import List
 import unittest
 
-import test_config
+import test_context
 
 import overpass_query
 
@@ -18,56 +18,56 @@ class TestOverpassQueryNeedSleeep(unittest.TestCase):
     """Tests overpass_query_need_sleep()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        routes: List[test_config.URLRoute] = [
-            test_config.URLRoute(url="https://overpass-api.de/api/status",
-                                 data_path="",
-                                 result_path="tests/network/overpass-status-happy.txt")
+        ctx = test_context.make_test_context()
+        routes: List[test_context.URLRoute] = [
+            test_context.URLRoute(url="https://overpass-api.de/api/status",
+                                  data_path="",
+                                  result_path="tests/network/overpass-status-happy.txt")
         ]
-        network = test_config.TestNetwork(routes)
-        conf.set_network(network)
-        self.assertEqual(overpass_query.overpass_query_need_sleep(conf), 0)
+        network = test_context.TestNetwork(routes)
+        ctx.set_network(network)
+        self.assertEqual(overpass_query.overpass_query_need_sleep(ctx), 0)
 
     def test_wait(self) -> None:
         """Tests the wait path."""
-        conf = test_config.make_test_config()
-        routes: List[test_config.URLRoute] = [
-            test_config.URLRoute(url="https://overpass-api.de/api/status",
-                                 data_path="",
-                                 result_path="tests/network/overpass-status-wait.txt")
+        ctx = test_context.make_test_context()
+        routes: List[test_context.URLRoute] = [
+            test_context.URLRoute(url="https://overpass-api.de/api/status",
+                                  data_path="",
+                                  result_path="tests/network/overpass-status-wait.txt")
         ]
-        network = test_config.TestNetwork(routes)
-        conf.set_network(network)
-        self.assertEqual(overpass_query.overpass_query_need_sleep(conf), 12)
+        network = test_context.TestNetwork(routes)
+        ctx.set_network(network)
+        self.assertEqual(overpass_query.overpass_query_need_sleep(ctx), 12)
 
     def test_wait_negative(self) -> None:
         """Tests the wait for negative amount path."""
-        conf = test_config.make_test_config()
-        routes: List[test_config.URLRoute] = [
-            test_config.URLRoute(url="https://overpass-api.de/api/status",
-                                 data_path="",
-                                 result_path="tests/network/overpass-status-wait-negative.txt")
+        ctx = test_context.make_test_context()
+        routes: List[test_context.URLRoute] = [
+            test_context.URLRoute(url="https://overpass-api.de/api/status",
+                                  data_path="",
+                                  result_path="tests/network/overpass-status-wait-negative.txt")
         ]
-        network = test_config.TestNetwork(routes)
-        conf.set_network(network)
-        self.assertEqual(overpass_query.overpass_query_need_sleep(conf), 1)
+        network = test_context.TestNetwork(routes)
+        ctx.set_network(network)
+        self.assertEqual(overpass_query.overpass_query_need_sleep(ctx), 1)
 
 
 class TestOverpassQuery(unittest.TestCase):
     """Tests overpass_query()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        routes: List[test_config.URLRoute] = [
-            test_config.URLRoute(url="https://overpass-api.de/api/interpreter",
-                                 data_path="tests/network/overpass-happy.expected-data",
-                                 result_path="tests/network/overpass-happy.csv")
+        ctx = test_context.make_test_context()
+        routes: List[test_context.URLRoute] = [
+            test_context.URLRoute(url="https://overpass-api.de/api/interpreter",
+                                  data_path="tests/network/overpass-happy.expected-data",
+                                  result_path="tests/network/overpass-happy.csv")
         ]
-        network = test_config.TestNetwork(routes)
-        conf.set_network(network)
+        network = test_context.TestNetwork(routes)
+        ctx.set_network(network)
         with open("tests/network/overpass-happy.expected-data") as stream:
             query = stream.read()
-            buf, err = overpass_query.overpass_query(conf, query)
+            buf, err = overpass_query.overpass_query(ctx, query)
             self.assertEqual(buf[:3], "@id")
             self.assertEqual(err, str())
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -13,26 +13,26 @@ import datetime
 import os
 import unittest
 
-import test_config
+import test_context
 
-import config
+import context
 import stats
 
 
-def make_test_time_old() -> config.Time:
+def make_test_time_old() -> context.Time:
     """Generates unix timestamp for an old date."""
-    return test_config.TestTime(calendar.timegm(datetime.date(1970, 1, 1).timetuple()))
+    return test_context.TestTime(calendar.timegm(datetime.date(1970, 1, 1).timetuple()))
 
 
 class TestHandleProgress(unittest.TestCase):
     """Tests handle_progress()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_progress(conf, src_root, j)
+        stats.handle_progress(ctx, src_root, j)
         progress = j["progress"]
         self.assertEqual(progress["date"], "2020-05-10")
         # 254651 / 300 * 100
@@ -40,11 +40,11 @@ class TestHandleProgress(unittest.TestCase):
 
     def test_old_time(self) -> None:
         """Tests the case when the .count file doesn't exist for a date."""
-        conf = test_config.make_test_config()
-        conf.set_time(make_test_time_old())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(make_test_time_old())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_progress(conf, src_root, j)
+        stats.handle_progress(ctx, src_root, j)
         progress = j["progress"]
         self.assertEqual(progress["date"], "1970-01-01")
 
@@ -53,22 +53,22 @@ class TestHandleTopusers(unittest.TestCase):
     """Tests handle_topusers()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_topusers(conf, src_root, j)
+        stats.handle_topusers(ctx, src_root, j)
         topusers = j["topusers"]
         self.assertEqual(len(topusers), 20)
         self.assertEqual(topusers[0], ["user1", "68885"])
 
     def test_old_time(self) -> None:
         """Tests the case when the .count file doesn't exist for a date."""
-        conf = test_config.make_test_config()
-        conf.set_time(make_test_time_old())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(make_test_time_old())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_topusers(conf, src_root, j)
+        stats.handle_topusers(ctx, src_root, j)
         topusers = j["topusers"]
         self.assertFalse(topusers)
 
@@ -77,11 +77,11 @@ class TestHandleTopcities(unittest.TestCase):
     """Tests handle_topcities()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_topcities(conf, src_root, j)
+        stats.handle_topcities(ctx, src_root, j)
         topcities = j["topcities"]
         self.assertEqual(len(topcities), 2)
         self.assertEqual(topcities[0], ("budapest_02", 190))
@@ -92,24 +92,24 @@ class TestHandleDailyNew(unittest.TestCase):
     """Tests handle_daily_new()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
         # From now on, today is 2020-05-10, so this will read 2020-04-26, 2020-04-27, etc
         # (till a file is missing.)
-        stats.handle_daily_new(conf, src_root, j)
+        stats.handle_daily_new(ctx, src_root, j)
         daily = j["daily"]
         self.assertEqual(len(daily), 1)
         self.assertEqual(daily[0], ["2020-04-26", 364])
 
     def test_empty_day_range(self) -> None:
         """Tests the case when the day range is empty."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_daily_new(conf, src_root, j, day_range=-1)
+        stats.handle_daily_new(ctx, src_root, j, day_range=-1)
         daily = j["daily"]
         self.assertFalse(daily)
 
@@ -118,11 +118,11 @@ class TestHandleMonthlyNew(unittest.TestCase):
     """Tests handle_monthly_new()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_monthly_new(conf, src_root, j)
+        stats.handle_monthly_new(ctx, src_root, j)
         monthly = j["monthly"]
         self.assertEqual(len(monthly), 2)
         # 2019-05 start -> end
@@ -132,27 +132,27 @@ class TestHandleMonthlyNew(unittest.TestCase):
 
     def test_empty_month_range(self) -> None:
         """Tests the case when the month range is empty."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_monthly_new(conf, src_root, j, month_range=-1)
+        stats.handle_monthly_new(ctx, src_root, j, month_range=-1)
         monthly = j["monthly"]
         self.assertTrue(monthly)
 
     def test_incomplete_last_month(self) -> None:
         """Tests the case when we have no data for the last, incomplete month."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
         # This would be the data for the current state of the last, incomplete month.
-        hide_path = conf.get_abspath("workdir/stats/2020-05-10.count")
-        file_system = test_config.TestFileSystem()
+        hide_path = ctx.get_abspath("workdir/stats/2020-05-10.count")
+        file_system = test_context.TestFileSystem()
         file_system.set_hide_paths([hide_path])
-        conf.set_file_system(file_system)
+        ctx.set_file_system(file_system)
 
-        stats.handle_monthly_new(conf, src_root, j)
+        stats.handle_monthly_new(ctx, src_root, j)
         monthly = j["monthly"]
         # 1st element: 2019-05 start -> end
         # No 2nd element, would be diff from last month end -> today
@@ -164,22 +164,22 @@ class TestHandleDailyTotal(unittest.TestCase):
     """Tests handle_daily_total()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_daily_total(conf, src_root, j)
+        stats.handle_daily_total(ctx, src_root, j)
         dailytotal = j["dailytotal"]
         self.assertEqual(len(dailytotal), 1)
         self.assertEqual(dailytotal[0], ["2020-04-27", 251614])
 
     def test_empty_day_range(self) -> None:
         """Tests the case when the day range is empty."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_daily_total(conf, src_root, j, day_range=-1)
+        stats.handle_daily_total(ctx, src_root, j, day_range=-1)
         dailytotal = j["dailytotal"]
         self.assertFalse(dailytotal)
 
@@ -188,22 +188,22 @@ class TestHandleUserTotal(unittest.TestCase):
     """Tests handle_user_total()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_user_total(conf, src_root, j)
+        stats.handle_user_total(ctx, src_root, j)
         usertotal = j["usertotal"]
         self.assertEqual(len(usertotal), 1)
         self.assertEqual(usertotal[0], ["2020-04-27", 43])
 
     def test_empty_day_range(self) -> None:
         """Tests the case when the day range is empty."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_user_total(conf, src_root, j, day_range=-1)
+        stats.handle_user_total(ctx, src_root, j, day_range=-1)
         usertotal = j["usertotal"]
         self.assertFalse(usertotal)
 
@@ -212,32 +212,32 @@ class TestHandleMonthlyTotal(unittest.TestCase):
     """Tests handle_monthly_total()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_monthly_total(conf, src_root, j)
+        stats.handle_monthly_total(ctx, src_root, j)
         monthlytotal = j["monthlytotal"]
         self.assertEqual(len(monthlytotal), 1)
         self.assertEqual(monthlytotal[0], ['2019-05', 203317])
 
     def test_empty_day_range(self) -> None:
         """Tests the case when the day range is empty."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_monthly_total(conf, src_root, j, month_range=-1)
+        stats.handle_monthly_total(ctx, src_root, j, month_range=-1)
         monthlytotal = j["monthlytotal"]
         self.assertFalse(monthlytotal)
 
     def test_one_element_day_range(self) -> None:
         """Tests the case when the day range is of just one element."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        src_root = ctx.get_abspath("workdir/stats")
         j: Dict[str, Any] = {}
-        stats.handle_monthly_total(conf, src_root, j, month_range=0)
+        stats.handle_monthly_total(ctx, src_root, j, month_range=0)
         monthlytotal = j["monthlytotal"]
         self.assertEqual(len(monthlytotal), 2)
         self.assertEqual(monthlytotal[0], ["2020-04", 253027])
@@ -248,7 +248,7 @@ class TestGetPreviousMonth(unittest.TestCase):
     """Tests get_previous_month()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        time = test_config.make_test_time()
+        time = test_context.make_test_time()
         today = datetime.date.fromtimestamp(time.now())
 
         actual = stats.get_previous_month(today, 2)
@@ -261,24 +261,24 @@ class TestGetTopcities(unittest.TestCase):
     """Tests get_topcities()."""
     def test_old_missing(self) -> None:
         """Tests the case when the old path is missing."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        file_system = test_config.TestFileSystem()
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        file_system = test_context.TestFileSystem()
+        src_root = ctx.get_abspath("workdir/stats")
         file_system.set_hide_paths([os.path.join(src_root, "2020-04-10.citycount")])
-        conf.set_file_system(file_system)
-        ret = stats.get_topcities(conf, src_root)
+        ctx.set_file_system(file_system)
+        ret = stats.get_topcities(ctx, src_root)
         self.assertEqual(ret, [])
 
     def test_new_missing(self) -> None:
         """Tests the case when the new path is missing."""
-        conf = test_config.make_test_config()
-        conf.set_time(test_config.make_test_time())
-        file_system = test_config.TestFileSystem()
-        src_root = conf.get_abspath("workdir/stats")
+        ctx = test_context.make_test_context()
+        ctx.set_time(test_context.make_test_time())
+        file_system = test_context.TestFileSystem()
+        src_root = ctx.get_abspath("workdir/stats")
         file_system.set_hide_paths([os.path.join(src_root, "2020-05-10.citycount")])
-        conf.set_file_system(file_system)
-        ret = stats.get_topcities(conf, src_root)
+        ctx.set_file_system(file_system)
+        ret = stats.get_topcities(ctx, src_root)
         self.assertEqual(ret, [])
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -14,7 +14,7 @@ import urllib.error
 
 import yattag
 
-import test_config
+import test_context
 
 import i18n
 import util
@@ -165,30 +165,30 @@ class TestHandleOverpassError(unittest.TestCase):
     def test_no_sleep(self) -> None:
         """Tests the case when no sleep is needed."""
         error = urllib.error.HTTPError("http://example.com", 404, "no such file", {}, io.BytesIO())
-        conf = test_config.make_test_config()
-        routes: List[test_config.URLRoute] = [
-            test_config.URLRoute(url="https://overpass-api.de/api/status",
-                                 data_path="",
-                                 result_path="tests/network/overpass-status-happy.txt")
+        ctx = test_context.make_test_context()
+        routes: List[test_context.URLRoute] = [
+            test_context.URLRoute(url="https://overpass-api.de/api/status",
+                                  data_path="",
+                                  result_path="tests/network/overpass-status-happy.txt")
         ]
-        network = test_config.TestNetwork(routes)
-        conf.set_network(network)
-        doc = util.handle_overpass_error(conf, str(error))
+        network = test_context.TestNetwork(routes)
+        ctx.set_network(network)
+        doc = util.handle_overpass_error(ctx, str(error))
         expected = """<div id="overpass-error">Overpass error: HTTP Error 404: no such file</div>"""
         self.assertEqual(doc.getvalue(), expected)
 
     def test_need_sleep(self) -> None:
         """Tests the case when sleep is needed."""
         error = urllib.error.HTTPError("http://example.com", 404, "no such file", {}, io.BytesIO())
-        conf = test_config.make_test_config()
-        routes: List[test_config.URLRoute] = [
-            test_config.URLRoute(url="https://overpass-api.de/api/status",
-                                 data_path="",
-                                 result_path="tests/network/overpass-status-wait.txt")
+        ctx = test_context.make_test_context()
+        routes: List[test_context.URLRoute] = [
+            test_context.URLRoute(url="https://overpass-api.de/api/status",
+                                  data_path="",
+                                  result_path="tests/network/overpass-status-wait.txt")
         ]
-        network = test_config.TestNetwork(routes)
-        conf.set_network(network)
-        doc = util.handle_overpass_error(conf, str(error))
+        network = test_context.TestNetwork(routes)
+        ctx.set_network(network)
+        doc = util.handle_overpass_error(ctx, str(error))
         expected = """<div id="overpass-error">Overpass error: HTTP Error 404: no such file"""
         expected += """<br />Note: wait for 12 seconds</div>"""
         self.assertEqual(doc.getvalue(), expected)
@@ -199,17 +199,17 @@ class TestSetupLocalization(unittest.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         environ = {"HTTP_ACCEPT_LANGUAGE": "hu,en;q=0.9,en-US;q=0.8"}
-        conf = test_config.make_test_config()
-        i18n.set_language(conf, "en")
-        util.setup_localization(environ, conf)
+        ctx = test_context.make_test_context()
+        i18n.set_language(ctx, "en")
+        util.setup_localization(environ, ctx)
         self.assertEqual(i18n.get_language(), "hu")
 
     def test_parse_error(self) -> None:
         """Tests the error path."""
         environ = {"HTTP_ACCEPT_LANGUAGE": ","}
-        conf = test_config.make_test_config()
-        i18n.set_language(conf, "en")
-        util.setup_localization(environ, conf)
+        ctx = test_context.make_test_context()
+        i18n.set_language(ctx, "en")
+        util.setup_localization(environ, ctx)
         self.assertEqual(i18n.get_language(), "en")
 
 

--- a/tests/test_webframe.py
+++ b/tests/test_webframe.py
@@ -16,7 +16,7 @@ import unittest.mock
 # pylint: disable=unused-import
 import yattag
 
-import test_config
+import test_context
 
 import webframe
 
@@ -29,9 +29,9 @@ class TestHandleStatic(unittest.TestCase):
     """Tests handle_static()."""
     def test_happy(self) -> None:
         """Tests the happy path: css case."""
-        conf = test_config.make_test_config()
-        prefix = conf.get_ini().get_uri_prefix()
-        content, content_type, extra_headers = webframe.handle_static(conf, prefix + "/static/osm.min.css")
+        ctx = test_context.make_test_context()
+        prefix = ctx.get_ini().get_uri_prefix()
+        content, content_type, extra_headers = webframe.handle_static(ctx, prefix + "/static/osm.min.css")
         self.assertTrue(len(content))
         self.assertEqual(content_type, "text/css")
         self.assertEqual(len(extra_headers), 1)
@@ -39,9 +39,9 @@ class TestHandleStatic(unittest.TestCase):
 
     def test_generated_javascript(self) -> None:
         """Tests the generated javascript case."""
-        conf = test_config.make_test_config()
-        prefix = conf.get_ini().get_uri_prefix()
-        content, content_type, extra_headers = webframe.handle_static(conf, prefix + "/static/bundle.js")
+        ctx = test_context.make_test_context()
+        prefix = ctx.get_ini().get_uri_prefix()
+        content, content_type, extra_headers = webframe.handle_static(ctx, prefix + "/static/bundle.js")
         self.assertEqual("// bundle.js\n", content.decode("utf-8"))
         self.assertEqual(content_type, "application/x-javascript")
         self.assertEqual(len(extra_headers), 1)
@@ -49,9 +49,9 @@ class TestHandleStatic(unittest.TestCase):
 
     def test_json(self) -> None:
         """Tests the json case."""
-        conf = test_config.make_test_config()
-        prefix = conf.get_ini().get_uri_prefix()
-        content, content_type, extra_headers = webframe.handle_static(conf, prefix + "/static/stats-empty.json")
+        ctx = test_context.make_test_context()
+        prefix = ctx.get_ini().get_uri_prefix()
+        content, content_type, extra_headers = webframe.handle_static(ctx, prefix + "/static/stats-empty.json")
         self.assertTrue(content.decode("utf-8").startswith("{"))
         self.assertEqual(content_type, "application/json")
         self.assertEqual(len(extra_headers), 1)
@@ -59,8 +59,8 @@ class TestHandleStatic(unittest.TestCase):
 
     def test_ico(self) -> None:
         """Tests the ico case."""
-        conf = test_config.make_test_config()
-        content, content_type, extra_headers = webframe.handle_static(conf, "/favicon.ico")
+        ctx = test_context.make_test_context()
+        content, content_type, extra_headers = webframe.handle_static(ctx, "/favicon.ico")
         self.assertTrue(len(content))
         self.assertEqual(content_type, "image/x-icon")
         self.assertEqual(len(extra_headers), 1)
@@ -68,8 +68,8 @@ class TestHandleStatic(unittest.TestCase):
 
     def test_svg(self) -> None:
         """Tests the svg case."""
-        conf = test_config.make_test_config()
-        content, content_type, extra_headers = webframe.handle_static(conf, "/favicon.svg")
+        ctx = test_context.make_test_context()
+        content, content_type, extra_headers = webframe.handle_static(ctx, "/favicon.svg")
         self.assertTrue(len(content))
         self.assertEqual(content_type, "image/svg+xml")
         self.assertEqual(len(extra_headers), 1)
@@ -77,9 +77,9 @@ class TestHandleStatic(unittest.TestCase):
 
     def test_else(self) -> None:
         """Tests the case when the content type is not recognized."""
-        conf = test_config.make_test_config()
-        prefix = conf.get_ini().get_uri_prefix()
-        content, content_type, extra_headers = webframe.handle_static(conf, prefix + "/static/test.xyz")
+        ctx = test_context.make_test_context()
+        prefix = ctx.get_ini().get_uri_prefix()
+        content, content_type, extra_headers = webframe.handle_static(ctx, prefix + "/static/test.xyz")
         self.assertFalse(len(content))
         self.assertFalse(len(content_type))
         # No last modified non-existing file.
@@ -121,8 +121,8 @@ class TestFillMissingHeaderItems(unittest.TestCase):
         relation_name = "gazdagret"
         items: List[yattag.doc.Doc] = []
         additional_housenumbers = True
-        conf = test_config.make_test_config()
-        webframe.fill_missing_header_items(conf, streets, additional_housenumbers, relation_name, items)
+        ctx = test_context.make_test_context()
+        webframe.fill_missing_header_items(ctx, streets, additional_housenumbers, relation_name, items)
         html = items[0].getvalue()
         self.assertIn("Missing house numbers", html)
         self.assertNotIn("Missing streets", html)

--- a/tests/test_wsgi_additional.py
+++ b/tests/test_wsgi_additional.py
@@ -10,7 +10,7 @@ import io
 import json
 import unittest
 
-import test_config
+import test_context
 import test_wsgi
 
 import areas
@@ -31,25 +31,25 @@ class TestStreets(test_wsgi.TestWsgi):
 
     def test_view_result_txt_no_osm_streets(self) -> None:
         """Tests the txt output, no osm streets case."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_streets_path()
-        file_system = test_config.TestFileSystem()
+        file_system = test_context.TestFileSystem()
         file_system.set_hide_paths([hide_path])
-        self.conf.set_file_system(file_system)
+        self.ctx.set_file_system(file_system)
         result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.txt")
         self.assertEqual(result, "No existing streets")
 
     def test_view_result_txt_no_ref_streets(self) -> None:
         """Tests the txt output, no ref streets case."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_ref_streets_path()
-        file_system = test_config.TestFileSystem()
+        file_system = test_context.TestFileSystem()
         file_system.set_hide_paths([hide_path])
-        self.conf.set_file_system(file_system)
+        self.ctx.set_file_system(file_system)
         result = self.get_txt_for_path("/additional-streets/gazdagret/view-result.txt")
         self.assertEqual(result, "No reference streets")
 
@@ -64,22 +64,22 @@ class TestHandleMainHousenrAdditionalCount(test_wsgi.TestWsgi):
     """Tests handle_main_housenr_additional_count()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("budafok")
-        actual = wsgi.handle_main_housenr_additional_count(conf, relation)
+        actual = wsgi.handle_main_housenr_additional_count(ctx, relation)
         self.assertIn("42 house numbers", actual.getvalue())
 
     def test_no_count_file(self) -> None:
         """Tests what happens when the count file is not there."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("budafok")
         hide_path = relation.get_files().get_housenumbers_additional_count_path()
-        file_system = test_config.TestFileSystem()
+        file_system = test_context.TestFileSystem()
         file_system.set_hide_paths([hide_path])
-        conf.set_file_system(file_system)
-        actual = wsgi.handle_main_housenr_additional_count(conf, relation)
+        ctx.set_file_system(file_system)
+        actual = wsgi.handle_main_housenr_additional_count(ctx, relation)
         self.assertNotIn("42 housenumbers", actual.getvalue())
 
 
@@ -93,39 +93,39 @@ class TestAdditionalHousenumbers(test_wsgi.TestWsgi):
 
     def test_no_osm_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm streets case."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_streets_path()
-        file_system = test_config.TestFileSystem()
+        file_system = test_context.TestFileSystem()
         file_system.set_hide_paths([hide_path])
-        self.conf.set_file_system(file_system)
+        self.ctx.set_file_system(file_system)
         root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
         results = root.findall("body/div[@id='no-osm-streets']")
         self.assertEqual(len(results), 1)
 
     def test_no_osm_housenumbers_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm housenumbers case."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_housenumbers_path()
-        file_system = test_config.TestFileSystem()
+        file_system = test_context.TestFileSystem()
         file_system.set_hide_paths([hide_path])
-        self.conf.set_file_system(file_system)
+        self.ctx.set_file_system(file_system)
         root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
         results = root.findall("body/div[@id='no-osm-housenumbers']")
         self.assertEqual(len(results), 1)
 
     def test_no_ref_housenumbers_well_formed(self) -> None:
         """Tests if the output is well-formed, no ref housenumbers case."""
-        conf = test_config.make_test_config()
-        relations = areas.Relations(conf)
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_ref_housenumbers_path()
-        file_system = test_config.TestFileSystem()
+        file_system = test_context.TestFileSystem()
         file_system.set_hide_paths([hide_path])
-        self.conf.set_file_system(file_system)
+        self.ctx.set_file_system(file_system)
         root = self.get_dom_for_path("/additional-housenumbers/gazdagret/view-result")
         results = root.findall("body/div[@id='no-ref-housenumbers']")
         self.assertEqual(len(results), 1)
@@ -147,7 +147,7 @@ class TestAdditionalStreets(test_wsgi.TestWsgi):
 
     def test_street_from_housenr_well_formed(self) -> None:
         """Tests if the output is well-formed when the street name comes from a housenr."""
-        file_system = test_config.TestFileSystem()
+        file_system = test_context.TestFileSystem()
         yamls_cache = {
             "relations.yaml": {
                 "gh611": {
@@ -162,32 +162,32 @@ class TestAdditionalStreets(test_wsgi.TestWsgi):
         yamls_cache_value = io.BytesIO()
         yamls_cache_value.write(json.dumps(yamls_cache).encode("utf-8"))
         yamls_cache_value.seek(0)
-        file_system.set_files({self.conf.get_abspath("data/yamls.cache"): yamls_cache_value})
-        self.conf.set_file_system(file_system)
+        file_system.set_files({self.ctx.get_abspath("data/yamls.cache"): yamls_cache_value})
+        self.ctx.set_file_system(file_system)
         root = self.get_dom_for_path("/additional-streets/gh611/view-result")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
 
     def test_no_osm_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no osm streets case."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_osm_streets_path()
-        file_system = test_config.TestFileSystem()
+        file_system = test_context.TestFileSystem()
         file_system.set_hide_paths([hide_path])
-        self.conf.set_file_system(file_system)
+        self.ctx.set_file_system(file_system)
         root = self.get_dom_for_path("/additional-streets/gazdagret/view-result")
         results = root.findall("body/div[@id='no-osm-streets']")
         self.assertEqual(len(results), 1)
 
     def test_no_ref_streets_well_formed(self) -> None:
         """Tests if the output is well-formed, no ref streets case."""
-        relations = areas.Relations(test_config.make_test_config())
+        relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation("gazdagret")
         hide_path = relation.get_files().get_ref_streets_path()
-        file_system = test_config.TestFileSystem()
+        file_system = test_context.TestFileSystem()
         file_system.set_hide_paths([hide_path])
-        self.conf.set_file_system(file_system)
+        self.ctx.set_file_system(file_system)
         root = self.get_dom_for_path("/additional-streets/gazdagret/view-result")
         results = root.findall("body/div[@id='no-ref-streets']")
         self.assertEqual(len(results), 1)

--- a/tests/test_wsgi_json.py
+++ b/tests/test_wsgi_json.py
@@ -15,9 +15,9 @@ from typing import cast
 import json
 import unittest
 
-import test_config
+import test_context
 
-import config
+import context
 import wsgi
 
 if TYPE_CHECKING:
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 class TestWsgiJson(unittest.TestCase):
     """Base class for wsgi_json tests."""
 
-    def get_json_for_path(self, conf: config.Config, path: str) -> Dict[str, Any]:
+    def get_json_for_path(self, ctx: context.Context, path: str) -> Dict[str, Any]:
         """Generates an json dict for a given wsgi path."""
         def start_response(status: str, response_headers: List[Tuple[str, str]]) -> None:
             # Make sure the built-in exception catcher is not kicking in.
@@ -36,12 +36,12 @@ class TestWsgiJson(unittest.TestCase):
             header_dict = dict(response_headers)
             self.assertEqual(header_dict["Content-type"], "application/json; charset=utf-8")
 
-        prefix = conf.get_ini().get_uri_prefix()
+        prefix = ctx.get_ini().get_uri_prefix()
         environ = {
             "PATH_INFO": prefix + path
         }
         callback = cast('StartResponse', start_response)
-        output_iterable = wsgi.application(environ, callback, conf)
+        output_iterable = wsgi.application(environ, callback, ctx)
         output_list = cast(List[str], output_iterable)
         self.assertTrue(output_list)
         output = output_list[0]
@@ -52,28 +52,28 @@ class TestJsonStreets(TestWsgiJson):
     """Tests streets_update_result_json()."""
     def test_update_result_json(self) -> None:
         """Tests if the update-result json output is well-formed."""
-        conf = test_config.make_test_config()
-        routes: List[test_config.URLRoute] = [
-            test_config.URLRoute(url="https://overpass-api.de/api/interpreter",
-                                 data_path="",
-                                 result_path="tests/network/overpass-streets-gazdagret.csv")
+        ctx = test_context.make_test_context()
+        routes: List[test_context.URLRoute] = [
+            test_context.URLRoute(url="https://overpass-api.de/api/interpreter",
+                                  data_path="",
+                                  result_path="tests/network/overpass-streets-gazdagret.csv")
         ]
-        network = test_config.TestNetwork(routes)
-        conf.set_network(network)
-        root = self.get_json_for_path(conf, "/streets/gazdagret/update-result.json")
+        network = test_context.TestNetwork(routes)
+        ctx.set_network(network)
+        root = self.get_json_for_path(ctx, "/streets/gazdagret/update-result.json")
         self.assertEqual(root["error"], "")
 
     def test_update_result_json_error(self) -> None:
         """Tests if the update-result json output on error is well-formed."""
-        conf = test_config.make_test_config()
-        routes: List[test_config.URLRoute] = [
-            test_config.URLRoute(url="https://overpass-api.de/api/interpreter",
-                                 data_path="",
-                                 result_path="")
+        ctx = test_context.make_test_context()
+        routes: List[test_context.URLRoute] = [
+            test_context.URLRoute(url="https://overpass-api.de/api/interpreter",
+                                  data_path="",
+                                  result_path="")
         ]
-        network = test_config.TestNetwork(routes)
-        conf.set_network(network)
-        root = self.get_json_for_path(conf, "/streets/gazdagret/update-result.json")
+        network = test_context.TestNetwork(routes)
+        ctx.set_network(network)
+        root = self.get_json_for_path(ctx, "/streets/gazdagret/update-result.json")
         self.assertIn("error", root)
 
 
@@ -81,28 +81,28 @@ class TestJsonStreetHousenumbers(TestWsgiJson):
     """Tests street_housenumbers_update_result_json()."""
     def test_update_result_json(self) -> None:
         """Tests if the update-result output is well-formed."""
-        conf = test_config.make_test_config()
-        routes: List[test_config.URLRoute] = [
-            test_config.URLRoute(url="https://overpass-api.de/api/interpreter",
-                                 data_path="",
-                                 result_path="tests/network/overpass-housenumbers-gazdagret.csv")
+        ctx = test_context.make_test_context()
+        routes: List[test_context.URLRoute] = [
+            test_context.URLRoute(url="https://overpass-api.de/api/interpreter",
+                                  data_path="",
+                                  result_path="tests/network/overpass-housenumbers-gazdagret.csv")
         ]
-        network = test_config.TestNetwork(routes)
-        conf.set_network(network)
-        root = self.get_json_for_path(conf, "/street-housenumbers/gazdagret/update-result.json")
+        network = test_context.TestNetwork(routes)
+        ctx.set_network(network)
+        root = self.get_json_for_path(ctx, "/street-housenumbers/gazdagret/update-result.json")
         self.assertEqual(root["error"], "")
 
     def test_update_result_error_json(self) -> None:
         """Tests if the update-result output on error is well-formed."""
-        conf = test_config.make_test_config()
-        routes: List[test_config.URLRoute] = [
-            test_config.URLRoute(url="https://overpass-api.de/api/interpreter",
-                                 data_path="",
-                                 result_path="")
+        ctx = test_context.make_test_context()
+        routes: List[test_context.URLRoute] = [
+            test_context.URLRoute(url="https://overpass-api.de/api/interpreter",
+                                  data_path="",
+                                  result_path="")
         ]
-        network = test_config.TestNetwork(routes)
-        conf.set_network(network)
-        root = self.get_json_for_path(conf, "/street-housenumbers/gazdagret/update-result.json")
+        network = test_context.TestNetwork(routes)
+        ctx.set_network(network)
+        root = self.get_json_for_path(ctx, "/street-housenumbers/gazdagret/update-result.json")
         self.assertIn("error", root)
 
 
@@ -110,8 +110,8 @@ class TestJsonMissingHousenumbers(TestWsgiJson):
     """Tests missing_housenumbers_update_result_json()."""
     def test_update_result_json(self) -> None:
         """Tests if the update-result json output is well-formed."""
-        conf = test_config.make_test_config()
-        root = self.get_json_for_path(conf, "/missing-housenumbers/gazdagret/update-result.json")
+        ctx = test_context.make_test_context()
+        root = self.get_json_for_path(ctx, "/missing-housenumbers/gazdagret/update-result.json")
         self.assertEqual(root["error"], "")
 
 
@@ -119,8 +119,8 @@ class TestJsonMissingStreets(TestWsgiJson):
     """Tests missing_streets_update_result_json()."""
     def test_update_result_json(self) -> None:
         """Tests if the update-result json output is well-formed."""
-        conf = test_config.make_test_config()
-        root = self.get_json_for_path(conf, "/missing-streets/gazdagret/update-result.json")
+        ctx = test_context.make_test_context()
+        root = self.get_json_for_path(ctx, "/missing-streets/gazdagret/update-result.json")
         self.assertEqual(root["error"], "")
 
 

--- a/util.py
+++ b/util.py
@@ -31,7 +31,7 @@ import yattag
 
 from i18n import translate as tr
 import accept_language
-import config
+import context
 import i18n
 import overpass_query
 import ranges
@@ -463,19 +463,19 @@ def html_escape(text: str) -> yattag.doc.Doc:
     return doc
 
 
-def handle_overpass_error(conf: config.Config, http_error: str) -> yattag.doc.Doc:
+def handle_overpass_error(ctx: context.Context, http_error: str) -> yattag.doc.Doc:
     """Handles a HTTP error from Overpass."""
     doc = yattag.doc.Doc()
     with doc.tag("div", id="overpass-error"):
         doc.text(tr("Overpass error: {0}").format(http_error))
-        sleep = overpass_query.overpass_query_need_sleep(conf)
+        sleep = overpass_query.overpass_query_need_sleep(ctx)
         if sleep:
             doc.stag("br")
             doc.text(tr("Note: wait for {} seconds").format(sleep))
     return doc
 
 
-def setup_localization(environ: Dict[str, Any], conf: config.Config) -> str:
+def setup_localization(environ: Dict[str, Any], ctx: context.Context) -> str:
     """Provides localized strings for this thread."""
     # Set up localization.
     languages = environ.get("HTTP_ACCEPT_LANGUAGE")
@@ -483,7 +483,7 @@ def setup_localization(environ: Dict[str, Any], conf: config.Config) -> str:
         parsed = accept_language.parse_accept_language(languages)
         if parsed:
             language = parsed[0].get_language()
-            i18n.set_language(conf, language)
+            i18n.set_language(ctx, language)
             return language
     return ""
 
@@ -841,11 +841,11 @@ def get_city_key(postcode: str, city: str, valid_settlements: Set[str]) -> str:
     return "_Empty"
 
 
-def get_valid_settlements(conf: config.Config) -> Set[str]:
+def get_valid_settlements(ctx: context.Context) -> Set[str]:
     """Builds a set of valid settlement names."""
     settlements: Set[str] = set()
 
-    with open(conf.get_ini().get_reference_citycounts_path(), "r") as stream:
+    with open(ctx.get_ini().get_reference_citycounts_path(), "r") as stream:
         first = True
         for line in stream.readlines():
             if first:

--- a/wsgi_additional.py
+++ b/wsgi_additional.py
@@ -14,13 +14,13 @@ import yattag
 from i18n import translate as tr
 import areas
 import cache
-import config
+import context
 import util
 import webframe
 
 
 def additional_streets_view_txt(
-    conf: config.Config,
+    ctx: context.Context,
     relations: areas.Relations,
     request_uri: str,
     chkl: bool
@@ -31,9 +31,9 @@ def additional_streets_view_txt(
     relation = relations.get_relation(relation_name)
 
     output = ""
-    if not conf.get_file_system().path_exists(relation.get_files().get_osm_streets_path()):
+    if not ctx.get_file_system().path_exists(relation.get_files().get_osm_streets_path()):
         output += tr("No existing streets")
-    elif not conf.get_file_system().path_exists(relation.get_files().get_ref_streets_path()):
+    elif not ctx.get_file_system().path_exists(relation.get_files().get_ref_streets_path()):
         output += tr("No reference streets")
     else:
         streets = relation.get_additional_streets()
@@ -48,7 +48,7 @@ def additional_streets_view_txt(
 
 
 def additional_streets_view_result(
-    conf: config.Config,
+    ctx: context.Context,
     relations: areas.Relations,
     request_uri: str
 ) -> yattag.doc.Doc:
@@ -58,10 +58,10 @@ def additional_streets_view_result(
     relation = relations.get_relation(relation_name)
 
     doc = yattag.doc.Doc()
-    prefix = conf.get_ini().get_uri_prefix()
-    if not conf.get_file_system().path_exists(relation.get_files().get_osm_streets_path()):
+    prefix = ctx.get_ini().get_uri_prefix()
+    if not ctx.get_file_system().path_exists(relation.get_files().get_osm_streets_path()):
         doc.asis(webframe.handle_no_osm_streets(prefix, relation_name).getvalue())
-    elif not conf.get_file_system().path_exists(relation.get_files().get_ref_streets_path()):
+    elif not ctx.get_file_system().path_exists(relation.get_files().get_ref_streets_path()):
         doc.asis(webframe.handle_no_ref_streets(prefix, relation_name).getvalue())
     else:
         # Get "only in OSM" streets.
@@ -104,7 +104,7 @@ def additional_streets_view_result(
 
 
 def additional_housenumbers_view_result(
-    conf: config.Config,
+    ctx: context.Context,
     relations: areas.Relations,
     request_uri: str
 ) -> yattag.doc.Doc:
@@ -115,15 +115,15 @@ def additional_housenumbers_view_result(
 
     doc = yattag.doc.Doc()
     relation = relations.get_relation(relation_name)
-    prefix = conf.get_ini().get_uri_prefix()
-    if not conf.get_file_system().path_exists(relation.get_files().get_osm_streets_path()):
+    prefix = ctx.get_ini().get_uri_prefix()
+    if not ctx.get_file_system().path_exists(relation.get_files().get_osm_streets_path()):
         doc.asis(webframe.handle_no_osm_streets(prefix, relation_name).getvalue())
-    elif not conf.get_file_system().path_exists(relation.get_files().get_osm_housenumbers_path()):
+    elif not ctx.get_file_system().path_exists(relation.get_files().get_osm_housenumbers_path()):
         doc.asis(webframe.handle_no_osm_housenumbers(prefix, relation_name).getvalue())
-    elif not conf.get_file_system().path_exists(relation.get_files().get_ref_housenumbers_path()):
+    elif not ctx.get_file_system().path_exists(relation.get_files().get_ref_housenumbers_path()):
         doc.asis(webframe.handle_no_ref_housenumbers(prefix, relation_name).getvalue())
     else:
-        doc = cache.get_additional_housenumbers_html(conf, relation)
+        doc = cache.get_additional_housenumbers_html(ctx, relation)
     return doc
 
 


### PR DESCRIPTION
Because the config piece is only config.Ini, everything else is more
some shared read-only global state, like filesystem, network, etc.

Change-Id: I6b8a84edc565b65914a2df713472830fa9ac0e41
