### PR TITLE
context.Network: avoid pointless optional parameter

### DIFF
--- a/context.py
+++ b/context.py
@@ -12,7 +12,6 @@ It intentionally doesn't import any other 'own' modules, so it can be used anywh
 from typing import BinaryIO
 from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Tuple
 from typing import cast
 import calendar
@@ -71,7 +70,7 @@ class StdFileSystem(FileSystem):
 
 class Network:
     """Network interface."""
-    def urlopen(self, url: str, data: Optional[bytes] = None) -> Tuple[bytes, str]:  # pragma: no cover
+    def urlopen(self, url: str, data: bytes) -> Tuple[bytes, str]:  # pragma: no cover
         """Opens an URL. Empty data means HTTP GET, otherwise it means a HTTP POST."""
         # pylint: disable=no-self-use
         # pylint: disable=unused-argument
@@ -80,13 +79,18 @@ class Network:
 
 class StdNetwork(Network):
     """Network implementation, backed by the Python stdlib."""
-    def urlopen(self, url: str, data: Optional[bytes] = None) -> Tuple[bytes, str]:  # pragma: no cover
+    def urlopen(self, url: str, data: bytes) -> Tuple[bytes, str]:  # pragma: no cover
         try:
-            with urllib.request.urlopen(url, data) as stream:
+            optional_data = None
+            if data:
+                optional_data = data
+            with urllib.request.urlopen(url, optional_data) as stream:
                 buf = stream.read()
             return (cast(bytes, buf), str())
         except urllib.error.HTTPError as http_error:
             return (bytes(), str(http_error))
+        except urllib.error.URLError as url_error:
+            return (bytes(), str(url_error))
 
 
 class Time:

--- a/overpass_query.py
+++ b/overpass_query.py
@@ -26,7 +26,7 @@ def overpass_query(ctx: context.Context, query: str) -> Tuple[str, str]:
 def overpass_query_need_sleep(ctx: context.Context) -> int:
     """Checks if we need to sleep before executing an overpass query."""
     urlopen = ctx.get_network().urlopen
-    buf, err = urlopen(ctx.get_ini().get_overpass_uri() + "/api/status")
+    buf, err = urlopen(ctx.get_ini().get_overpass_uri() + "/api/status", bytes())
     if err:
         return 0
     status = buf.decode('utf-8')

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -9,7 +9,6 @@
 from typing import BinaryIO
 from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Tuple
 import calendar
 import datetime
@@ -93,7 +92,7 @@ class TestNetwork(context.Network):
     def __init__(self, routes: List[URLRoute]) -> None:
         self.__routes = routes
 
-    def urlopen(self, url: str, data: Optional[bytes] = None) -> Tuple[bytes, str]:
+    def urlopen(self, url: str, data: bytes) -> Tuple[bytes, str]:
         for route in self.__routes:
             if url != route.url:
                 continue


### PR DESCRIPTION
Only a single place used the default.

Also catch both http and url errors when turning them into strings.

Change-Id: I2a926c4b7204f54d816f3328698003d0537f5b47
