### PR TITLE
Start porting yattag.py to Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ name = "rust"
 # crate-type = ["cdylib", "rlib"]
 crate-type = ["cdylib"]
 
+[dependencies]
+html-escape = "0.2.9"
+
 [dependencies.pyo3]
 version = "0.13.2"
 features = ["extension-module"]

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ version.py: .git/$(shell git symbolic-ref HEAD) Makefile
 rust.so: target/debug/librust.so
 	ln -sf target/debug/librust.so rust.so
 
-target/debug/librust.so: Cargo.toml src/lib.rs src/ranges.rs
+target/debug/librust.so: Cargo.toml src/lib.rs src/ranges.rs src/yattag.rs
 	cargo build
 
 config.ts: wsgi.ini Makefile

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,14 @@
 use pyo3::prelude::*;
 
 mod ranges;
+mod yattag;
 
 #[pymodule]
 fn rust(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<ranges::PyRange>()?;
     m.add_class::<ranges::PyRanges>()?;
+    m.add_class::<yattag::PyDoc>()?;
+    m.add_class::<yattag::PyTag>()?;
 
     Ok(())
 }

--- a/src/yattag.rs
+++ b/src/yattag.rs
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2021 Miklos Vajna. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#![deny(warnings)]
+#![warn(clippy::all)]
+#![warn(missing_docs)]
+
+//! Generate HTML with Rust.
+//!
+//! This is more or less a Rust port of the Python package, mostly because
+//! <https://crates.io/crates/html-builder> would require you to manually escape attribute values.
+
+use pyo3::class::PyContextProtocol;
+use pyo3::prelude::*;
+use pyo3::types::PyType;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+/// Generates xml/html documents.
+pub struct Doc {
+    value: Arc<Mutex<String>>,
+}
+
+impl Doc {
+    pub fn new() -> Doc {
+        Doc {
+            value: Arc::new(Mutex::new(String::from(""))),
+        }
+    }
+
+    /// Gets the escaped value.
+    fn get_value(&self) -> String {
+        self.value.lock().unwrap().clone()
+    }
+
+    /// Appends escaped content to the value.
+    fn append_value(&self, value: String) {
+        self.value.lock().unwrap().push_str(&value)
+    }
+
+    /// Starts a new tag.
+    fn tag(&self, name: &str, attrs: Vec<(&str, &str)>) -> Tag {
+        Tag::new(&self.value, name, attrs)
+    }
+
+    /// Starts a new tag and closes it as well.
+    fn stag(&self, name: &str, attrs: Vec<(&str, &str)>) {
+        self.append_value(format!("<{}", name));
+        for attr in attrs {
+            let key = attr.0;
+            let value = html_escape::encode_double_quoted_attribute(&attr.1);
+            self.append_value(format!(" {}=\"{}\"", key, value));
+        }
+        self.append_value(String::from(" />"))
+    }
+
+    /// Appends unescaped content to the document.
+    fn text(&self, text: &str) {
+        let encoded = html_escape::encode_safe(text).to_string();
+        self.append_value(encoded);
+    }
+}
+
+#[pyclass]
+pub struct PyDoc {
+    doc: Doc,
+}
+
+#[pymethods]
+impl PyDoc {
+    #[new]
+    fn new() -> Self {
+        let doc = Doc::new();
+        PyDoc { doc }
+    }
+
+    fn get_value(&self) -> String {
+        self.doc.get_value()
+    }
+
+    fn append_value(&self, value: String) {
+        self.doc.append_value(value)
+    }
+
+    fn tag(&self, name: &str, attrs: Vec<(&str, &str)>) -> PyTag {
+        let tag = self.doc.tag(name, attrs);
+        PyTag { tag: Some(tag) }
+    }
+
+    fn stag(&self, name: &str, attrs: Vec<(&str, &str)>) {
+        self.doc.stag(name, attrs)
+    }
+
+    fn text(&self, text: &str) {
+        self.doc.text(text)
+    }
+}
+
+/// Starts a tag, which is closed automatically.
+struct Tag {
+    value: Arc<Mutex<String>>,
+    name: String,
+}
+
+impl Tag {
+    fn new(value: &Arc<Mutex<String>>, name: &str, attrs: Vec<(&str, &str)>) -> Tag {
+        value.lock().unwrap().push_str(&format!("<{}", name));
+        for attr in attrs {
+            let key = attr.0;
+            let val = html_escape::encode_double_quoted_attribute(&attr.1);
+            value
+                .lock()
+                .unwrap()
+                .push_str(&format!(" {}=\"{}\"", key, val));
+        }
+        value.lock().unwrap().push('>');
+        let value = value.clone();
+        Tag {
+            value,
+            name: name.to_string(),
+        }
+    }
+}
+
+impl Drop for Tag {
+    fn drop(&mut self) {
+        self.value
+            .lock()
+            .unwrap()
+            .push_str(&format!("</{}>", self.name));
+    }
+}
+
+#[pyclass]
+pub struct PyTag {
+    tag: Option<Tag>,
+}
+
+#[pymethods]
+impl PyTag {
+    #[new]
+    fn new(py: Python<'_>, doc: PyObject, name: &str, attrs: Vec<(&str, &str)>) -> PyResult<Self> {
+        // Convert PyObject to Doc.
+        let doc: PyRefMut<'_, PyDoc> = doc.extract(py)?;
+        let tag = Tag::new(&doc.doc.value, name, attrs);
+        Ok(PyTag { tag: Some(tag) })
+    }
+}
+
+#[pyproto]
+impl<'p> PyContextProtocol<'p> for PyTag {
+    fn __enter__(&'p mut self) -> PyResult<()> {
+        Ok(())
+    }
+
+    fn __exit__(
+        &mut self,
+        _ty: Option<&'p PyType>,
+        _value: Option<&'p PyAny>,
+        _traceback: Option<&'p PyAny>,
+    ) -> PyResult<bool> {
+        if self.tag.is_some() {
+            self.tag = None;
+        }
+        Ok(true)
+    }
+}


### PR DESCRIPTION
It works, but type hints are missing on the Python side.

Change-Id: I21e5c9af59fe26acb12c5d4ddd7dcf89ba9fd4d3
