### PR TITLE
Replace the yattag dependency with a subset module

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -13,7 +13,7 @@ created caches, so always run `make` after changing the code and before using it
 git grep "'<" *.py
 git grep '"<' *.py
 # Ensure unescaped string can be added do a document as-is only in case it's an escaped string.
-git grep -n -w asis|grep -v getvalue
+git grep -n -w append_value|grep -v get_value
 ----
 
 Exception to this rule is the HTML DOCTYPE header and cache content produced by `yattag`.

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ PYTHON_SAFE_OBJECTS = \
 	wsgi.py \
 	wsgi_additional.py \
 	wsgi_json.py \
+	yattag.py \
 
 # These have bad coverage.
 PYTHON_UNSAFE_OBJECTS = \

--- a/areas.py
+++ b/areas.py
@@ -577,7 +577,7 @@ class Relation(RelationBase):
     def numbered_streets_to_table(
         self,
         numbered_streets: util.NumberedStreets
-    ) -> Tuple[List[List[yattag.doc.Doc]], int]:
+    ) -> Tuple[List[List[yattag.Doc]], int]:
         """Turns a list of numbered streets into a HTML table."""
         todo_count = 0
         table = []
@@ -592,12 +592,12 @@ class Relation(RelationBase):
             number_ranges = util.get_housenumber_ranges(result[1])
             row.append(util.html_escape(str(len(number_ranges))))
 
-            doc = yattag.doc.Doc()
+            doc = yattag.Doc()
             if not self.get_config().get_street_is_even_odd(result[0].get_osm_name()):
                 for index, item in enumerate(sorted(number_ranges, key=util.split_house_number_range)):
                     if index:
                         doc.text(", ")
-                    doc.asis(util.color_house_number(item).getvalue())
+                    doc.append_value(util.color_house_number(item).get_value())
             else:
                 util.format_even_odd(number_ranges, doc)
             row.append(doc)
@@ -608,10 +608,10 @@ class Relation(RelationBase):
         # It's possible that get_housenumber_ranges() reduces the # of house numbers, e.g. 2, 4 and
         # 6 may be turned into 2-6, which is just 1 item. Sort by the 2nd col, which is the new
         # number of items.
-        table += sorted(rows, reverse=True, key=lambda cells: int(cells[1].getvalue()))
+        table += sorted(rows, reverse=True, key=lambda cells: int(cells[1].get_value()))
         return table, todo_count
 
-    def write_missing_housenumbers(self) -> Tuple[int, int, int, str, List[List[yattag.doc.Doc]]]:
+    def write_missing_housenumbers(self) -> Tuple[int, int, int, str, List[List[yattag.Doc]]]:
         """
         Calculate a write stat for the house number coverage of a relation.
         Returns a tuple of: todo street count, todo count, done count, percent and table.
@@ -635,7 +635,7 @@ class Relation(RelationBase):
 
         return len(ongoing_streets), todo_count, done_count, percent, table
 
-    def write_additional_housenumbers(self) -> Tuple[int, int, List[List[yattag.doc.Doc]]]:
+    def write_additional_housenumbers(self) -> Tuple[int, int, List[List[yattag.Doc]]]:
         """
         Calculate and write stat for the unexpected house number coverage of a relation.
         Returns a tuple of: todo street count, todo count and table.

