### PR TITLE
CI: allow porting Python modules to Rust

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.6
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.53.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Change-Id: Ieb39403625a13e910fb61cbf55bf5b6f7d812b84
