### PR TITLE
webframe: context time is in utc, datetime.date.fromtimestamp takes a local time

### DIFF
--- a/webframe.py
+++ b/webframe.py
@@ -18,6 +18,7 @@ from typing import cast
 import datetime
 import json
 import os
+import time
 import urllib
 import xmlrpc.client
 
@@ -372,7 +373,7 @@ def handle_stats_cityprogress(ctx: context.Context, relations: areas.Relations) 
             city = cells[0]
             count = int(cells[1])
             ref_citycounts[city] = count
-    today = datetime.date.fromtimestamp(ctx.get_time().now()).strftime("%Y-%m-%d")
+    today = time.strftime("%Y-%m-%d", time.gmtime(ctx.get_time().now()))
     osm_citycounts: Dict[str, int] = {}
     with open(ctx.get_ini().get_workdir() + "/stats/" + today + ".citycount", "r") as stream:
         for line in stream.readlines():


### PR DESCRIPTION
So use time.gmtime() instead which takes utc time.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/1508>.

Change-Id: I1d66a246ee22618754bb825e5098f353df7615a3
