### PR TITLE
test_parse_access_log: avoid mocking

### DIFF
--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -13,7 +13,6 @@ import json
 import os
 import time
 import unittest
-import unittest.mock
 
 import test_context
 

--- a/tests/test_webframe.py
+++ b/tests/test_webframe.py
@@ -12,7 +12,6 @@ from typing import Tuple
 from typing import cast
 import traceback
 import unittest
-import unittest.mock
 
 # pylint: disable=unused-import
 import yattag

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -19,7 +19,6 @@ import datetime
 import io
 import json
 import unittest
-import unittest.mock
 import urllib.error
 import urllib.parse
 import xml.etree.ElementTree as ET


### PR DESCRIPTION
Which was the last test that used mocking. This was probelatic because
mocking breaks when the port is ported to C.

Change-Id: Ide06da8ce7b0ce5089f00fac8f7b3a2a7aa7f0f6
