### PR TITLE
Port context.Network to Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib"]
 accept-language = "2.0.0"
 git-version = "0.3.5"
 html-escape = "0.2.9"
+reqwest = { version = "0.11.4", features = ["blocking"] }
 
 [dependencies.pyo3]
 version = "0.13.2"

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ PYTHON_TEST_OBJECTS = \
 
 # These have good coverage.
 PYTHON_SAFE_OBJECTS = \
+	api.py \
 	area_files.py \
 	areas.py \
 	cache.py \
@@ -147,10 +148,10 @@ tests/workdir/osm.min.css: workdir/osm.min.css
 wsgi.ini:
 	cp data/wsgi.ini.template wsgi.ini
 
-data/yamls.cache: cache_yamls.py $(YAML_OBJECTS)
+data/yamls.cache: cache_yamls.py rust.so $(YAML_OBJECTS)
 	./cache_yamls.py data workdir
 
-tests/data/yamls.cache: cache_yamls.py $(YAML_TEST_OBJECTS)
+tests/data/yamls.cache: cache_yamls.py rust.so $(YAML_TEST_OBJECTS)
 	./cache_yamls.py tests/data tests/workdir
 
 check-filters: check-filters-syntax check-filters-schema

--- a/api.py
+++ b/api.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Miklos Vajna and contributors.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""
+Shared type hints.
+"""
+
+from typing import Tuple
+
+
+class Network:
+    """Network interface."""
+    def urlopen(self, url: str, data: bytes) -> Tuple[bytes, str]:  # pragma: no cover
+        """Opens an URL. Empty data means HTTP GET, otherwise it means a HTTP POST."""
+        # pylint: disable=no-self-use
+        # pylint: disable=unused-argument
+        ...
+
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/rust.pyi
+++ b/rust.pyi
@@ -13,6 +13,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import cast
+import api
 
 
 class PyRange:
@@ -110,5 +111,10 @@ def py_parse(raw_languages: str) -> List[str]:
 def py_get_version() -> str:
     """Gets the git version."""
     ...
+
+class PyStdNetwork(api.Network):
+    """Network implementation, backed by the Python stdlib."""
+    def urlopen(self, url: str, data: bytes) -> Tuple[bytes, str]:  # pragma: no cover
+        ...
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Miklos Vajna. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#![deny(warnings)]
+#![warn(clippy::all)]
+#![warn(missing_docs)]
+
+//! Abstractions to help writing unit tests: filesystem, network, etc.
+
+use pyo3::prelude::*;
+
+pub type BoxResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+/// Network interface.
+trait Network {
+    /// Opens an URL. Empty data means HTTP GET, otherwise it means a HTTP POST.
+    fn urlopen(&self, url: &str, data: &str) -> BoxResult<String>;
+}
+
+/// Network implementation, backed by the reqwest.
+struct StdNetwork {
+}
+
+impl Network for StdNetwork {
+    fn urlopen(&self, url: &str, data: &str) -> BoxResult<String> {
+        if !data.is_empty() {
+            let client = reqwest::blocking::Client::new();
+            let body = String::from(data);
+            let buf = client.post(url).body(body).send()?;
+            return Ok(buf.text()?);
+        }
+
+        let buf = reqwest::blocking::get(url)?;
+
+        Ok(buf.text()?)
+    }
+}
+
+#[pyclass]
+pub struct PyStdNetwork {
+    network: StdNetwork,
+}
+
+#[pymethods]
+impl PyStdNetwork {
+    #[new]
+    fn new() -> Self {
+        let network = StdNetwork{};
+        PyStdNetwork { network }
+    }
+
+    fn urlopen(&self, url: &str, data: &str) -> (String, String) {
+        match self.network.urlopen(url, data) {
+            Ok(value) => (value, String::from("")),
+            Err(err) => (String::from(""), err.to_string())
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,11 @@ mod accept_language;
 mod ranges;
 mod version;
 mod yattag;
+mod context;
 
 #[pymodule]
 fn rust(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_class::<context::PyStdNetwork>()?;
     m.add_class::<ranges::PyRange>()?;
     m.add_class::<ranges::PyRanges>()?;
     m.add_class::<yattag::PyDoc>()?;

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -16,6 +16,7 @@ import io
 import os
 import unittest
 
+import api
 import context
 
 
@@ -87,7 +88,7 @@ class URLRoute:
         self.result_path = result_path
 
 
-class TestNetwork(context.Network):
+class TestNetwork(api.Network):
     """Network implementation, for test purposes."""
     def __init__(self, routes: List[URLRoute]) -> None:
         self.__routes = routes


### PR DESCRIPTION
Which means test_context and rust.pyi needs some shared place to declare
a common interface on the Python side, so introduce an api.py for that.

Change-Id: I96818bb2d1c016bb6325b0994807c281994c725e
