### PR TITLE
Port context.StdFileSystem.open_read() to Rust

### DIFF
--- a/areas.py
+++ b/areas.py
@@ -355,7 +355,7 @@ class RelationBase:
         """Gets streets from reference."""
         streets: List[str] = []
         with self.get_files().get_ref_streets_read_stream(self.__ctx) as sock:
-            for line in sock.readlines():
+            for line in sock:
                 line = line.strip()
                 streets.append(util.from_bytes(line))
         return sorted(set(streets))
@@ -435,7 +435,7 @@ class RelationBase:
         ret: Dict[str, List[util.HouseNumber]] = {}
         lines: Dict[str, List[str]] = {}
         with self.get_files().get_ref_housenumbers_read_stream(self.ctx) as sock:
-            for line_bytes in sock.readlines():
+            for line_bytes in sock:
                 line = util.from_bytes(line_bytes)
                 line = line.strip()
                 key, _, value = line.partition("\t")

--- a/context.py
+++ b/context.py
@@ -55,9 +55,7 @@ class StdFileSystem(FileSystem):
         return self.rust.getmtime(path)
 
     def open_read(self, path: str) -> BinaryIO:
-        # The caller will do this:
-        # pylint: disable=consider-using-with
-        return open(path, "rb")
+        return self.rust.open_read(path)
 
     def open_write(self, path: str) -> BinaryIO:
         # The caller will do this:

--- a/cron.py
+++ b/cron.py
@@ -220,7 +220,7 @@ def update_stats_count(ctx: context.Context, today: str) -> None:
     first = True
     valid_settlements = util.get_valid_settlements(ctx)
     with ctx.get_file_system().open_read(csv_path) as stream:
-        for line_bytes in stream.readlines():
+        for line_bytes in stream:
             line = util.from_bytes(line_bytes)
             if first:
                 # Ignore the oneliner header.
@@ -250,7 +250,7 @@ def update_stats_topusers(ctx: context.Context, today: str) -> None:
     usercount_path = os.path.join(statedir, "%s.usercount" % today)
     users: Dict[str, int] = {}
     with ctx.get_file_system().open_read(csv_path) as stream:
-        for line_bytes in stream.readlines():
+        for line_bytes in stream:
             line = util.from_bytes(line_bytes)
             # Only care about the last column.
             user = line[line.rfind("\t"):].strip()
@@ -272,7 +272,7 @@ def update_stats_refcount(ctx: context.Context, state_dir: str) -> None:
     count = 0
     with ctx.get_file_system().open_read(ctx.get_ini().get_reference_citycounts_path()) as stream:
         first = True
-        for line_bytes in stream.readlines():
+        for line_bytes in stream:
             line = util.from_bytes(line_bytes)
             if first:
                 first = False

--- a/parse_access_log.py
+++ b/parse_access_log.py
@@ -60,7 +60,7 @@ def get_frequent_relations(ctx: context.Context, log_file: str) -> Set[str]:
         # Example line:
         # a.b.c.d - - [01/Jul/2020:00:08:01 +0200] \
         # "GET /osm/street-housenumbers/budapest_12/update-result HTTP/1.1" 200 1747 "-" "Mozilla/5.0 ..."
-        for line in stream.readlines():
+        for line in stream:
             if is_search_bot(line):
                 continue
             match = re.match('.*"GET ([^ ]+) .*', line)

