### PR TITLE
Port context.Context.get/set_time() to Rust

### DIFF
--- a/context.py
+++ b/context.py
@@ -65,7 +65,6 @@ class StdFileSystem(FileSystem):
         return open(path, "wb")
 
 
-StdTime = rust.PyStdTime
 StdSubprocess = rust.PyStdSubprocess
 StdUnit = rust.PyStdUnit
 Ini = rust.PyIni
@@ -78,7 +77,6 @@ class Context:
         root_dir = os.path.abspath(os.path.dirname(__file__))
         self.root = os.path.join(root_dir, prefix)
         self.__file_system: FileSystem = StdFileSystem()
-        self.__time: api.Time = StdTime()
         self.__subprocess: api.Subprocess = StdSubprocess()
         self.__unit: api.Unit = StdUnit()
 
@@ -104,11 +102,11 @@ class Context:
 
     def set_time(self, time_impl: api.Time) -> None:
         """Sets the time implementation."""
-        self.__time = time_impl
+        return self.__rust.set_time(time_impl)
 
     def get_time(self) -> api.Time:
         """Gets the time implementation."""
-        return self.__time
+        return self.__rust.get_time()
 
     def set_subprocess(self, subprocess: api.Subprocess) -> None:
         """Sets the subprocess implementation."""

--- a/rust.pyi
+++ b/rust.pyi
@@ -124,14 +124,6 @@ class PyStdFileSystem:
     def getmtime(self, path: str) -> float:
         ...
 
-class PyStdTime(api.Time):
-    """Time implementation, backed by the Python stdlib, i.e. intentionally not tested."""
-    def now(self) -> float:
-        ...
-
-    def sleep(self, seconds: float) -> None:
-        ...
-
 class PyStdSubprocess(api.Subprocess):
     """Subprocess implementation, backed by the Python stdlib, i.e. intentionally not tested."""
     def run(self, args: List[str], env: Dict[str, str]) -> str:
@@ -199,6 +191,14 @@ class PyContext:
 
     def get_network(self) -> api.Network:
         """Gets the network implementation."""
+        ...
+
+    def set_time(self, time_impl: api.Time) -> None:
+        """Sets the time implementation."""
+        ...
+
+    def get_time(self) -> api.Time:
+        """Gets the time implementation."""
         ...
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ mod yattag;
 #[pymodule]
 fn rust(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<context::PyStdFileSystem>()?;
-    m.add_class::<context::PyStdTime>()?;
     m.add_class::<context::PyStdSubprocess>()?;
     m.add_class::<context::PyStdUnit>()?;
     m.add_class::<context::PyIni>()?;

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -162,7 +162,7 @@ class TestUnit(api.Unit):
         return "TestError"
 
 
-def make_test_time() -> api.Time:
+def make_test_time() -> TestTime:
     """Generates unix timestamp for 2020-05-10."""
     return TestTime(calendar.timegm(datetime.date(2020, 5, 10).timetuple()))
 

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -6,7 +6,6 @@
 
 """The test_cron module covers the cron module."""
 
-from typing import cast
 from typing import List
 import io
 import json
@@ -33,11 +32,11 @@ class TestOverpassSleep(unittest.TestCase):
         ]
         network = test_context.TestNetwork(routes)
         ctx.set_network(network)
-        ctx.set_time(test_context.make_test_time())
+        test_time = test_context.make_test_time()
+        ctx.set_time(test_time)
 
         cron.overpass_sleep(ctx)
 
-        test_time = cast(test_context.TestTime, ctx.get_time())
         self.assertEqual(test_time.get_sleep(), 0)
 
     def test_need_sleep(self) -> None:
@@ -53,11 +52,11 @@ class TestOverpassSleep(unittest.TestCase):
         ]
         network = test_context.TestNetwork(routes)
         ctx.set_network(network)
-        ctx.set_time(test_context.make_test_time())
+        test_time = test_context.make_test_time()
+        ctx.set_time(test_time)
 
         cron.overpass_sleep(ctx)
 
-        test_time = cast(test_context.TestTime, ctx.get_time())
         self.assertEqual(test_time.get_sleep(), 12)
 
 
@@ -351,7 +350,8 @@ class TestUpdateStats(unittest.TestCase):
     def test_no_overpass(self) -> None:
         """Tests the case when we don't call overpass."""
         ctx = test_context.make_test_context()
-        ctx.set_time(test_context.make_test_time())
+        test_time = test_context.make_test_time()
+        ctx.set_time(test_time)
         routes: List[test_context.URLRoute] = [
             test_context.URLRoute(url="https://overpass-api.de/api/status",
                                   data_path="",
@@ -365,7 +365,6 @@ class TestUpdateStats(unittest.TestCase):
 
         cron.update_stats(ctx, overpass=False)
 
-        test_time = cast(test_context.TestTime, ctx.get_time())
         self.assertEqual(test_time.get_sleep(), 0)
 
 


### PR DESCRIPTION
And also get rid of casts in tests/test_cron.py, they are hackish and
now that TestTime is accessed through a Rust wrapper they would even
break.

Change-Id: I585c1873a0b183bd097d7ab06f224c5ca438966b
