### PR TITLE
Change urlopen() type hints to take string data and return string data

### DIFF
--- a/api.py
+++ b/api.py
@@ -13,7 +13,7 @@ from typing import Tuple
 
 class Network:
     """Network interface."""
-    def urlopen(self, url: str, data: bytes) -> Tuple[bytes, str]:  # pragma: no cover
+    def urlopen(self, url: str, data: str) -> Tuple[str, str]:  # pragma: no cover
         """Opens an URL. Empty data means HTTP GET, otherwise it means a HTTP POST."""
         # pylint: disable=no-self-use
         # pylint: disable=unused-argument

--- a/overpass_query.py
+++ b/overpass_query.py
@@ -18,18 +18,18 @@ def overpass_query(ctx: context.Context, query: str) -> Tuple[str, str]:
     url = ctx.get_ini().get_overpass_uri() + "/api/interpreter"
 
     urlopen = ctx.get_network().urlopen
-    buf, err = urlopen(url, bytes(query, "utf-8"))
+    buf, err = urlopen(url, query)
 
-    return (buf.decode('utf-8'), err)
+    return (buf, err)
 
 
 def overpass_query_need_sleep(ctx: context.Context) -> int:
     """Checks if we need to sleep before executing an overpass query."""
     urlopen = ctx.get_network().urlopen
-    buf, err = urlopen(ctx.get_ini().get_overpass_uri() + "/api/status", bytes())
+    buf, err = urlopen(ctx.get_ini().get_overpass_uri() + "/api/status", str())
     if err:
         return 0
-    status = buf.decode('utf-8')
+    status = buf
     sleep = 0
     available = False
     for line in status.splitlines():

--- a/rust.pyi
+++ b/rust.pyi
@@ -125,7 +125,7 @@ class PyStdFileSystem:
 
 class PyStdNetwork(api.Network):
     """Network implementation, backed by the Rust stdlib."""
-    def urlopen(self, url: str, data: bytes) -> Tuple[bytes, str]:  # pragma: no cover
+    def urlopen(self, url: str, data: str) -> Tuple[str, str]:  # pragma: no cover
         ...
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -93,28 +93,28 @@ class TestNetwork(api.Network):
     def __init__(self, routes: List[URLRoute]) -> None:
         self.__routes = routes
 
-    def urlopen(self, url: str, data: bytes) -> Tuple[bytes, str]:
+    def urlopen(self, url: str, data: str) -> Tuple[str, str]:
         for route in self.__routes:
             if url != route.url:
                 continue
 
             if route.data_path:
-                with open(route.data_path, "rb") as stream:
+                with open(route.data_path, "r") as stream:
                     expected = stream.read()
                     if data != expected:
                         assert data
                         assert data == expected, \
-                            "bad data: actual is '" + str(data, 'utf-8') + \
-                            "', expected '" + str(expected, "utf-8") + "'"
+                            "bad data: actual is '" + data + \
+                            "', expected '" + expected + "'"
 
             if not route.result_path:
-                return (bytes(), "empty result_path for url '" + url + "'")
-            with open(route.result_path, "rb") as stream:
+                return (str(), "empty result_path for url '" + url + "'")
+            with open(route.result_path, "r") as stream:
                 # Allow specifying multiple results for the same URL.
                 self.__routes.remove(route)
                 return (stream.read(), str())
 
-        return (bytes(), "url missing from route list: '" + url + "'")
+        return (str(), "url missing from route list: '" + url + "'")
 
 
 class TestTime(context.Time):


### PR DESCRIPTION
As that's what the implementation does. Otherwise we get:

  File "/home/osm-gimmisn/git/osm-gimmisn/cron.py", line 341, in our_main
    update_stats(ctx, overpass)
  File "/home/osm-gimmisn/git/osm-gimmisn/cron.py", line 308, in update_stats
    overpass_sleep(ctx)
  File "/home/osm-gimmisn/git/osm-gimmisn/cron.py", line 53, in overpass_sleep
    sleep = overpass_query.overpass_query_need_sleep(ctx)
  File "/home/osm-gimmisn/git/osm-gimmisn/overpass_query.py", line 29, in overpass_query_need_sleep
    buf, err = urlopen(ctx.get_ini().get_overpass_uri() + "/api/status", bytes())
TypeError: argument 'data': 'bytes' object cannot be converted to 'PyString'

Change-Id: I0f1098e7ef938f5d774e91ee70ab8fc0fca7aaba
