### PR TITLE
Port util.LetterSuffixStyle to Rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,11 @@ TS_OBJECTS = \
 RS_OBJECTS = \
 	src/accept_language.rs \
 	src/context.rs \
+	src/i18n.rs \
 	src/lib.rs \
 	src/overpass_query.rs \
 	src/ranges.rs \
+	src/util.rs \
 	src/version.rs \
 	src/yattag.rs \
 

--- a/areas.py
+++ b/areas.py
@@ -98,15 +98,15 @@ class RelationConfig(RelationConfigBase):
         """Sets the housenumber_letters property from code."""
         self.set_property("housenumber-letters", housenumber_letters)
 
-    def set_letter_suffix_style(self, letter_suffix_style: util.LetterSuffixStyle) -> None:
+    def set_letter_suffix_style(self, letter_suffix_style: int) -> None:
         """Sets the letter suffix style."""
         self.set_property("letter-suffix-style", letter_suffix_style)
 
-    def get_letter_suffix_style(self) -> util.LetterSuffixStyle:
+    def get_letter_suffix_style(self) -> int:
         """Gets the letter suffix style."""
         if self.get_property("letter-suffix-style"):
-            return cast(util.LetterSuffixStyle, self.get_property("letter-suffix-style"))
-        return util.LetterSuffixStyle.UPPER
+            return cast(int, self.get_property("letter-suffix-style"))
+        return rust.PyLetterSuffixStyle.upper()
 
     def get_refstreets(self) -> Dict[str, str]:
         """Returns an OSM name -> ref name map."""

--- a/rust.pyi
+++ b/rust.pyi
@@ -243,4 +243,13 @@ def py_translate(english: str) -> str:
     """Translates English input according to the current UI language."""
     ...
 
+class PyLetterSuffixStyle:
+    @staticmethod
+    def upper() -> int:
+        ...
+
+    @staticmethod
+    def lower() -> int:
+        ...
+
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/src/context.rs
+++ b/src/context.rs
@@ -1050,3 +1050,9 @@ impl PyContext {
         self.context.set_file_system(&file_system);
     }
 }
+
+pub fn register_python_symbols(module: &PyModule) -> PyResult<()> {
+    module.add_class::<PyIni>()?;
+    module.add_class::<PyContext>()?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,21 +18,19 @@ mod context;
 mod i18n;
 mod overpass_query;
 mod ranges;
+mod util;
 mod version;
 mod yattag;
 
 #[pymodule]
 fn rust(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    m.add_class::<context::PyIni>()?;
-    m.add_class::<context::PyContext>()?;
-    m.add_class::<ranges::PyRange>()?;
-    m.add_class::<ranges::PyRanges>()?;
-    m.add_class::<yattag::PyDoc>()?;
-    m.add_class::<yattag::PyTag>()?;
     accept_language::register_python_symbols(&m)?;
+    context::register_python_symbols(&m)?;
     i18n::register_python_symbols(&m)?;
     overpass_query::register_python_symbols(&m)?;
+    ranges::register_python_symbols(&m)?;
+    util::register_python_symbols(&m)?;
     version::register_python_symbols(&m)?;
-
+    yattag::register_python_symbols(&m)?;
     Ok(())
 }

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -217,3 +217,9 @@ impl<'p> PyObjectProtocol<'p> for PyRanges {
         }
     }
 }
+
+pub fn register_python_symbols(module: &PyModule) -> PyResult<()> {
+    module.add_class::<PyRange>()?;
+    module.add_class::<PyRanges>()?;
+    Ok(())
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Miklos Vajna. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#![deny(warnings)]
+#![warn(clippy::all)]
+#![warn(missing_docs)]
+
+//! The util module contains functionality shared between other modules.
+
+use pyo3::prelude::*;
+
+/// Specifies the style of the output of normalize_letter_suffix().
+enum LetterSuffixStyle {
+    /// "42/A"
+    Upper,
+    /// "42a"
+    Lower,
+}
+
+#[pyclass]
+pub struct PyLetterSuffixStyle {
+}
+
+#[pymethods]
+impl PyLetterSuffixStyle {
+    #[staticmethod]
+    fn upper() -> i32 {
+        LetterSuffixStyle::Upper as i32
+    }
+
+    #[staticmethod]
+    fn lower() -> i32 {
+        LetterSuffixStyle::Lower as i32
+    }
+}
+
+pub fn register_python_symbols(module: &PyModule) -> PyResult<()> {
+    module.add_class::<PyLetterSuffixStyle>()?;
+    Ok(())
+}

--- a/src/yattag.rs
+++ b/src/yattag.rs
@@ -168,3 +168,9 @@ impl<'p> PyContextProtocol<'p> for PyTag {
         ty == Some(gil.python().get_type::<PyValueError>())
     }
 }
+
+pub fn register_python_symbols(module: &PyModule) -> PyResult<()> {
+    module.add_class::<PyDoc>()?;
+    module.add_class::<PyTag>()?;
+    Ok(())
+}

--- a/tests/test_areas.py
+++ b/tests/test_areas.py
@@ -975,9 +975,9 @@ class TestRelationConfigLetterSuffixStyle(unittest.TestCase):
         relation_name = "empty"
         relations = areas.Relations(test_context.make_test_context())
         relation = relations.get_relation(relation_name)
