### PR TITLE
test_areas.TestRelationWriteMissingStreets.test_empty: write to memory

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,25 +5,25 @@ score=no
 
 [FORMAT]
 
-# Maximum number of characters on a single line.
-max-line-length=120
+# Default: 100.
+max-line-length=200
 
-# Maximum number of lines in a module.
+# Default: 1000.
 max-module-lines=2000
 
 [DESIGN]
 
-# Minimum number of public methods for a class (see R0903).
+# Default: 2, not allowing ctor + public attributes.
 min-public-methods=0
 
-# Maximum number of locals for function / method body.
-max-locals=20
+# Default: 15.
+max-locals=30
 
-# Maximum number of attributes for a class (see R0902).
-max-attributes=8
+# Default: 7.
+max-attributes=14
 
-# Maximum number of return / yield for function / method body.
-max-returns=10
+# Default: 6.
+max-returns=12
 
-# Double of the default.
+# Default: 20.
 max-public-methods=40

--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -746,13 +746,22 @@ class TestRelationWriteMissingStreets(unittest.TestCase):
 
     def test_empty(self) -> None:
         """Tests the case when percent can't be determined."""
-        relations = areas.Relations(test_context.make_test_context())
+        ctx = test_context.make_test_context()
+        relations = areas.Relations(ctx)
+        file_system = test_context.TestFileSystem()
+        percent_value = io.BytesIO()
+        percent_value.__setattr__("close", lambda: None)
+        files = {
+            ctx.get_abspath("workdir/empty-streets.percent"): percent_value,
+        }
+        file_system.set_files(files)
+        ctx.set_file_system(file_system)
         relation_name = "empty"
         relation = relations.get_relation(relation_name)
         ret = relation.write_missing_streets()
+        self.assertTrue(percent_value.tell())
         _todo_count, _done_count, percent, _streets = ret
         self.assertEqual(percent, '100.00')
-        os.unlink(os.path.join(relations.get_workdir(), "empty-streets.percent"))
 
 
 class TestRelationBuildRefHousenumbers(unittest.TestCase):


### PR DESCRIPTION
Also consistently override pylint settings: set to double-of-default or
to 0 depending on if it's a min or a max.

Change-Id: I8bc413c0226daa3c8ca9e2a8a487d8bc721d6bc2
