### PR TITLE
Port accept_language.py to Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 html-escape = "0.2.9"
+accept-language = "2.0.0"
 
 [dependencies.pyo3]
 version = "0.13.2"

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,12 @@ TS_OBJECTS = \
 	stats.ts \
 	types.d.ts \
 
+RS_OBJECTS = \
+	src/accept_language.rs \
+	src/lib.rs \
+	src/ranges.rs \
+	src/yattag.rs \
+
 ifndef V
 	QUIET_FLAKE8 = @echo '   ' FLAKE8 $@;
 	QUIET_MSGFMT = @echo '   ' MSGMFT $@;
@@ -104,7 +110,7 @@ version.py: .git/$(shell git symbolic-ref HEAD) Makefile
 rust.so: target/debug/librust.so
 	ln -sf target/debug/librust.so rust.so
 
-target/debug/librust.so: Cargo.toml src/lib.rs src/ranges.rs src/yattag.rs
+target/debug/librust.so: Cargo.toml $(RS_OBJECTS)
 	cargo build
 
 config.ts: wsgi.ini Makefile

--- a/accept_language.py
+++ b/accept_language.py
@@ -1,69 +1,12 @@
 #!/usr/bin/env python3
-#
-# Version: 0.1.2
-# Author: Chatbot Developers
-# License: Apache License 2.0
 
 """
-The accept_language module parses an Accept-Language HTTP header, originally from
-<https://github.com/Babylonpartners/parse-accept-language>.
+The accept_language module parses an Accept-Language HTTP header.
 """
 
 
-from typing import List
-import re
+import rust
 
-VALIDATE_LANG_REGEX = re.compile('^[a-z]+$', flags=re.IGNORECASE)
-QUALITY_VAL_SUB_REGEX = re.compile('^q=', flags=re.IGNORECASE)
-DEFAULT_QUALITY_VALUE = 1.0
-
-
-class Lang:
-    """One detected language."""
-    def __init__(self, language: str, quality: float) -> None:
-        self.__language = language
-        self.__quality = quality
-
-    def get_language(self) -> str:
-        """Returns the language."""
-        return self.__language
-
-    def get_quality(self) -> float:
-        """Returns the quality."""
-        return self.__quality
-
-
-def parse(accept_language_str: str) -> List[str]:
-    """
-    Parse a RFC 2616 Accept-Language string.
-    https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14
-
-    :param accept_language_str: A string in RFC 2616 format.
-    """
-    if not accept_language_str:
-        return []
-
-    parsed_langs = []
-    for accept_lang_segment in accept_language_str.split(','):
-        quality_value = DEFAULT_QUALITY_VALUE
-        lang_code = accept_lang_segment.strip()
-        if ';' in accept_lang_segment:
-            lang_code, quality_value_string = accept_lang_segment.split(';')
-            quality_value = float(QUALITY_VAL_SUB_REGEX.sub('', quality_value_string))
-
-        lang_code_components = re.split('-|_', lang_code)
-        if not all(VALIDATE_LANG_REGEX.match(c) for c in lang_code_components):
-            continue
-
-        if len(lang_code_components) == 1:
-            # language code 2/3 letters, e.g. fr
-            language = lang_code_components[0].lower()
-        else:
-            # full language tag, e.g. en-US
-            language = lang_code_components[0].lower()
-        parsed_langs.append(
-            Lang(language=language, quality=quality_value)
-        )
-    return [i.get_language() for i in sorted(parsed_langs, key=lambda i: i.get_quality(), reverse=True)]
+parse = rust.py_parse
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/rust.pyi
+++ b/rust.pyi
@@ -98,4 +98,13 @@ class PyTag:
     def __exit__(self, tpe: Any, value: Any, traceback: Any) -> None:
         ...
 
+def py_parse(raw_languages: str) -> List[str]:
+    """
+    Parse a RFC 2616 Accept-Language string.
+    https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14
+
+    :param accept_language_str: A string in RFC 2616 format.
+    """
+    ...
+
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/src/accept_language.rs
+++ b/src/accept_language.rs
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Miklos Vajna. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#![deny(warnings)]
+#![warn(clippy::all)]
+#![warn(missing_docs)]
+
+//! The accept_language module parses an Accept-Language HTTP header.
+
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub fn py_parse(raw_languages: &str) -> Vec<String> {
+    accept_language::parse(raw_languages)
+}
+
+pub fn register_python_symbols(module: &PyModule) -> PyResult<()> {
+    module.add_function(pyo3::wrap_pyfunction!(py_parse, module)?)?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 
 use pyo3::prelude::*;
 
+mod accept_language;
 mod ranges;
 mod yattag;
 
@@ -22,6 +23,7 @@ fn rust(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<ranges::PyRanges>()?;
     m.add_class::<yattag::PyDoc>()?;
     m.add_class::<yattag::PyTag>()?;
+    accept_language::register_python_symbols(&m)?;
 
     Ok(())
 }

--- a/src/yattag.rs
+++ b/src/yattag.rs
@@ -107,16 +107,14 @@ struct Tag {
 
 impl Tag {
     fn new(value: &Arc<Mutex<String>>, name: &str, attrs: Vec<(&str, &str)>) -> Tag {
-        value.lock().unwrap().push_str(&format!("<{}", name));
+        let mut locked_value = value.lock().unwrap();
+        locked_value.push_str(&format!("<{}", name));
         for attr in attrs {
             let key = attr.0;
             let val = html_escape::encode_double_quoted_attribute(&attr.1);
-            value
-                .lock()
-                .unwrap()
-                .push_str(&format!(" {}=\"{}\"", key, val));
+            locked_value.push_str(&format!(" {}=\"{}\"", key, val));
         }
-        value.lock().unwrap().push('>');
+        locked_value.push('>');
         let value = value.clone();
         Tag {
             value,

--- a/tests/test_accept_language.py
+++ b/tests/test_accept_language.py
@@ -15,18 +15,13 @@ class TestParseAcceptLanguage(unittest.TestCase):
     """Tests parse_accept_language()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        parsed = accept_language.parse("en-US,el;q=0.8")
-        self.assertEqual(parsed[0], "en")
+        parsed = accept_language.parse("hu,en;q=0.9,en-US;q=0.8")
+        self.assertEqual(parsed[0], "hu")
 
-    def test_empty(self) -> None:
-        """Tests empty input."""
-        parsed = accept_language.parse("")
-        self.assertEqual(parsed, [])
-
-    def test_invalid_lang(self) -> None:
-        """Tests the case when a language string is invalid."""
-        parsed = accept_language.parse("en42-US,el;q=0.8")
-        self.assertEqual(parsed[0], "el")
+    def test_english(self) -> None:
+        """Tests when the language is not explicitly set."""
+        parsed = accept_language.parse("en-US,en;q=0.5")
+        self.assertEqual(parsed[0], "en-US")
 
 
 if __name__ == '__main__':

--- a/tools/dump-deps.sh
+++ b/tools/dump-deps.sh
@@ -17,6 +17,9 @@ do
     do
         # Silence stubs for rust modules.
         case $dependency in
+            accept_language)
+                continue
+            ;;
             ranges)
                 continue
             ;;


### PR DESCRIPTION
There is <https://crates.io/crates/accept-language>, so only the Python
wrapper is needed in own code.

Change-Id: I1a965a243f62a458a359f822575f6d55e1bfee3b
