### PR TITLE
Finish porting context.FileSystem to Rust

### DIFF
--- a/context.py
+++ b/context.py
@@ -51,11 +51,14 @@ class FileSystem:
 
 class StdFileSystem(FileSystem):
     """File system implementation, backed by the Python stdlib."""
+    def __init__(self) -> None:
+        self.rust = rust.PyStdFileSystem()
+
     def path_exists(self, path: str) -> bool:
-        return os.path.exists(path)
+        return self.rust.path_exists(path)
 
     def getmtime(self, path: str) -> float:
-        return os.path.getmtime(path)
+        return self.rust.getmtime(path)
 
     def open_read(self, path: str) -> BinaryIO:
         # The caller will do this:

--- a/rust.pyi
+++ b/rust.pyi
@@ -112,8 +112,19 @@ def py_get_version() -> str:
     """Gets the git version."""
     ...
 
+class PyStdFileSystem:
+    """File system implementation, backed by the Rust stdlib."""
+    def __init__(self) -> None:
+        ...
+
+    def path_exists(self, path: str) -> bool:
+        ...
+
+    def getmtime(self, path: str) -> float:
+        ...
+
 class PyStdNetwork(api.Network):
-    """Network implementation, backed by the Python stdlib."""
+    """Network implementation, backed by the Rust stdlib."""
     def urlopen(self, url: str, data: bytes) -> Tuple[bytes, str]:  # pragma: no cover
         ...
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -58,6 +58,31 @@ impl FileSystem for StdFileSystem {
     }
 }
 
+#[pyclass]
+pub struct PyStdFileSystem {
+    file_system: StdFileSystem,
+}
+
+#[pymethods]
+impl PyStdFileSystem {
+    #[new]
+    fn new() -> Self {
+        let file_system = StdFileSystem {};
+        PyStdFileSystem { file_system }
+    }
+
+    fn path_exists(&self, path: &str) -> bool {
+        self.file_system.path_exists(path)
+    }
+
+    fn getmtime(&self, path: &str) -> PyResult<f64> {
+        match self.file_system.getmtime(path) {
+            Ok(value) => Ok(value),
+            Err(_) => Err(pyo3::exceptions::PyIOError::new_err("getmtime() failed")),
+        }
+    }
+}
+
 /// Network interface.
 trait Network {
     /// Opens an URL. Empty data means HTTP GET, otherwise it means a HTTP POST.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod yattag;
 
 #[pymodule]
 fn rust(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_class::<context::PyStdFileSystem>()?;
     m.add_class::<context::PyStdNetwork>()?;
     m.add_class::<ranges::PyRange>()?;
     m.add_class::<ranges::PyRanges>()?;


### PR DESCRIPTION
But don't bother wrapping the open_read() / open_write() part as there
is no easy way to expose an opened Rust file to Python and we don't
really need it, either.

Change-Id: I9696b672a697f82efa97a8de1cbc39f356f29aee