--- a/cache.py
+++ b/cache.py
@@ -62,71 +62,71 @@ def is_additional_housenumbers_html_cached(ctx: context.Context, relation: areas
     return is_cache_outdated(ctx, cache_path, dependencies)
 
 
-def get_missing_housenumbers_html(ctx: context.Context, relation: areas.Relation) -> yattag.doc.Doc:
+def get_missing_housenumbers_html(ctx: context.Context, relation: areas.Relation) -> yattag.Doc:
     """Gets the cached HTML of the missing housenumbers for a relation."""
-    doc = yattag.doc.Doc()
+    doc = yattag.Doc()
     if is_missing_housenumbers_html_cached(ctx, relation):
         with relation.get_files().get_housenumbers_htmlcache_read_stream(ctx) as stream:
-            doc.asis(util.from_bytes(stream.read()))
+            doc.append_value(util.from_bytes(stream.read()))
         return doc
 
     ret = relation.write_missing_housenumbers()
     todo_street_count, todo_count, done_count, percent, table = ret
 
-    with doc.tag("p"):
+    with doc.tag("p", []):
         prefix = ctx.get_ini().get_uri_prefix()
         relation_name = relation.get_name()
         doc.text(tr("OpenStreetMap is possibly missing the below {0} house numbers for {1} streets.")
                  .format(str(todo_count), str(todo_street_count)))
         doc.text(tr(" (existing: {0}, ready: {1}).").format(str(done_count), util.format_percent(str(percent))))
-        doc.stag("br")
-        with doc.tag("a", href="https://github.com/vmiklos/osm-gimmisn/tree/master/doc"):
+        doc.stag("br", [])
+        with doc.tag("a", [("href", "https://github.com/vmiklos/osm-gimmisn/tree/master/doc")]):
             doc.text(tr("Filter incorrect information"))
         doc.text(".")
-        doc.stag("br")
-        with doc.tag("a", href=prefix + "/missing-housenumbers/{}/view-turbo".format(relation_name)):
+        doc.stag("br", [])
+        with doc.tag("a", [("href", prefix + "/missing-housenumbers/{}/view-turbo".format(relation_name))]):
             doc.text(tr("Overpass turbo query for the below streets"))
-        doc.stag("br")
-        with doc.tag("a", href=prefix + "/missing-housenumbers/{}/view-result.txt".format(relation_name)):
+        doc.stag("br", [])
+        with doc.tag("a", [("href", prefix + "/missing-housenumbers/{}/view-result.txt".format(relation_name))]):
             doc.text(tr("Plain text format"))
-        doc.stag("br")
-        with doc.tag("a", href=prefix + "/missing-housenumbers/{}/view-result.chkl".format(relation_name)):
+        doc.stag("br", [])
+        with doc.tag("a", [("href", prefix + "/missing-housenumbers/{}/view-result.chkl".format(relation_name))]):
             doc.text(tr("Checklist format"))
 
-    doc.asis(util.html_table_from_list(table).getvalue())
-    doc.asis(util.invalid_refstreets_to_html(relation.get_invalid_refstreets()).getvalue())
-    doc.asis(util.invalid_filter_keys_to_html(relation.get_invalid_filter_keys()).getvalue())
+    doc.append_value(util.html_table_from_list(table).get_value())
+    doc.append_value(util.invalid_refstreets_to_html(relation.get_invalid_refstreets()).get_value())
+    doc.append_value(util.invalid_filter_keys_to_html(relation.get_invalid_filter_keys()).get_value())
 
     with relation.get_files().get_housenumbers_htmlcache_write_stream(ctx) as stream:
-        stream.write(util.to_bytes(doc.getvalue()))
+        stream.write(util.to_bytes(doc.get_value()))
 
     return doc
 
 
-def get_additional_housenumbers_html(ctx: context.Context, relation: areas.Relation) -> yattag.doc.Doc:
+def get_additional_housenumbers_html(ctx: context.Context, relation: areas.Relation) -> yattag.Doc:
     """Gets the cached HTML of the additional housenumbers for a relation."""
-    doc = yattag.doc.Doc()
+    doc = yattag.Doc()
     if is_additional_housenumbers_html_cached(ctx, relation):
         with relation.get_files().get_additional_housenumbers_htmlcache_read_stream(ctx) as stream:
-            doc.asis(util.from_bytes(stream.read()))
+            doc.append_value(util.from_bytes(stream.read()))
         return doc
 
     ret = relation.write_additional_housenumbers()
     todo_street_count, todo_count, table = ret
 
-    with doc.tag("p"):
+    with doc.tag("p", []):
         doc.text(tr("OpenStreetMap additionally has the below {0} house numbers for {1} streets.")
                  .format(str(todo_count), str(todo_street_count)))
-        doc.stag("br")
-        with doc.tag("a", href="https://github.com/vmiklos/osm-gimmisn/tree/master/doc"):
+        doc.stag("br", [])
+        with doc.tag("a", [("href", "https://github.com/vmiklos/osm-gimmisn/tree/master/doc")]):
             doc.text(tr("Filter incorrect information"))
 
-    doc.asis(util.html_table_from_list(table).getvalue())
-    doc.asis(util.invalid_refstreets_to_html(relation.get_invalid_refstreets()).getvalue())
-    doc.asis(util.invalid_filter_keys_to_html(relation.get_invalid_filter_keys()).getvalue())
+    doc.append_value(util.html_table_from_list(table).get_value())
+    doc.append_value(util.invalid_refstreets_to_html(relation.get_invalid_refstreets()).get_value())
+    doc.append_value(util.invalid_filter_keys_to_html(relation.get_invalid_filter_keys()).get_value())
 
     with relation.get_files().get_additional_housenumbers_htmlcache_write_stream(ctx) as stream:
-        stream.write(util.to_bytes(doc.getvalue()))
+        stream.write(util.to_bytes(doc.get_value()))
 
     return doc
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ pylint==2.9.3
 pyyaml==5.4.1
 unidecode==1.2.0
 yamllint==1.26.1
-yattag==1.14.0

--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -13,13 +13,12 @@ import io
 import os
 import unittest
 
-import yattag
-
 import test_context
 
 import areas
 import ranges
 import util
+import yattag
 
 
 class TestRelationGetOsmStreets(unittest.TestCase):
@@ -617,13 +616,13 @@ class TestRelationGetAdditionalHousenumbers(unittest.TestCase):
         self.assertEqual(only_in_osm_strs, [('Only In OSM utca', ['1'])])
 
 
-def table_doc_to_string(table: List[List[yattag.doc.Doc]]) -> List[List[str]]:
+def table_doc_to_string(table: List[List[yattag.Doc]]) -> List[List[str]]:
     """Unwraps an escaped matrix of yattag documents into a string matrix."""
     table_content = []
     for row in table:
         row_content = []
         for cell in row:
-            row_content.append(cell.getvalue())
+            row_content.append(cell.get_value())
         table_content.append(row_content)
     return table_content
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -100,7 +100,7 @@ class TestGetAdditionalHousenumbersHtml(unittest.TestCase):
         relation = relations.get_relation("gazdagret")
         first = cache.get_additional_housenumbers_html(ctx, relation)
         second = cache.get_additional_housenumbers_html(ctx, relation)
-        self.assertEqual(first.getvalue(), second.getvalue())
+        self.assertEqual(first.get_value(), second.get_value())
 
 
 class TestIsMissingHousenumbersTxtCached(unittest.TestCase):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -12,12 +12,11 @@ import os
 import unittest
 import urllib.error
 
-import yattag
-
 import test_context
 
 import i18n
 import util
+import yattag
 
 
 def hnr_list(ranges: List[str]) -> List[util.HouseNumberRange]:
@@ -46,25 +45,25 @@ class TestFormatEvenOdd(unittest.TestCase):
 
     def test_html(self) -> None:
         """Tests HTML coloring."""
-        doc = yattag.doc.Doc()
+        doc = yattag.Doc()
         util.format_even_odd(hnr_list(["2*", "4"]), doc)
-        self.assertEqual(doc.getvalue(), '<span style="color: blue;">2</span>, 4')
+        self.assertEqual(doc.get_value(), '<span style="color: blue;">2</span>, 4')
 
     def test_html_comment(self) -> None:
         """Tests HTML commenting."""
-        doc = yattag.doc.Doc()
+        doc = yattag.Doc()
         house_numbers = [
             util.HouseNumberRange("2*", "foo"),
             util.HouseNumberRange("4", ""),
         ]
         util.format_even_odd(house_numbers, doc)
-        self.assertEqual(doc.getvalue(), '<span style="color: blue;"><abbr title="foo" tabindex="0">2</abbr></span>, 4')
+        self.assertEqual(doc.get_value(), '<span style="color: blue;"><abbr title="foo" tabindex="0">2</abbr></span>, 4')
 
     def test_html_multi_odd(self) -> None:
         """Tests HTML output with multiple odd numbers."""
-        doc = yattag.doc.Doc()
+        doc = yattag.Doc()
         util.format_even_odd(hnr_list(["1", "3"]), doc)
-        self.assertEqual(doc.getvalue(), "1, 3")
+        self.assertEqual(doc.get_value(), "1, 3")
 
 
 class TestBuildStreetReferenceCache(unittest.TestCase):
@@ -180,7 +179,7 @@ class TestHandleOverpassError(unittest.TestCase):
         ctx.set_network(network)
         doc = util.handle_overpass_error(ctx, str(error))
         expected = """<div id="overpass-error">Overpass error: HTTP Error 404: no such file</div>"""
-        self.assertEqual(doc.getvalue(), expected)
+        self.assertEqual(doc.get_value(), expected)
 
     def test_need_sleep(self) -> None:
         """Tests the case when sleep is needed."""
@@ -196,7 +195,7 @@ class TestHandleOverpassError(unittest.TestCase):
         doc = util.handle_overpass_error(ctx, str(error))
         expected = """<div id="overpass-error">Overpass error: HTTP Error 404: no such file"""
         expected += """<br />Note: wait for 12 seconds</div>"""
-        self.assertEqual(doc.getvalue(), expected)
+        self.assertEqual(doc.get_value(), expected)
 
 
 class TestSetupLocalization(unittest.TestCase):
@@ -224,7 +223,7 @@ class TestGenLink(unittest.TestCase):
         """Tests the happy path."""
         doc = util.gen_link("http://www.example.com", "label")
         expected = '<a href="http://www.example.com">label...</a>'
-        self.assertEqual(doc.getvalue(), expected)
+        self.assertEqual(doc.get_value(), expected)
 
 
 class TestProcessTemplate(unittest.TestCase):
@@ -249,7 +248,7 @@ class TestHtmlTableFromList(unittest.TestCase):
         expected += '<tr><th><a href="#">A1</a></th>'
         expected += '<th><a href="#">B1</a></th></tr>'
         expected += '<tr><td>A2</td><td>B2</td></tr></table>'
-        ret = util.html_table_from_list(fro).getvalue()
+        ret = util.html_table_from_list(fro).get_value()
         self.assertEqual(ret, expected)
 
 
@@ -260,9 +259,9 @@ class TestTsvToList(unittest.TestCase):
         sock = util.CsvIO(io.BytesIO(b"h1\th2\n\nv1\tv2\n"))
         ret = util.tsv_to_list(sock)
         self.assertEqual(len(ret), 2)
-        row1 = [cell.getvalue() for cell in ret[0]]
+        row1 = [cell.get_value() for cell in ret[0]]
         self.assertEqual(row1, ['h1', 'h2'])
-        row2 = [cell.getvalue() for cell in ret[1]]
+        row2 = [cell.get_value() for cell in ret[1]]
         self.assertEqual(row2, ['v1', 'v2'])
 
     def test_type(self) -> None:
@@ -270,9 +269,9 @@ class TestTsvToList(unittest.TestCase):
         stream = util.CsvIO(io.BytesIO(b"@id\t@type\n42\tnode\n"))
         ret = util.tsv_to_list(stream)
         self.assertEqual(len(ret), 2)
-        row1 = [cell.getvalue() for cell in ret[0]]
+        row1 = [cell.get_value() for cell in ret[0]]
         self.assertEqual(row1, ["@id", "@type"])
-        row2 = [cell.getvalue() for cell in ret[1]]
+        row2 = [cell.get_value() for cell in ret[1]]
         cell_a2 = '<a href="https://www.openstreetmap.org/node/42" target="_blank">42</a>'
         self.assertEqual(row2, [cell_a2, "node"])
 
@@ -281,7 +280,7 @@ class TestTsvToList(unittest.TestCase):
         sock = util.CsvIO(io.BytesIO(b"\"h,1\"\th2\n"))
         ret = util.tsv_to_list(sock)
         self.assertEqual(len(ret), 1)
-        row1 = [cell.getvalue() for cell in ret[0]]
+        row1 = [cell.get_value() for cell in ret[0]]
         # Note how this is just h,1 and not "h,1".
         self.assertEqual(row1, ['h,1', 'h2'])
 
@@ -294,7 +293,7 @@ A street\t9"""
         sock = util.CsvIO(io.BytesIO(csv))
         ret = util.tsv_to_list(sock)
         # 0th is header
-        row3 = [cell.getvalue() for cell in ret[3]]
+        row3 = [cell.get_value() for cell in ret[3]]
         # Note how 10 is ordered after 9.
         self.assertEqual(row3[1], "10")
 
@@ -367,7 +366,7 @@ class TestGitLink(unittest.TestCase):
     """Tests git_link()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        actual = util.git_link("v1-151-g64ecc85", "http://www.example.com/").getvalue()
+        actual = util.git_link("v1-151-g64ecc85", "http://www.example.com/").get_value()
         expected = "<a href=\"http://www.example.com/64ecc85\">v1-151-g64ecc85</a>"
         self.assertEqual(actual, expected)
 
@@ -435,7 +434,7 @@ class TestStreet(unittest.TestCase):
         """Tests the happy path."""
         street = util.Street("foo", "bar")
         self.assertEqual(street.get_ref_name(), "bar")
-        self.assertEqual(street.to_html().getvalue(), "foo<br />(bar)")
+        self.assertEqual(street.to_html().get_value(), "foo<br />(bar)")
 
 
 class TestGetCityKey(unittest.TestCase):
@@ -469,12 +468,12 @@ class TestInvalidFilterKeysToHtml(unittest.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         ret = util.invalid_filter_keys_to_html(["foo"])
-        self.assertIn("<li>", ret.getvalue())
+        self.assertIn("<li>", ret.get_value())
 
     def test_empty(self) -> None:
         """Tests when the arg is empty."""
         ret = util.invalid_filter_keys_to_html([])
-        self.assertEqual(ret.getvalue(), "")
+        self.assertEqual(ret.get_value(), "")
 
 
 class TestGetColumn(unittest.TestCase):

--- a/tests/test_webframe.py
+++ b/tests/test_webframe.py
@@ -13,12 +13,10 @@ from typing import cast
 import traceback
 import unittest
 
-# pylint: disable=unused-import
-import yattag
-
 import test_context
 
 import webframe
+import yattag
 
 if TYPE_CHECKING:
     # pylint: disable=no-name-in-module,import-error,unused-import
@@ -119,11 +117,11 @@ class TestFillMissingHeaderItems(unittest.TestCase):
         """Tests the happy path."""
         streets = "no"
         relation_name = "gazdagret"
-        items: List[yattag.doc.Doc] = []
+        items: List[yattag.Doc] = []
         additional_housenumbers = True
         ctx = test_context.make_test_context()
         webframe.fill_missing_header_items(ctx, streets, additional_housenumbers, relation_name, items)
-        html = items[0].getvalue()
+        html = items[0].get_value()
         self.assertIn("Missing house numbers", html)
         self.assertNotIn("Missing streets", html)
 

--- a/tests/test_wsgi_additional.py
+++ b/tests/test_wsgi_additional.py
@@ -68,7 +68,7 @@ class TestHandleMainHousenrAdditionalCount(test_wsgi.TestWsgi):
         relations = areas.Relations(ctx)
         relation = relations.get_relation("budafok")
         actual = wsgi.handle_main_housenr_additional_count(ctx, relation)
-        self.assertIn("42 house numbers", actual.getvalue())
+        self.assertIn("42 house numbers", actual.get_value())
 
     def test_no_count_file(self) -> None:
         """Tests what happens when the count file is not there."""
@@ -80,7 +80,7 @@ class TestHandleMainHousenrAdditionalCount(test_wsgi.TestWsgi):
         file_system.set_hide_paths([hide_path])
         ctx.set_file_system(file_system)
         actual = wsgi.handle_main_housenr_additional_count(ctx, relation)
-        self.assertNotIn("42 housenumbers", actual.getvalue())
+        self.assertNotIn("42 housenumbers", actual.get_value())
 
 
 class TestAdditionalHousenumbers(test_wsgi.TestWsgi):

--- a/tools/dump-deps.sh
+++ b/tools/dump-deps.sh
@@ -15,6 +15,13 @@ do
     module=$(basename $module_file .py)
     for dependency in $(grep ^import $module_file|sed 's/import //'; grep ^from $module_file |sed 's/from \(.*\) import.*/\1/g'|sort -u)
     do
+        # Silence stubs for rust modules.
+        case $dependency in
+            ranges)
+                continue
+            ;;
+        esac
+
         if [ ! -e "$dependency.py" ]; then
             continue
         fi

--- a/webframe.py
+++ b/webframe.py
@@ -35,75 +35,75 @@ if TYPE_CHECKING:
     from wsgiref.types import StartResponse
 
 
-def get_footer(last_updated: str = "") -> yattag.doc.Doc:
+def get_footer(last_updated: str = "") -> yattag.Doc:
     """Produces the end of the page."""
-    items: List[yattag.doc.Doc] = []
-    doc = yattag.doc.Doc()
+    items: List[yattag.Doc] = []
+    doc = yattag.Doc()
     doc.text(tr("Version: "))
-    doc.asis(util.git_link(version.VERSION, "https://github.com/vmiklos/osm-gimmisn/commit/").getvalue())
+    doc.append_value(util.git_link(version.VERSION, "https://github.com/vmiklos/osm-gimmisn/commit/").get_value())
     items.append(doc)
     items.append(util.html_escape(tr("OSM data © OpenStreetMap contributors.")))
     if last_updated:
         items.append(util.html_escape(tr("Last update: ") + last_updated))
-    doc = yattag.doc.Doc()
-    doc.stag("hr")
-    with doc.tag("div"):
+    doc = yattag.Doc()
+    doc.stag("hr", [])
+    with doc.tag("div", []):
         for index, item in enumerate(items):
             if index:
                 doc.text(" ¦ ")
-            doc.asis(item.getvalue())
+            doc.append_value(item.get_value())
     return doc
 
 
-def fill_header_function(ctx: context.Context, function: str, relation_name: str, items: List[yattag.doc.Doc]) -> None:
+def fill_header_function(ctx: context.Context, function: str, relation_name: str, items: List[yattag.Doc]) -> None:
     """Fills items with function-specific links in the header. Returns a title."""
     prefix = ctx.get_ini().get_uri_prefix()
     if function == "missing-housenumbers":
         # The OSM data source changes much more frequently than the ref one, so add a dedicated link
         # to update OSM house numbers first.
-        doc = yattag.doc.Doc()
-        with doc.tag("span", id="trigger-street-housenumbers-update"):
-            with doc.tag("a", href=prefix + "/street-housenumbers/" + relation_name + "/update-result"):
+        doc = yattag.Doc()
+        with doc.tag("span", [("id", "trigger-street-housenumbers-update")]):
+            with doc.tag("a", [("href", prefix + "/street-housenumbers/" + relation_name + "/update-result")]):
                 doc.text(tr("Update from OSM"))
         items.append(doc)
 
-        doc = yattag.doc.Doc()
-        with doc.tag("span", id="trigger-missing-housenumbers-update"):
-            with doc.tag("a", href=prefix + "/missing-housenumbers/" + relation_name + "/update-result"):
+        doc = yattag.Doc()
+        with doc.tag("span", [("id", "trigger-missing-housenumbers-update")]):
+            with doc.tag("a", [("href", prefix + "/missing-housenumbers/" + relation_name + "/update-result")]):
                 doc.text(tr("Update from reference"))
         items.append(doc)
     elif function in ("missing-streets", "additional-streets"):
         # The OSM data source changes much more frequently than the ref one, so add a dedicated link
         # to update OSM streets first.
-        doc = yattag.doc.Doc()
-        with doc.tag("span", id="trigger-streets-update"):
-            with doc.tag("a", href=prefix + "/streets/" + relation_name + "/update-result"):
+        doc = yattag.Doc()
+        with doc.tag("span", [("id", "trigger-streets-update")]):
+            with doc.tag("a", [("href", prefix + "/streets/" + relation_name + "/update-result")]):
                 doc.text(tr("Update from OSM"))
         items.append(doc)
 
-        doc = yattag.doc.Doc()
-        with doc.tag("span", id="trigger-missing-streets-update"):
-            with doc.tag("a", href=prefix + "/missing-streets/" + relation_name + "/update-result"):
+        doc = yattag.Doc()
+        with doc.tag("span", [("id", "trigger-missing-streets-update")]):
+            with doc.tag("a", [("href", prefix + "/missing-streets/" + relation_name + "/update-result")]):
                 doc.text(tr("Update from reference"))
         items.append(doc)
     elif function == "street-housenumbers":
-        doc = yattag.doc.Doc()
-        with doc.tag("span", id="trigger-street-housenumbers-update"):
-            with doc.tag("a", href=prefix + "/street-housenumbers/" + relation_name + "/update-result"):
+        doc = yattag.Doc()
+        with doc.tag("span", [("id", "trigger-street-housenumbers-update")]):
+            with doc.tag("a", [("href", prefix + "/street-housenumbers/" + relation_name + "/update-result")]):
                 doc.text(tr("Call Overpass to update"))
         items.append(doc)
-        doc = yattag.doc.Doc()
-        with doc.tag("a", href=prefix + "/street-housenumbers/" + relation_name + "/view-query"):
+        doc = yattag.Doc()
+        with doc.tag("a", [("href", prefix + "/street-housenumbers/" + relation_name + "/view-query")]):
             doc.text(tr("View query"))
         items.append(doc)
     elif function == "streets":
-        doc = yattag.doc.Doc()
-        with doc.tag("span", id="trigger-streets-update"):
-            with doc.tag("a", href=prefix + "/streets/" + relation_name + "/update-result"):
+        doc = yattag.Doc()
+        with doc.tag("span", [("id", "trigger-streets-update")]):
+            with doc.tag("a", [("href", prefix + "/streets/" + relation_name + "/update-result")]):
                 doc.text(tr("Call Overpass to update"))
         items.append(doc)
-        doc = yattag.doc.Doc()
-        with doc.tag("a", href=prefix + "/streets/" + relation_name + "/view-query"):
+        doc = yattag.Doc()
+        with doc.tag("a", [("href", prefix + "/streets/" + relation_name + "/view-query")]):
             doc.text(tr("View query"))
         items.append(doc)
 
@@ -113,28 +113,28 @@ def fill_missing_header_items(
     streets: str,
     additional_housenumbers: bool,
     relation_name: str,
-    items: List[yattag.doc.Doc]
+    items: List[yattag.Doc]
 ) -> None:
     """Generates the 'missing house numbers/streets' part of the header."""
     prefix = ctx.get_ini().get_uri_prefix()
     if streets != "only":
-        doc = yattag.doc.Doc()
-        with doc.tag("a", href=prefix + "/missing-housenumbers/" + relation_name + "/view-result"):
+        doc = yattag.Doc()
+        with doc.tag("a", [("href", prefix + "/missing-housenumbers/" + relation_name + "/view-result")]):
             doc.text(tr("Missing house numbers"))
         items.append(doc)
 
         if additional_housenumbers:
-            doc = yattag.doc.Doc()
-            with doc.tag("a", href=prefix + "/additional-housenumbers/" + relation_name + "/view-result"):
+            doc = yattag.Doc()
+            with doc.tag("a", [("href", prefix + "/additional-housenumbers/" + relation_name + "/view-result")]):
                 doc.text(tr("Additional house numbers"))
             items.append(doc)
     if streets != "no":
-        doc = yattag.doc.Doc()
-        with doc.tag("a", href=prefix + "/missing-streets/" + relation_name + "/view-result"):
+        doc = yattag.Doc()
+        with doc.tag("a", [("href", prefix + "/missing-streets/" + relation_name + "/view-result")]):
             doc.text(tr("Missing streets"))
         items.append(doc)
-        doc = yattag.doc.Doc()
-        with doc.tag("a", href=prefix + "/additional-streets/" + relation_name + "/view-result"):
+        doc = yattag.Doc()
+        with doc.tag("a", [("href", prefix + "/additional-streets/" + relation_name + "/view-result")]):
             doc.text(tr("Additional streets"))
         items.append(doc)
 
@@ -143,18 +143,18 @@ def fill_existing_header_items(
     ctx: context.Context,
     streets: str,
     relation_name: str,
-    items: List[yattag.doc.Doc]
+    items: List[yattag.Doc]
 ) -> None:
     """Generates the 'existing house numbers/streets' part of the header."""
     prefix = ctx.get_ini().get_uri_prefix()
     if streets != "only":
-        doc = yattag.doc.Doc()
-        with doc.tag("a", href=prefix + "/street-housenumbers/" + relation_name + "/view-result"):
+        doc = yattag.Doc()
+        with doc.tag("a", [("href", prefix + "/street-housenumbers/" + relation_name + "/view-result")]):
             doc.text(tr("Existing house numbers"))
         items.append(doc)
 
-    doc = yattag.doc.Doc()
-    with doc.tag("a", href=prefix + "/streets/" + relation_name + "/view-result"):
+    doc = yattag.Doc()
+    with doc.tag("a", [("href", prefix + "/streets/" + relation_name + "/view-result")]):
         doc.text(tr("Existing streets"))
     items.append(doc)
 
@@ -165,19 +165,19 @@ def get_toolbar(
         function: str = "",
         relation_name: str = "",
         relation_osmid: int = 0
-) -> yattag.doc.Doc:
+) -> yattag.Doc:
     """Produces the start of the page. Note that the content depends on the function and the
     relation, but not on the action to keep a balance between too generic and too specific
     content."""
