### PR TITLE
Start porting context.FileSystem to Rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,10 @@
 use pyo3::prelude::*;
 
 mod accept_language;
+mod context;
 mod ranges;
 mod version;
 mod yattag;
-mod context;
 
 #[pymodule]
 fn rust(_py: Python<'_>, m: &PyModule) -> PyResult<()> {


### PR DESCRIPTION
It's done, but the Python bindings are missing.

Change-Id: Ie89174fac3949c89844812026d7a0a0689a4e4d5
