### PR TITLE
Port context.StdFileSystem.open_write() to Rust

### DIFF
--- a/api.py
+++ b/api.py
@@ -8,9 +8,37 @@
 Shared type hints.
 """
 
+from typing import BinaryIO
 from typing import Dict
 from typing import List
 from typing import Tuple
+
+
+class FileSystem:
+    """File system interface."""
+    def path_exists(self, path: str) -> bool:  # pragma: no cover
+        """Test whether a path exists."""
+        # pylint: disable=no-self-use
+        # pylint: disable=unused-argument
+        ...
+
+    def getmtime(self, path: str) -> float:  # pragma: no cover
+        """Return the last modification time of a file."""
+        # pylint: disable=no-self-use
+        # pylint: disable=unused-argument
+        ...
+
+    def open_read(self, path: str) -> BinaryIO:  # pragma: no cover
+        """Opens a file for reading in binary mode."""
+        # pylint: disable=no-self-use
+        # pylint: disable=unused-argument
+        ...
+
+    def open_write(self, path: str) -> BinaryIO:  # pragma: no cover
+        """Opens a file for writing in binary mode."""
+        # pylint: disable=no-self-use
+        # pylint: disable=unused-argument
+        ...
 
 
 class Network:

--- a/context.py
+++ b/context.py
@@ -9,61 +9,14 @@ The config module contains functionality related to configuration handling.
 It intentionally doesn't import any other 'own' modules, so it can be used anywhere.
 """
 
-from typing import BinaryIO
 import os
 
 import api
 import rust
 
 
-class FileSystem:
-    """File system interface."""
-    def path_exists(self, path: str) -> bool:  # pragma: no cover
-        """Test whether a path exists."""
-        # pylint: disable=no-self-use
-        # pylint: disable=unused-argument
-        ...
-
-    def getmtime(self, path: str) -> float:  # pragma: no cover
-        """Return the last modification time of a file."""
-        # pylint: disable=no-self-use
-        # pylint: disable=unused-argument
-        ...
-
-    def open_read(self, path: str) -> BinaryIO:  # pragma: no cover
-        """Opens a file for reading in binary mode."""
-        # pylint: disable=no-self-use
-        # pylint: disable=unused-argument
-        ...
-
-    def open_write(self, path: str) -> BinaryIO:  # pragma: no cover
-        """Opens a file for writing in binary mode."""
-        # pylint: disable=no-self-use
-        # pylint: disable=unused-argument
-        ...
-
-
-class StdFileSystem(FileSystem):
-    """File system implementation, backed by the Python stdlib."""
-    def __init__(self) -> None:
-        self.rust = rust.PyStdFileSystem()
-
-    def path_exists(self, path: str) -> bool:
-        return self.rust.path_exists(path)
-
-    def getmtime(self, path: str) -> float:
-        return self.rust.getmtime(path)
-
-    def open_read(self, path: str) -> BinaryIO:
-        return self.rust.open_read(path)
-
-    def open_write(self, path: str) -> BinaryIO:
-        # The caller will do this:
-        # pylint: disable=consider-using-with
-        return open(path, "wb")
-
-
 Ini = rust.PyIni
+StdFileSystem = rust.PyStdFileSystem
 
 
 class Context:
@@ -72,17 +25,17 @@ class Context:
         self.__rust = rust.PyContext(prefix)
         root_dir = os.path.abspath(os.path.dirname(__file__))
         self.root = os.path.join(root_dir, prefix)
-        self.__file_system: FileSystem = StdFileSystem()
+        self.__file_system: api.FileSystem = StdFileSystem()
 
     def get_abspath(self, rel_path: str) -> str:
         """Make a path absolute, taking the repo root as a base dir."""
         return self.__rust.get_abspath(rel_path)
 
-    def set_file_system(self, file_system: FileSystem) -> None:
+    def set_file_system(self, file_system: api.FileSystem) -> None:
         """Sets the file system implementation."""
         self.__file_system = file_system
 
-    def get_file_system(self) -> FileSystem:
+    def get_file_system(self) -> api.FileSystem:
         """Gets the file system implementation."""
         return self.__file_system
 

--- a/rust.pyi
+++ b/rust.pyi
@@ -114,7 +114,7 @@ def py_get_version() -> str:
     """Gets the git version."""
     ...
 
-class PyStdFileSystem:
+class PyStdFileSystem(api.FileSystem):
     """File system implementation, backed by the Rust stdlib."""
     def __init__(self) -> None:
         ...
@@ -126,6 +126,9 @@ class PyStdFileSystem:
         ...
 
     def open_read(self, path: str) -> BinaryIO:
+        ...
+
+    def open_write(self, path: str) -> BinaryIO:
         ...
 
 class PyIni:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -25,7 +25,7 @@ def make_test_context() -> context.Context:
     return context.Context("tests")
 
 
-class TestFileSystem(context.FileSystem):
+class TestFileSystem(api.FileSystem):
     """File system implementation, for test purposes."""
     def __init__(self) -> None:
         self.__hide_paths: List[str] = []


### PR DESCRIPTION
Which means no wrapper is needed around rust.PyStdFileSystem anymore.

Change-Id: If337e723578ed4dbd96018af6da547d746cc0743
