### PR TITLE
overpass_query: port overpass_query() to Rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ RS_OBJECTS = \
 	src/accept_language.rs \
 	src/context.rs \
 	src/lib.rs \
+	src/overpass_query.rs \
 	src/ranges.rs \
 	src/version.rs \
 	src/yattag.rs \

--- a/api.py
+++ b/api.py
@@ -11,7 +11,6 @@ Shared type hints.
 from typing import BinaryIO
 from typing import Dict
 from typing import List
-from typing import Tuple
 
 
 class FileSystem:
@@ -43,7 +42,7 @@ class FileSystem:
 
 class Network:
     """Network interface."""
-    def urlopen(self, url: str, data: str) -> Tuple[str, str]:  # pragma: no cover
+    def urlopen(self, url: str, data: str) -> str:  # pragma: no cover
         """Opens an URL. Empty data means HTTP GET, otherwise it means a HTTP POST."""
         # pylint: disable=no-self-use
         # pylint: disable=unused-argument

--- a/cron.py
+++ b/cron.py
@@ -76,9 +76,10 @@ def update_osm_streets(ctx: context.Context, relations: areas.Relations, update:
             retry += 1
             overpass_sleep(ctx)
             query = relation.get_osm_streets_query()
-            buf, err = overpass_query.overpass_query(ctx, query)
-            if err:
-                info("update_osm_streets: http error: %s", err)
+            try:
+                buf = overpass_query.overpass_query(ctx, query)
+            except OSError as err:
+                info("update_osm_streets: http error: %s", str(err))
                 continue
             relation.get_files().write_osm_streets(ctx, buf)
             break
@@ -99,9 +100,10 @@ def update_osm_housenumbers(ctx: context.Context, relations: areas.Relations, up
             retry += 1
             overpass_sleep(ctx)
             query = relation.get_osm_housenumbers_query()
-            buf, err = overpass_query.overpass_query(ctx, query)
-            if err:
-                info("update_osm_housenumbers: http error: %s", err)
+            try:
+                buf = overpass_query.overpass_query(ctx, query)
+            except OSError as err:
+                info("update_osm_housenumbers: http error: %s", str(err))
                 continue
             relation.get_files().write_osm_housenumbers(ctx, buf)
             break
@@ -306,9 +308,10 @@ def update_stats(ctx: context.Context, overpass: bool) -> None:
                 info("update_stats: try #%s", retry)
             retry += 1
             overpass_sleep(ctx)
-            response, err = overpass_query.overpass_query(ctx, query)
-            if err:
-                info("update_stats: http error: %s", err)
+            try:
+                response = overpass_query.overpass_query(ctx, query)
+            except OSError as err:
+                info("update_stats: http error: %s", str(err))
                 continue
             with ctx.get_file_system().open_write(csv_path) as stream:
                 stream.write(util.to_bytes(response))

--- a/overpass_query.py
+++ b/overpass_query.py
@@ -7,27 +7,20 @@
 
 """The overpass_query module allows getting data out of the OSM DB without a full download."""
 
-from typing import Tuple
 import re
 
 import context
+import rust
 
 
-def overpass_query(ctx: context.Context, query: str) -> Tuple[str, str]:
-    """Posts the query string to the overpass API and returns the result string."""
-    url = ctx.get_ini().get_overpass_uri() + "/api/interpreter"
-
-    urlopen = ctx.get_network().urlopen
-    buf, err = urlopen(url, query)
-
-    return (buf, err)
+overpass_query = rust.py_overpass_query
 
 
 def overpass_query_need_sleep(ctx: context.Context) -> int:
     """Checks if we need to sleep before executing an overpass query."""
-    urlopen = ctx.get_network().urlopen
-    buf, err = urlopen(ctx.get_ini().get_overpass_uri() + "/api/status", str())
-    if err:
+    try:
+        buf = ctx.get_network().urlopen(ctx.get_ini().get_overpass_uri() + "/api/status", str())
+    except OSError:
         return 0
     status = buf
     sleep = 0

--- a/rust.pyi
+++ b/rust.pyi
@@ -221,5 +221,9 @@ class PyContext:
         """Gets the file system implementation."""
         ...
 
+def py_overpass_query(ctx: PyContext, query: str) -> str:
+    """Posts the query string to the overpass API and returns the result string."""
+    ...
+
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ use pyo3::prelude::*;
 
 mod accept_language;
 mod context;
+mod overpass_query;
 mod ranges;
 mod version;
 mod yattag;
@@ -29,6 +30,7 @@ fn rust(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<yattag::PyTag>()?;
     accept_language::register_python_symbols(&m)?;
     version::register_python_symbols(&m)?;
+    overpass_query::register_python_symbols(&m)?;
 
     Ok(())
 }

--- a/src/overpass_query.rs
+++ b/src/overpass_query.rs
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Miklos Vajna. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#![deny(warnings)]
+#![warn(clippy::all)]
+#![warn(missing_docs)]
+
+//! The overpass_query module allows getting data out of the OSM DB without a full download.
+
+use pyo3::prelude::*;
+
+/// Posts the query string to the overpass API and returns the result string.
+pub fn overpass_query(ctx: &crate::context::Context, query: String) -> anyhow::Result<String> {
+    let url = ctx.get_ini().get_overpass_uri() + "/api/interpreter";
+
+    ctx.get_network().urlopen(&url, &query)
+}
+
+#[pyfunction]
+pub fn py_overpass_query(py: Python<'_>, ctx: PyObject, query: String) -> PyResult<String> {
+    let ctx: PyRefMut<'_, crate::context::PyContext> = ctx.extract(py)?;
+    match overpass_query(&ctx.context, query) {
+        Ok(value) => Ok(value),
+        Err(err) => Err(pyo3::exceptions::PyOSError::new_err(format!(
+            "overpass_query() failed: {}",
+            err.to_string()
+        ))),
+    }
+}
+
+pub fn register_python_symbols(module: &PyModule) -> PyResult<()> {
+    module.add_function(pyo3::wrap_pyfunction!(py_overpass_query, module)?)?;
+    Ok(())
+}

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -9,7 +9,6 @@
 from typing import BinaryIO
 from typing import Dict
 from typing import List
-from typing import Tuple
 import calendar
 import datetime
 import io
@@ -93,7 +92,7 @@ class TestNetwork(api.Network):
     def __init__(self, routes: List[URLRoute]) -> None:
         self.__routes = routes
 
-    def urlopen(self, url: str, data: str) -> Tuple[str, str]:
+    def urlopen(self, url: str, data: str) -> str:
         for route in self.__routes:
             if url != route.url:
                 continue
@@ -108,13 +107,13 @@ class TestNetwork(api.Network):
                             "', expected '" + expected + "'"
 
             if not route.result_path:
-                return (str(), "empty result_path for url '" + url + "'")
+                raise OSError("empty result_path for url '" + url + "'")
             with open(route.result_path, "r") as stream:
                 # Allow specifying multiple results for the same URL.
                 self.__routes.remove(route)
-                return (stream.read(), str())
+                return stream.read()
 
-        return (str(), "url missing from route list: '" + url + "'")
+        raise OSError("url missing from route list: '" + url + "'")
 
 
 class TestTime(api.Time):

--- a/tests/test_overpass_query.py
+++ b/tests/test_overpass_query.py
@@ -67,9 +67,8 @@ class TestOverpassQuery(unittest.TestCase):
         ctx.set_network(network)
         with open("tests/network/overpass-happy.expected-data") as stream:
             query = stream.read()
-            buf, err = overpass_query.overpass_query(ctx, query)
+            buf = overpass_query.overpass_query(ctx, query)
             self.assertEqual(buf[:3], "@id")
-            self.assertEqual(err, str())
 
 
 if __name__ == '__main__':

--- a/wsgi.py
+++ b/wsgi.py
@@ -52,9 +52,10 @@ def handle_streets(ctx: context.Context, relations: areas.Relations, request_uri
             doc.text(relation.get_osm_streets_query())
     elif action == "update-result":
         query = relation.get_osm_streets_query()
-        buf, err = overpass_query.overpass_query(ctx, query)
-        if err:
-            doc.append_value(util.handle_overpass_error(ctx, err).get_value())
+        try:
+            buf = overpass_query.overpass_query(ctx, query)
+        except OSError as error:
+            doc.append_value(util.handle_overpass_error(ctx, str(error)).get_value())
         else:
             relation.get_files().write_osm_streets(ctx, buf)
             streets = relation.get_config().should_check_missing_streets()
@@ -92,9 +93,10 @@ def handle_street_housenumbers(ctx: context.Context, relations: areas.Relations,
             doc.text(relation.get_osm_housenumbers_query())
     elif action == "update-result":
         query = relation.get_osm_housenumbers_query()
-        buf, err = overpass_query.overpass_query(ctx, query)
-        if err:
-            doc.append_value(util.handle_overpass_error(ctx, err).get_value())
+        try:
+            buf = overpass_query.overpass_query(ctx, query)
+        except OSError as error:
+            doc.append_value(util.handle_overpass_error(ctx, str(error)).get_value())
         else:
             relation.get_files().write_osm_housenumbers(ctx, buf)
             doc.text(tr("Update successful: "))

--- a/wsgi_json.py
+++ b/wsgi_json.py
@@ -32,12 +32,12 @@ def streets_update_result_json(ctx: context.Context, relations: areas.Relations,
     relation = relations.get_relation(relation_name)
     query = relation.get_osm_streets_query()
     ret: Dict[str, str] = {}
-    buf, err = overpass_query.overpass_query(ctx, query)
-    if err:
-        ret["error"] = err
-    else:
+    try:
+        buf = overpass_query.overpass_query(ctx, query)
         relation.get_files().write_osm_streets(ctx, buf)
         ret["error"] = ""
+    except OSError as error:
+        ret["error"] = str(error)
     return json.dumps(ret)
 
 
@@ -48,12 +48,12 @@ def street_housenumbers_update_result_json(ctx: context.Context, relations: area
     relation = relations.get_relation(relation_name)
     query = relation.get_osm_housenumbers_query()
     ret: Dict[str, str] = {}
-    buf, err = overpass_query.overpass_query(ctx, query)
-    if err:
-        ret["error"] = err
-    else:
+    try:
+        buf = overpass_query.overpass_query(ctx, query)
         relation.get_files().write_osm_housenumbers(ctx, buf)
         ret["error"] = ""
+    except OSError as error:
+        ret["error"] = str(error)
     return json.dumps(ret)
 
 


### PR DESCRIPTION
Can turn the error case into a Python exception after all, so no need to
return a tuple.

Change-Id: I1ad926b00da1eefec0f71da09eaf56aca4bd8cda
