### PR TITLE
Port context.Context.get/set_network() to Rust

### DIFF
--- a/context.py
+++ b/context.py
@@ -65,7 +65,6 @@ class StdFileSystem(FileSystem):
         return open(path, "wb")
 
 
-StdNetwork = rust.PyStdNetwork
 StdTime = rust.PyStdTime
 StdSubprocess = rust.PyStdSubprocess
 StdUnit = rust.PyStdUnit
@@ -79,7 +78,6 @@ class Context:
         root_dir = os.path.abspath(os.path.dirname(__file__))
         self.root = os.path.join(root_dir, prefix)
         self.__file_system: FileSystem = StdFileSystem()
-        self.__network: api.Network = StdNetwork()
         self.__time: api.Time = StdTime()
         self.__subprocess: api.Subprocess = StdSubprocess()
         self.__unit: api.Unit = StdUnit()
@@ -98,11 +96,11 @@ class Context:
 
     def set_network(self, network: api.Network) -> None:
         """Sets the network implementation."""
-        self.__network = network
+        return self.__rust.set_network(network)
 
     def get_network(self) -> api.Network:
         """Gets the network implementation."""
-        return self.__network
+        return self.__rust.get_network()
 
     def set_time(self, time_impl: api.Time) -> None:
         """Sets the time implementation."""

--- a/rust.pyi
+++ b/rust.pyi
@@ -124,11 +124,6 @@ class PyStdFileSystem:
     def getmtime(self, path: str) -> float:
         ...
 
-class PyStdNetwork(api.Network):
-    """Network implementation, backed by the Rust stdlib."""
-    def urlopen(self, url: str, data: str) -> Tuple[str, str]:  # pragma: no cover
-        ...
-
 class PyStdTime(api.Time):
     """Time implementation, backed by the Python stdlib, i.e. intentionally not tested."""
     def now(self) -> float:
@@ -196,6 +191,14 @@ class PyContext:
 
     def get_ini(self) -> PyIni:
         """Gets the ini file."""
+        ...
+
+    def set_network(self, network: api.Network) -> None:
+        """Sets the network implementation."""
+        ...
+
+    def get_network(self) -> api.Network:
+        """Gets the network implementation."""
         ...
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ mod yattag;
 #[pymodule]
 fn rust(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<context::PyStdFileSystem>()?;
-    m.add_class::<context::PyStdNetwork>()?;
     m.add_class::<context::PyStdTime>()?;
     m.add_class::<context::PyStdSubprocess>()?;
     m.add_class::<context::PyStdUnit>()?;

--- a/tools/dump-deps.sh
+++ b/tools/dump-deps.sh
@@ -17,6 +17,9 @@ do
     do
         # Silence stubs for rust modules.
         case $dependency in
+            api)
+                continue
+            ;;
             yattag)
                 continue
             ;;


### PR DESCRIPTION
Which requries wrappers in both directions around Network, but the
wrapper around StdNetwork is no longer needed.

Change-Id: Idf2a7f56bd3fa0b8b8ffaea1fdc6bc855e2f3b7d