-    items: List[yattag.doc.Doc] = []
+    items: List[yattag.Doc] = []
 
     if relations and relation_name:
         relation = relations.get_relation(relation_name)
         streets = relation.get_config().should_check_missing_streets()
         additional_housenumbers = relation.get_config().should_check_additional_housenumbers()
 
-    doc = yattag.doc.Doc()
-    with doc.tag("a", href=ctx.get_ini().get_uri_prefix() + "/"):
+    doc = yattag.Doc()
+    with doc.tag("a", [("href", ctx.get_ini().get_uri_prefix() + "/")]):
         doc.text(tr("Area list"))
     items.append(doc)
 
@@ -189,10 +189,10 @@ def get_toolbar(
     if relation_name:
         fill_existing_header_items(ctx, streets, relation_name, items)
 
-    doc = yattag.doc.Doc()
+    doc = yattag.Doc()
 
     # Emit localized strings for JS purposes.
-    with doc.tag("div", style="display: none;"):
+    with doc.tag("div", [("style", "display: none;")]):
         string_pairs = [
             ("str-toolbar-overpass-wait", tr("Waiting for Overpass...")),
             ("str-toolbar-overpass-error", tr("Error from Overpass: ")),
@@ -200,40 +200,37 @@ def get_toolbar(
             ("str-toolbar-reference-error", tr("Error from reference: ")),
         ]
         for key, value in string_pairs:
-            kwargs: Dict[str, str] = {}
-            kwargs["id"] = key
-            kwargs["data-value"] = value
-            with doc.tag("div", **kwargs):
+            with doc.tag("div", [("id", key), ("data-value", value)]):
                 pass
 
-    with doc.tag("a", href="https://overpass-turbo.eu/"):
+    with doc.tag("a", [("href", "https://overpass-turbo.eu/")]):
         doc.text(tr("Overpass turbo"))
     items.append(doc)
 
     if relation_osmid:
-        doc = yattag.doc.Doc()
-        with doc.tag("a", href="https://www.openstreetmap.org/relation/" + str(relation_osmid)):
+        doc = yattag.Doc()
+        with doc.tag("a", [("href", "https://www.openstreetmap.org/relation/" + str(relation_osmid))]):
             doc.text(tr("Area boundary"))
         items.append(doc)
     else:
         # These are on the main page only.
-        doc = yattag.doc.Doc()
-        with doc.tag("a", href=ctx.get_ini().get_uri_prefix() + "/housenumber-stats/hungary/"):
+        doc = yattag.Doc()
+        with doc.tag("a", [("href", ctx.get_ini().get_uri_prefix() + "/housenumber-stats/hungary/")]):
             doc.text(tr("Statistics"))
         items.append(doc)
 
-        doc = yattag.doc.Doc()
-        with doc.tag("a", href="https://github.com/vmiklos/osm-gimmisn/tree/master/doc"):
+        doc = yattag.Doc()
+        with doc.tag("a", [("href", "https://github.com/vmiklos/osm-gimmisn/tree/master/doc")]):
             doc.text(tr("Documentation"))
         items.append(doc)
 
-    doc = yattag.doc.Doc()
-    with doc.tag("div", id="toolbar"):
+    doc = yattag.Doc()
+    with doc.tag("div", [("id", "toolbar")]):
         for index, item in enumerate(items):
             if index:
                 doc.text(" ¦ ")
-            doc.asis(item.getvalue())
-    doc.stag("hr")
+            doc.append_value(item.get_value())
+    doc.stag("hr", [])
     return doc
 
 
@@ -326,24 +323,24 @@ def handle_exception(
     status = '500 Internal Server Error'
     path_info = environ.get("PATH_INFO")
     request_uri = path_info
-    doc = yattag.doc.Doc()
+    doc = yattag.Doc()
     util.write_html_header(doc)
-    with doc.tag("pre"):
+    with doc.tag("pre", []):
         doc.text(tr("Internal error when serving {0}").format(request_uri) + "\n")
         doc.text(error)
-    response_properties = Response("text/html", status, doc.getvalue().encode("utf-8"), [])
+    response_properties = Response("text/html", status, doc.get_value().encode("utf-8"), [])
     return send_response(environ, start_response, response_properties)
 
 
-def handle_404() -> yattag.doc.Doc:
+def handle_404() -> yattag.Doc:
     """Displays a not-found page."""
-    doc = yattag.doc.Doc()
+    doc = yattag.Doc()
     util.write_html_header(doc)
-    with doc.tag("html"):
-        with doc.tag("body"):
-            with doc.tag("h1"):
+    with doc.tag("html", []):
+        with doc.tag("body", []):
+            with doc.tag("h1", []):
                 doc.text(tr("Not Found"))
-            with doc.tag("p"):
+            with doc.tag("p", []):
                 doc.text(tr("The requested URL was not found on this server."))
     return doc
 
@@ -355,10 +352,10 @@ def format_timestamp(timestamp: float) -> str:
     return date_time.strftime(fmt)
 
 
-def handle_stats_cityprogress(ctx: context.Context, relations: areas.Relations) -> yattag.doc.Doc:
+def handle_stats_cityprogress(ctx: context.Context, relations: areas.Relations) -> yattag.Doc:
     """Expected request_uri: e.g. /osm/housenumber-stats/hungary/cityprogress."""
-    doc = yattag.doc.Doc()
-    doc.asis(get_toolbar(ctx, relations).getvalue())
+    doc = yattag.Doc()
+    doc.append_value(get_toolbar(ctx, relations).get_value())
 
     ref_citycounts: Dict[str, int] = {}
     with open(ctx.get_ini().get_reference_citycounts_path(), "r") as stream:
@@ -400,22 +397,22 @@ def handle_stats_cityprogress(ctx: context.Context, relations: areas.Relations) 
                       util.html_escape(util.format_percent(percent)),
                       util.html_escape(str(osm_citycounts[city])),
                       util.html_escape(str(ref_citycounts[city]))])
-    doc.asis(util.html_table_from_list(table).getvalue())
+    doc.append_value(util.html_table_from_list(table).get_value())
 
-    with doc.tag("h2"):
+    with doc.tag("h2", []):
         doc.text(tr("Note"))
-    with doc.tag("div"):
+    with doc.tag("div", []):
         doc.text(tr("""These statistics are estimates, not taking house number filters into account.
 Only cities with house numbers in OSM are considered."""))
 
-    doc.asis(get_footer().getvalue())
+    doc.append_value(get_footer().get_value())
     return doc
 
 
-def handle_invalid_refstreets(ctx: context.Context, relations: areas.Relations) -> yattag.doc.Doc:
+def handle_invalid_refstreets(ctx: context.Context, relations: areas.Relations) -> yattag.Doc:
     """Expected request_uri: e.g. /osm/housenumber-stats/hungary/invalid-relations."""
-    doc = yattag.doc.Doc()
-    doc.asis(get_toolbar(ctx, relations).getvalue())
+    doc = yattag.Doc()
+    doc.append_value(get_toolbar(ctx, relations).get_value())
 
     prefix = ctx.get_ini().get_uri_prefix()
     for relation in relations.get_relations():
@@ -426,18 +423,18 @@ def handle_invalid_refstreets(ctx: context.Context, relations: areas.Relations) 
         key_invalids = relation.get_invalid_filter_keys()
         if not osm_invalids and not ref_invalids and not key_invalids:
             continue
-        with doc.tag("h1"):
+        with doc.tag("h1", []):
             relation_name = relation.get_name()
-            with doc.tag("a", href=prefix + "/streets/" + relation_name + "/view-result"):
+            with doc.tag("a", [("href", prefix + "/streets/" + relation_name + "/view-result")]):
                 doc.text(relation_name)
-        doc.asis(util.invalid_refstreets_to_html(invalid_refstreets).getvalue())
-        doc.asis(util.invalid_filter_keys_to_html(key_invalids).getvalue())
+        doc.append_value(util.invalid_refstreets_to_html(invalid_refstreets).get_value())
+        doc.append_value(util.invalid_filter_keys_to_html(key_invalids).get_value())
 
-    doc.asis(get_footer().getvalue())
+    doc.append_value(get_footer().get_value())
     return doc
 
 
-def handle_stats(ctx: context.Context, relations: areas.Relations, request_uri: str) -> yattag.doc.Doc:
+def handle_stats(ctx: context.Context, relations: areas.Relations, request_uri: str) -> yattag.Doc:
     """Expected request_uri: e.g. /osm/housenumber-stats/hungary/."""
     if request_uri.endswith("/cityprogress"):
         return handle_stats_cityprogress(ctx, relations)
@@ -445,13 +442,13 @@ def handle_stats(ctx: context.Context, relations: areas.Relations, request_uri: 
     if request_uri.endswith("/invalid-relations"):
         return handle_invalid_refstreets(ctx, relations)
 
-    doc = yattag.doc.Doc()
-    doc.asis(get_toolbar(ctx, relations).getvalue())
+    doc = yattag.Doc()
+    doc.append_value(get_toolbar(ctx, relations).get_value())
 
     prefix = ctx.get_ini().get_uri_prefix()
 
     # Emit localized strings for JS purposes.
-    with doc.tag("div", style="display: none;"):
+    with doc.tag("div", [("style", "display: none;")]):
         string_pairs = [
             ("str-daily-title", tr("New house numbers, last 2 weeks, as of {}")),
             ("str-daily-x-axis", tr("During this day")),
@@ -481,10 +478,7 @@ def handle_stats(ctx: context.Context, relations: areas.Relations, request_uri: 
             ("str-progress-y-axis", tr("Data source")),
         ]
         for key, value in string_pairs:
-            kwargs: Dict[str, str] = {}
-            kwargs["id"] = key
-            kwargs["data-value"] = value
-            with doc.tag("div", **kwargs):
+            with doc.tag("div", [("id", key), ("data-value", value)]):
                 pass
 
     title_ids = [
@@ -500,39 +494,39 @@ def handle_stats(ctx: context.Context, relations: areas.Relations, request_uri: 
         (tr("Invalid relation settings"), "invalid-relations"),
     ]
 
-    with doc.tag("ul"):
+    with doc.tag("ul", []):
         for title, identifier in title_ids:
-            with doc.tag("li"):
+            with doc.tag("li", []):
                 if identifier == "cityprogress":
-                    with doc.tag("a", href=prefix + "/housenumber-stats/hungary/cityprogress"):
+                    with doc.tag("a", [("href", prefix + "/housenumber-stats/hungary/cityprogress")]):
                         doc.text(title)
                     continue
                 if identifier == "invalid-relations":
-                    with doc.tag("a", href=prefix + "/housenumber-stats/hungary/invalid-relations"):
+                    with doc.tag("a", [("href", prefix + "/housenumber-stats/hungary/invalid-relations")]):
                         doc.text(title)
                     continue
-                with doc.tag("a", href="#_" + identifier):
+                with doc.tag("a", [("href", "#_" + identifier)]):
                     doc.text(title)
 
     for title, identifier in title_ids:
         if identifier in ("cityprogress", "invalid-relations"):
             continue
-        with doc.tag("h2", id="_" + identifier):
+        with doc.tag("h2", [("id", "_" + identifier)]):
             doc.text(title)
 
-        with doc.tag("div", klass="canvasblock js"):
-            with doc.tag("canvas", id=identifier):
+        with doc.tag("div", [("class", "canvasblock js")]):
+            with doc.tag("canvas", [("id", identifier)]):
                 pass
 
-    with doc.tag("h2"):
+    with doc.tag("h2", []):
         doc.text(tr("Note"))
-    with doc.tag("div"):
+    with doc.tag("div", []):
         doc.text(tr("""These statistics are provided purely for interested editors, and are not
 intended to reflect quality of work done by any given editor in OSM. If you want to use
 them to motivate yourself, that's fine, but keep in mind that a bit of useful work is
 more meaningful than a lot of useless work."""))
 
-    doc.asis(get_footer().getvalue())
+    doc.append_value(get_footer().get_value())
     return doc
 
 
@@ -565,9 +559,9 @@ def get_request_uri(environ: Dict[str, Any], ctx: context.Context, relations: ar
     return request_uri
 
 
-def check_existing_relation(ctx: context.Context, relations: areas.Relations, request_uri: str) -> yattag.doc.Doc:
+def check_existing_relation(ctx: context.Context, relations: areas.Relations, request_uri: str) -> yattag.Doc:
     """Prevents serving outdated data from a relation that has been renamed."""
-    doc = yattag.doc.Doc()
+    doc = yattag.Doc()
     prefix = ctx.get_ini().get_uri_prefix()
     if not request_uri.startswith(prefix + "/streets/") \
             and not request_uri.startswith(prefix + "/missing-streets/") \
@@ -581,100 +575,88 @@ def check_existing_relation(ctx: context.Context, relations: areas.Relations, re
     if relation_name in relations.get_names():
         return doc
 
-    with doc.tag("div", id="no-such-relation-error"):
+    with doc.tag("div", [("id", "no-such-relation-error")]):
         doc.text(tr("No such relation: {0}").format(relation_name))
     return doc
 
 
-def handle_no_osm_streets(prefix: str, relation_name: str) -> yattag.doc.Doc:
+def handle_no_osm_streets(prefix: str, relation_name: str) -> yattag.Doc:
     """Handles the no-osm-streets error on a page using JS."""
-    doc = yattag.doc.Doc()
+    doc = yattag.Doc()
     link = prefix + "/streets/" + relation_name + "/update-result"
-    with doc.tag("div", id="no-osm-streets"):
-        with doc.tag("a", href=link):
+    with doc.tag("div", [("id", "no-osm-streets")]):
+        with doc.tag("a", [("href", link)]):
             doc.text(tr("No existing streets: call Overpass to create..."))
     # Emit localized strings for JS purposes.
-    with doc.tag("div", style="display: none;"):
+    with doc.tag("div", [("style", "display: none;")]):
         string_pairs = [
             ("str-overpass-wait", tr("No existing streets: waiting for Overpass...")),
             ("str-overpass-error", tr("Error from Overpass: ")),
         ]
         for key, value in string_pairs:
-            kwargs: Dict[str, str] = {}
-            kwargs["id"] = key
-            kwargs["data-value"] = value
-            with doc.tag("div", **kwargs):
+            with doc.tag("div", [("id", key), ("data-value", value)]):
                 pass
     return doc
 
 
-def handle_no_osm_housenumbers(prefix: str, relation_name: str) -> yattag.doc.Doc:
+def handle_no_osm_housenumbers(prefix: str, relation_name: str) -> yattag.Doc:
     """Handles the no-osm-housenumbers error on a page using JS."""
-    doc = yattag.doc.Doc()
+    doc = yattag.Doc()
     link = prefix + "/street-housenumbers/" + relation_name + "/update-result"
-    with doc.tag("div", id="no-osm-housenumbers"):
-        with doc.tag("a", href=link):
+    with doc.tag("div", [("id", "no-osm-housenumbers")]):
+        with doc.tag("a", [("href", link)]):
             doc.text(tr("No existing house numbers: call Overpass to create..."))
     # Emit localized strings for JS purposes.
-    with doc.tag("div", style="display: none;"):
+    with doc.tag("div", [("style", "display: none;")]):
         string_pairs = [
             ("str-overpass-wait", tr("No existing house numbers: waiting for Overpass...")),
             ("str-overpass-error", tr("Error from Overpass: ")),
         ]
         for key, value in string_pairs:
-            kwargs: Dict[str, str] = {}
-            kwargs["id"] = key
-            kwargs["data-value"] = value
-            with doc.tag("div", **kwargs):
+            with doc.tag("div", [("id", key), ("data-value", value)]):
                 pass
     return doc
 
 
-def handle_no_ref_housenumbers(prefix: str, relation_name: str) -> yattag.doc.Doc:
+def handle_no_ref_housenumbers(prefix: str, relation_name: str) -> yattag.Doc:
     """Handles the no-ref-housenumbers error on a page using JS."""
-    doc = yattag.doc.Doc()
+    doc = yattag.Doc()
     link = prefix + "/missing-housenumbers/" + relation_name + "/update-result"
-    with doc.tag("div", id="no-ref-housenumbers"):
-        with doc.tag("a", href=link):
+    with doc.tag("div", [("id", "no-ref-housenumbers")]):
+        with doc.tag("a", [("href", link)]):
             doc.text(tr("No reference house numbers: create from reference..."))
     # Emit localized strings for JS purposes.
-    with doc.tag("div", style="display: none;"):
+    with doc.tag("div", [("style", "display: none;")]):
         string_pairs = [
             ("str-reference-wait", tr("No reference house numbers: creating from reference...")),
             ("str-reference-error", tr("Error from reference: ")),
         ]
         for key, value in string_pairs:
-            kwargs: Dict[str, str] = {}
-            kwargs["id"] = key
-            kwargs["data-value"] = value
-            with doc.tag("div", **kwargs):
+            with doc.tag("div", [("id", key), ("data-value", value)]):
                 pass
     return doc
 
 
-def handle_no_ref_streets(prefix: str, relation_name: str) -> yattag.doc.Doc:
+def handle_no_ref_streets(prefix: str, relation_name: str) -> yattag.Doc:
     """Handles the no-ref-streets error on a page using JS."""
-    doc = yattag.doc.Doc()
+    doc = yattag.Doc()
     link = prefix + "/missing-streets/" + relation_name + "/update-result"
-    with doc.tag("div", id="no-ref-streets"):
-        with doc.tag("a", href=link):
+    with doc.tag("div", [("id", "no-ref-streets")]):
+        with doc.tag("a", [("href", link)]):
             doc.text(tr("No street list: create from reference..."))
     # Emit localized strings for JS purposes.
-    with doc.tag("div", style="display: none;"):
+    with doc.tag("div", [("style", "display: none;")]):
         string_pairs = [
             ("str-reference-wait", tr("No reference streets: creating from reference...")),
             ("str-reference-error", tr("Error from reference: ")),
         ]
         for key, value in string_pairs:
-            kwargs: Dict[str, str] = {}
-            kwargs["id"] = key
-            kwargs["data-value"] = value
-            with doc.tag("div", **kwargs):
+            with doc.tag("div", [("id", key), ("data-value", value)]):
                 pass
     return doc
 
 
-def handle_github_webhook(environ: Dict[str, Any], ctx: context.Context) -> yattag.doc.Doc:
+def handle_github_webhook(environ: Dict[str, Any], ctx: context.Context) -> yattag.Doc:
     """Handles a GitHub style webhook."""
 
     body = urllib.parse.parse_qs(environ["wsgi.input"].read().decode('utf-8'))

--- a/wsgi_additional.py
+++ b/wsgi_additional.py
@@ -51,18 +51,18 @@ def additional_streets_view_result(
     ctx: context.Context,
     relations: areas.Relations,
     request_uri: str
-) -> yattag.doc.Doc:
+) -> yattag.Doc:
     """Expected request_uri: e.g. /osm/additional-streets/budapest_11/view-result."""
     tokens = request_uri.split("/")
     relation_name = tokens[-2]
     relation = relations.get_relation(relation_name)
 
-    doc = yattag.doc.Doc()
+    doc = yattag.Doc()
     prefix = ctx.get_ini().get_uri_prefix()
     if not ctx.get_file_system().path_exists(relation.get_files().get_osm_streets_path()):
-        doc.asis(webframe.handle_no_osm_streets(prefix, relation_name).getvalue())
+        doc.append_value(webframe.handle_no_osm_streets(prefix, relation_name).get_value())
     elif not ctx.get_file_system().path_exists(relation.get_files().get_ref_streets_path()):
-        doc.asis(webframe.handle_no_ref_streets(prefix, relation_name).getvalue())
+        doc.append_value(webframe.handle_no_ref_streets(prefix, relation_name).get_value())
     else:
         # Get "only in OSM" streets.
         streets = relation.write_additional_streets()
@@ -74,9 +74,9 @@ def additional_streets_view_result(
                   util.html_escape(tr("Source")),
                   util.html_escape(tr("Street name"))]]
         for street in streets:
-            cell = yattag.doc.Doc()
+            cell = yattag.Doc()
             href = "https://www.openstreetmap.org/{}/{}".format(street.get_osm_type(), street.get_osm_id())
-            with cell.tag("a", href=href, target="_blank"):
+            with cell.tag("a", [("href", href), ("target", "_blank")]):
                 cell.text(str(street.get_osm_id()))
             cells = [
                 cell,
@@ -86,20 +86,20 @@ def additional_streets_view_result(
             ]
             table.append(cells)
 
-        with doc.tag("p"):
+        with doc.tag("p", []):
             doc.text(tr("OpenStreetMap additionally has the below {0} streets.").format(str(count)))
-            doc.stag("br")
-            with doc.tag("a", href=prefix + "/additional-streets/" + relation_name + "/view-result.txt"):
+            doc.stag("br", [])
+            with doc.tag("a", [("href", prefix + "/additional-streets/" + relation_name + "/view-result.txt")]):
                 doc.text(tr("Plain text format"))
-            doc.stag("br")
-            with doc.tag("a", href=prefix + "/additional-streets/" + relation_name + "/view-result.chkl"):
+            doc.stag("br", [])
+            with doc.tag("a", [("href", prefix + "/additional-streets/" + relation_name + "/view-result.chkl")]):
                 doc.text(tr("Checklist format"))
-            doc.stag("br")
-            with doc.tag("a", href=prefix + "/additional-streets/{}/view-turbo".format(relation_name)):
+            doc.stag("br", [])
+            with doc.tag("a", [("href", prefix + "/additional-streets/{}/view-turbo".format(relation_name))]):
                 doc.text(tr("Overpass turbo query for the below streets"))
 
-        doc.asis(util.html_table_from_list(table).getvalue())
-        doc.asis(util.invalid_refstreets_to_html(relation.get_invalid_refstreets()).getvalue())
+        doc.append_value(util.html_table_from_list(table).get_value())
+        doc.append_value(util.invalid_refstreets_to_html(relation.get_invalid_refstreets()).get_value())
     return doc
 
 
@@ -107,37 +107,37 @@ def additional_housenumbers_view_result(
     ctx: context.Context,
     relations: areas.Relations,
     request_uri: str
-) -> yattag.doc.Doc:
+) -> yattag.Doc:
     """Expected request_uri: e.g. /osm/additional-housenumbers/budapest_11/view-result."""
     tokens = request_uri.split("/")
     relation_name = tokens[-2]
     relation = relations.get_relation(relation_name)
 
-    doc = yattag.doc.Doc()
+    doc = yattag.Doc()
     relation = relations.get_relation(relation_name)
     prefix = ctx.get_ini().get_uri_prefix()
     if not ctx.get_file_system().path_exists(relation.get_files().get_osm_streets_path()):
-        doc.asis(webframe.handle_no_osm_streets(prefix, relation_name).getvalue())
+        doc.append_value(webframe.handle_no_osm_streets(prefix, relation_name).get_value())
     elif not ctx.get_file_system().path_exists(relation.get_files().get_osm_housenumbers_path()):
-        doc.asis(webframe.handle_no_osm_housenumbers(prefix, relation_name).getvalue())
+        doc.append_value(webframe.handle_no_osm_housenumbers(prefix, relation_name).get_value())
     elif not ctx.get_file_system().path_exists(relation.get_files().get_ref_housenumbers_path()):
-        doc.asis(webframe.handle_no_ref_housenumbers(prefix, relation_name).getvalue())
+        doc.append_value(webframe.handle_no_ref_housenumbers(prefix, relation_name).get_value())
     else:
         doc = cache.get_additional_housenumbers_html(ctx, relation)
     return doc
 
 
-def additional_streets_view_turbo(relations: areas.Relations, request_uri: str) -> yattag.doc.Doc:
+def additional_streets_view_turbo(relations: areas.Relations, request_uri: str) -> yattag.Doc:
     """Expected request_uri: e.g. /osm/additional-housenumbers/ormezo/view-turbo."""
     tokens = request_uri.split("/")
     relation_name = tokens[-2]
 
-    doc = yattag.doc.Doc()
+    doc = yattag.Doc()
     relation = relations.get_relation(relation_name)
     streets = relation.get_additional_streets(sorted_result=False)
     query = areas.make_turbo_query_for_street_objs(relation, streets)
 
-    with doc.tag("pre"):
+    with doc.tag("pre", []):
         doc.text(query)
     return doc
 

--- a/yattag.py
+++ b/yattag.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Miklos Vajna and contributors.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""
+The yattag module generates HTML with Python.
+
+This is a stripped down version of the Python package.
+"""
+
+from typing import Any
+from typing import List
+from typing import Tuple
+
+
+class Doc:
+    """Generates xml/html documents."""
+    def __init__(self) -> None:
+        self.value = ""
+
+    def get_value(self) -> str:
+        """Gets the escaped value."""
+        return self.value
+
+    def append_value(self, value: str) -> None:
+        """Appends escaped content to the value."""
+        self.value += value
+
+    def tag(self, name: str, attrs: List[Tuple[str, str]]) -> 'Tag':
+        """Starts a new tag."""
+        return Tag(self, name, attrs)
+
+    def stag(self, name: str, attrs: List[Tuple[str, str]]) -> None:
+        """Starts a new tag and closes it as well."""
+        self.append_value("<{}".format(name))
+        for attr in attrs:
+            key = attr[0]
+            value = attr[1].replace("&", "&amp;").replace("<", "&lt;").replace('"', "&quot;")
+            self.append_value(" {}=\"{}\"".format(key, value))
+        self.append_value(" />")
+
+    def text(self, text: str) -> None:
+        """Appends unescaped content to the document."""
+        self.append_value(text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+
+class Tag:
+    """Starts a tag, which is closed automatically."""
+    def __init__(self, doc: Doc, name: str, attrs: List[Tuple[str, str]]) -> None:
+        doc.append_value("<{}".format(name))
+        for attr in attrs:
+            key = attr[0]
+            value = attr[1].replace("&", "&amp;").replace("<", "&lt;").replace('"', "&quot;")
+            doc.append_value(" {}=\"{}\"".format(key, value))
+        doc.append_value(">")
+        self.doc = doc
+        self.name = name
+
+    def __enter__(self) -> None:
+        pass
+
+    def __exit__(self, tpe: Any, value: Any, traceback: Any) -> None:
+        self.doc.append_value("</{}>".format(self.name))
+
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab:


### PR DESCRIPTION
- 68 lines is less than the 2.2k lines of that dependency
- attribute names containing hyphens (e.g. data-value) are no longer a
  special case this way
- this is now short enough to be ported to Rust

Change-Id: Ie055b7884d51b99cac2be67b5a720fb14a0c9634