-        self.assertEqual(relation.get_config().get_letter_suffix_style(), util.LetterSuffixStyle.UPPER)
-        relation.get_config().set_letter_suffix_style(util.LetterSuffixStyle.LOWER)
-        self.assertEqual(relation.get_config().get_letter_suffix_style(), util.LetterSuffixStyle.LOWER)
+        self.assertEqual(relation.get_config().get_letter_suffix_style(), rust.PyLetterSuffixStyle.upper())
+        relation.get_config().set_letter_suffix_style(rust.PyLetterSuffixStyle.lower())
+        self.assertEqual(relation.get_config().get_letter_suffix_style(), rust.PyLetterSuffixStyle.lower())
 
 
 class TestRefmegyeGetName(unittest.TestCase):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -330,15 +330,15 @@ class TestHouseNumber(unittest.TestCase):
     def test_normalize_letter_suffix(self) -> None:
         """Tests normalize_letter_suffix()."""
         normalize = util.HouseNumber.normalize_letter_suffix
-        self.assertEqual(normalize("42a", "", util.LetterSuffixStyle.UPPER), "42/A")
-        self.assertEqual(normalize("42 a", "", util.LetterSuffixStyle.UPPER), "42/A")
-        self.assertEqual(normalize("42/a", "", util.LetterSuffixStyle.UPPER), "42/A")
-        self.assertEqual(normalize("42/A", "", util.LetterSuffixStyle.UPPER), "42/A")
-        self.assertEqual(normalize("42/A*", "*", util.LetterSuffixStyle.UPPER), "42/A*")
-        self.assertEqual(normalize("42 A", "", util.LetterSuffixStyle.UPPER), "42/A")
+        self.assertEqual(normalize("42a", "", rust.PyLetterSuffixStyle.upper()), "42/A")
+        self.assertEqual(normalize("42 a", "", rust.PyLetterSuffixStyle.upper()), "42/A")
+        self.assertEqual(normalize("42/a", "", rust.PyLetterSuffixStyle.upper()), "42/A")
+        self.assertEqual(normalize("42/A", "", rust.PyLetterSuffixStyle.upper()), "42/A")
+        self.assertEqual(normalize("42/A*", "*", rust.PyLetterSuffixStyle.upper()), "42/A*")
+        self.assertEqual(normalize("42 A", "", rust.PyLetterSuffixStyle.upper()), "42/A")
         with self.assertRaises(ValueError):
-            util.HouseNumber.normalize_letter_suffix("x", "", util.LetterSuffixStyle.UPPER)
-        self.assertEqual(normalize("42/A", "", util.LetterSuffixStyle.LOWER), "42a")
+            util.HouseNumber.normalize_letter_suffix("x", "", rust.PyLetterSuffixStyle.upper())
+        self.assertEqual(normalize("42/A", "", rust.PyLetterSuffixStyle.lower()), "42a")
 
 
 class TestGetHousenumberRanges(unittest.TestCase):

--- a/util.py
+++ b/util.py
@@ -6,7 +6,6 @@
 
 """The util module contains functionality shared between other modules."""
 
-from enum import Enum
 from typing import Any
 from typing import BinaryIO
 from typing import Callable
@@ -34,15 +33,6 @@ from rust import py_translate as tr
 import context
 import overpass_query
 import rust
-
-
-class LetterSuffixStyle(Enum):
-    """Specifies the style of the output of normalize_letter_suffix()."""
-
-    # "42/A"
-    UPPER = 1
-    # "42a"
-    LOWER = 2
 
 
 class HouseNumberRange:
@@ -240,7 +230,7 @@ class HouseNumber:
         return bool(re.match(r"^([0-9]+)/[0-9]$", house_number))
 
     @staticmethod
-    def normalize_letter_suffix(house_number: str, source_suffix: str, style: LetterSuffixStyle) -> str:
+    def normalize_letter_suffix(house_number: str, source_suffix: str, style: int) -> str:
         """
         Turn '42A' and '42 A' (and their lowercase versions) into '42/A'.
         """
@@ -256,7 +246,7 @@ class HouseNumber:
             if not match:
                 raise ValueError
         groups = match.groups()
-        if style == LetterSuffixStyle.UPPER or digit_match:
+        if style == rust.PyLetterSuffixStyle.upper() or digit_match:
             return groups[0] + "/" + groups[2].upper() + source_suffix
         return groups[0] + groups[2].lower() + source_suffix
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -25,6 +25,7 @@ import areas
 import cache
 import context
 import overpass_query
+import rust
 import util
 import webframe
 import wsgi_additional
@@ -203,7 +204,7 @@ def missing_housenumbers_view_txt(ctx: context.Context, relations: areas.Relatio
     tokens = request_uri.split("/")
     relation_name = tokens[-2]
     relation = relations.get_relation(relation_name)
-    relation.get_config().set_letter_suffix_style(util.LetterSuffixStyle.LOWER)
+    relation.get_config().set_letter_suffix_style(rust.PyLetterSuffixStyle.lower())
 
     output = ""
     if not ctx.get_file_system().path_exists(relation.get_files().get_osm_streets_path()):
@@ -229,7 +230,7 @@ def missing_housenumbers_view_chkl(
     tokens = request_uri.split("/")
     relation_name = tokens[-2]
     relation = relations.get_relation(relation_name)
-    relation.get_config().set_letter_suffix_style(util.LetterSuffixStyle.LOWER)
+    relation.get_config().set_letter_suffix_style(rust.PyLetterSuffixStyle.lower())
 
     output = ""
     if not ctx.get_file_system().path_exists(relation.get_files().get_osm_streets_path()):


### PR DESCRIPTION
Also eliminate the registration of the individual classes from
src/lib.rs, like it was already the case for functions.

Change-Id: I435666a13390c22e13201369d19e14b8948906e5
