### PR TITLE
CI: test just one python version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,15 +9,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.6, 3.8]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.6
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
3.6 is enough, 3.8 is not something the primary instance runs nor what I
run locally.

Change-Id: Ibe2145520ca37a29ad30289dbfaa409d426bb131