--- a/rust.pyi
+++ b/rust.pyi
@@ -9,6 +9,7 @@ Type hints for rust.so.
 """
 
 from typing import Any
+from typing import BinaryIO
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -122,6 +123,9 @@ class PyStdFileSystem:
         ...
 
     def getmtime(self, path: str) -> float:
+        ...
+
+    def open_read(self, path: str) -> BinaryIO:
         ...
 
 class PyIni:

--- a/src/yattag.rs
+++ b/src/yattag.rs
@@ -14,6 +14,7 @@
 //! <https://crates.io/crates/html-builder> would require you to manually escape attribute values.
 
 use pyo3::class::PyContextProtocol;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyType;
 use std::sync::Arc;
@@ -156,13 +157,14 @@ impl<'p> PyContextProtocol<'p> for PyTag {
 
     fn __exit__(
         &mut self,
-        _ty: Option<&'p PyType>,
+        ty: Option<&'p PyType>,
         _value: Option<&'p PyAny>,
         _traceback: Option<&'p PyAny>,
-    ) -> PyResult<bool> {
+    ) -> bool {
         if self.tag.is_some() {
             self.tag = None;
         }
-        Ok(true)
+        let gil = Python::acquire_gil();
+        ty == Some(gil.python().get_type::<PyValueError>())
     }
 }

--- a/stats.py
+++ b/stats.py
@@ -47,7 +47,7 @@ def handle_topusers(ctx: context.Context, src_root: str, j: Dict[str, Any]) -> N
     topusers_path = os.path.join(src_root, "%s.topusers" % today)
     if os.path.exists(topusers_path):
         with open(topusers_path, "r") as stream:
-            for line in stream.readlines():
+            for line in stream:
                 line = line.strip()
                 count, _, user = line.partition(' ')
                 ret.append([user, count])
@@ -69,7 +69,7 @@ def get_topcities(ctx: context.Context, src_root: str) -> List[Tuple[str, int]]:
     if not ctx.get_file_system().path_exists(old_count_path):
         return ret
     with ctx.get_file_system().open_read(old_count_path) as stream:
-        for line_bytes in stream.readlines():
+        for line_bytes in stream:
             line = util.from_bytes(line_bytes).strip()
             city, _, count = line.partition('\t')
             if count:
@@ -79,7 +79,7 @@ def get_topcities(ctx: context.Context, src_root: str) -> List[Tuple[str, int]]:
     if not ctx.get_file_system().path_exists(new_count_path):
         return ret
     with ctx.get_file_system().open_read(new_count_path) as stream:
-        for line_bytes in stream.readlines():
+        for line_bytes in stream:
             line = util.from_bytes(line_bytes.strip())
             city, _, count = line.partition('\t')
             if count and city in old_counts:

--- a/util.py
+++ b/util.py
@@ -845,7 +845,7 @@ def get_valid_settlements(ctx: context.Context) -> Set[str]:
 
     with open(ctx.get_ini().get_reference_citycounts_path(), "r") as stream:
         first = True
-        for line in stream.readlines():
+        for line in stream:
             if first:
                 first = False
                 continue

--- a/webframe.py
+++ b/webframe.py
@@ -360,7 +360,7 @@ def handle_stats_cityprogress(ctx: context.Context, relations: areas.Relations) 
     ref_citycounts: Dict[str, int] = {}
     with open(ctx.get_ini().get_reference_citycounts_path(), "r") as stream:
         first = True
-        for line in stream.readlines():
+        for line in stream:
             if first:
                 first = False
                 continue
@@ -373,7 +373,7 @@ def handle_stats_cityprogress(ctx: context.Context, relations: areas.Relations) 
     today = time.strftime("%Y-%m-%d", time.gmtime(ctx.get_time().now()))
     osm_citycounts: Dict[str, int] = {}
     with open(ctx.get_ini().get_workdir() + "/stats/" + today + ".citycount", "r") as stream:
-        for line in stream.readlines():
+        for line in stream:
             cells = line.strip().split('\t')
             if len(cells) < 2:
                 continue


### PR DESCRIPTION
Which requires writing some iterator code, as pyo3 doesn't map from the
Read trait to a BinaryIO, but the Python csv module wants to read the
file line-by-line that way. Change own Python code to do the same, so at
least readlines() doesn't have to be implemented.

Change-Id: I5f63f46a21e8de6debca7fd9ff4a94708ae7e9b4
