### PR TITLE
Port util.HouseNumberRange to Rust

### DIFF
--- a/rust.pyi
+++ b/rust.pyi
@@ -252,4 +252,35 @@ class PyLetterSuffixStyle:
     def lower() -> int:
         ...
 
+class PyHouseNumberRange:
+    """
+    A house number range is a string that may expand to one or more HouseNumber instances in the
+    future. It can also have a comment.
+    """
+    def __init__(self, number: str, comment: str) -> None:
+        ...
+
+    def get_number(self) -> str:
+        """Returns the house number (range) string."""
+        ...
+
+    def get_comment(self) -> str:
+        """Returns the comment."""
+        ...
+
+    def __repr__(self) -> str:
+        ...
+
+    def __eq__(self, other: object) -> bool:
+        """Comment is explicitly non-interesting."""
+        ...
+
+    def __lt__(self, other: object) -> bool:
+        """Comment is explicitly non-interesting."""
+        ...
+
+    def __hash__(self) -> int:
+        """Comment is explicitly non-interesting."""
+        ...
+
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,7 +10,12 @@
 
 //! The util module contains functionality shared between other modules.
 
+use pyo3::class::basic::CompareOp;
+use pyo3::class::PyObjectProtocol;
 use pyo3::prelude::*;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
 
 /// Specifies the style of the output of normalize_letter_suffix().
 enum LetterSuffixStyle {
@@ -21,8 +26,7 @@ enum LetterSuffixStyle {
 }
 
 #[pyclass]
-pub struct PyLetterSuffixStyle {
-}
+pub struct PyLetterSuffixStyle {}
 
 #[pymethods]
 impl PyLetterSuffixStyle {
@@ -37,7 +41,107 @@ impl PyLetterSuffixStyle {
     }
 }
 
+/// A house number range is a string that may expand to one or more HouseNumber instances in the
+/// future. It can also have a comment.
+#[derive(Debug)]
+struct HouseNumberRange {
+    number: String,
+    comment: String,
+}
+
+impl HouseNumberRange {
+    fn new(number: &str, comment: &str) -> Self {
+        HouseNumberRange {
+            number: number.into(),
+            comment: comment.into(),
+        }
+    }
+
+    /// Returns the house number (range) string.
+    fn get_number(&self) -> &String {
+        &self.number
+    }
+
+    /// Returns the comment.
+    fn get_comment(&self) -> &String {
+        &self.comment
+    }
+
+    /// Comment is explicitly non-interesting.
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.number.cmp(&other.number)
+    }
+}
+
+impl PartialEq for HouseNumberRange {
+    /// Comment is explicitly non-interesting.
+    fn eq(&self, other: &Self) -> bool {
+        self.number == other.number
+    }
+}
+
+impl Hash for HouseNumberRange {
+    /// Comment is explicitly non-interesting.
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.number.hash(state);
+    }
+}
+
+#[pyclass]
+#[derive(Debug)]
+struct PyHouseNumberRange {
+    house_number_range: HouseNumberRange,
+}
+
+#[pymethods]
+impl PyHouseNumberRange {
+    #[new]
+    fn new(number: &str, comment: &str) -> Self {
+        let house_number_range = HouseNumberRange::new(number, comment);
+        PyHouseNumberRange { house_number_range }
+    }
+
+    fn get_number(&self) -> &String {
+        &self.house_number_range.get_number()
+    }
+
+    fn get_comment(&self) -> &String {
+        &self.house_number_range.get_comment()
+    }
+}
+
+#[pyproto]
+impl<'p> PyObjectProtocol<'p> for PyHouseNumberRange {
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("{:?}", self))
+    }
+
+    fn __richcmp__(
+        &'p self,
+        other: PyRef<'p, PyHouseNumberRange>,
+        op: CompareOp,
+    ) -> PyResult<PyObject> {
+        match op {
+            CompareOp::Eq => Ok(self
+                .house_number_range
+                .eq(&(*other).house_number_range)
+                .into_py(other.py())),
+            CompareOp::Lt => Ok((self.house_number_range.cmp(&(*other).house_number_range)
+                == std::cmp::Ordering::Less)
+                .into_py(other.py())),
+            _ => Ok(other.py().NotImplemented()),
+        }
+    }
+
+    fn __hash__(&self) -> PyResult<isize> {
+        let mut hasher = DefaultHasher::new();
+        self.house_number_range.hash(&mut hasher);
+        Ok(hasher.finish() as isize)
+    }
+}
+
 pub fn register_python_symbols(module: &PyModule) -> PyResult<()> {
     module.add_class::<PyLetterSuffixStyle>()?;
+    module.add_class::<PyHouseNumberRange>()?;
     Ok(())
 }

--- a/util.py
+++ b/util.py
@@ -35,39 +35,7 @@ import overpass_query
 import rust
 
 
-class HouseNumberRange:
-    """
-    A house number range is a string that may expand to one or more HouseNumber instances in the
-    future. It can also have a comment.
-    """
-    def __init__(self, number: str, comment: str) -> None:
-        self.__number = number
-        self.__comment = comment
-
-    def get_number(self) -> str:
-        """Returns the house number (range) string."""
-        return self.__number
-
-    def get_comment(self) -> str:
-        """Returns the comment."""
-        return self.__comment
-
-    def __repr__(self) -> str:
-        return "HouseNumberRange(number=%s, comment=%s)" % (self.__number, self.__comment)
-
-    def __eq__(self, other: object) -> bool:
-        """Comment is explicitly non-interesting."""
-        other_house_number_range = cast(HouseNumberRange, other)
-        return self.__number == other_house_number_range.get_number()
-
-    def __lt__(self, other: object) -> bool:
-        """Comment is explicitly non-interesting."""
-        other_house_number_range = cast(HouseNumberRange, other)
-        return self.__number < other_house_number_range.get_number()
-
-    def __hash__(self) -> int:
-        """Comment is explicitly non-interesting."""
-        return hash(self.__number)
+HouseNumberRange = rust.PyHouseNumberRange
 
 
 # Two strings: first is a range, second is an optional comment.


### PR DESCRIPTION
TIL: if you screw up eq(), then sorted(set(...)) on the Python side
won't work, even if hash() is implemented correctly.

Change-Id: I52152d5a19f6c9dae927c881247f0547be29ba08
