### PR TITLE
util: port HouseNumber to Rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,11 @@ clean:
 
 check: all check-filters check-flake8 check-mypy check-unit check-pylint check-eslint
 
-rust.so: target/debug/librust.so
-	ln -sf target/debug/librust.so rust.so
+rust.so: target/release/librust.so
+	ln -sf target/release/librust.so rust.so
 
-target/debug/librust.so: Cargo.toml $(RS_OBJECTS)
-	cargo build
+target/release/librust.so: Cargo.toml $(RS_OBJECTS)
+	cargo build --release
 
 config.ts: wsgi.ini Makefile
 	printf 'const uriPrefix = "%s";\nexport { uriPrefix };\n' $(shell grep prefix wsgi.ini |sed 's/uri_prefix = //') > $@

--- a/rust.pyi
+++ b/rust.pyi
@@ -349,5 +349,62 @@ class PyStreet:
         """OSM id is explicitly not interesting."""
         ...
 
+class PyHouseNumber:
+    """
+    A house number is a string which remembers what was its provider range.  E.g. the "1-3" string
+    can generate 3 house numbers, all of them with the same range.
+    The comment is similar to source, it's ignored during __eq__() and __hash__().
+    """
+    def __init__(self, number: str, source: str, comment: str) -> None:
+        ...
+
+    def get_number(self) -> str:
+        """Returns the house number string."""
+        ...
+
+    def get_diff_key(self) -> str:
+        """Gets a string that is used while diffing."""
+        ...
+
+    def get_source(self) -> str:
+        """Returns the source range."""
+        ...
+
+    def get_comment(self) -> str:
+        """Returns the comment."""
+        ...
+
+    def __repr__(self) -> str:
+        ...
+
+    def __eq__(self, other: object) -> bool:
+        """Source is explicitly non-interesting."""
+        ...
+
+    def __hash__(self) -> int:
+        """Source is explicitly non-interesting."""
+        ...
+
+    @staticmethod
+    def is_invalid(house_number: str, invalids: List[str]) -> bool:
+        """Decides if house_number is invalid according to invalids."""
+        ...
+
+    @staticmethod
+    def has_letter_suffix(house_number: str, source_suffix: str) -> bool:
+        """
+        Determines if the input is a house number, allowing letter suffixes. This means not only
+        '42' is allowed, but also '42a', '42/a' and '42 a'. Everything else is still considered just
+        junk after the numbers.
+        """
+        ...
+
+    @staticmethod
+    def normalize_letter_suffix(house_number: str, source_suffix: str, style: int) -> str:
+        """
+        Turn '42A' and '42 A' (and their lowercase versions) into '42/A'.
+        """
+        ...
+
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,19 +10,43 @@
 
 //! The util module contains functionality shared between other modules.
 
+use anyhow::anyhow;
 use pyo3::class::basic::CompareOp;
 use pyo3::class::PyObjectProtocol;
 use pyo3::prelude::*;
 use std::collections::hash_map::DefaultHasher;
+use std::convert::TryFrom;
 use std::hash::Hash;
 use std::hash::Hasher;
 
+thread_local! {
+    static NUMBER_PER_LETTER: regex::Regex = regex::Regex::new(r"^([0-9]+)( |/)?[A-Za-z]$").unwrap();
+    static NUMBER_PER_NUMBER: regex::Regex = regex::Regex::new(r"^([0-9]+)/[0-9]$").unwrap();
+    static NUMBER_WITH_JUNK: regex::Regex = regex::Regex::new(r"([0-9]+).*").unwrap();
+    static LETTER_SUFFIX: regex::Regex = regex::Regex::new(r".*([A-Za-z]+)\*?").unwrap();
+    static NUMBER_SUFFIX: regex::Regex = regex::Regex::new(r"^.*/([0-9])\*?$").unwrap();
+}
+
 /// Specifies the style of the output of normalize_letter_suffix().
+#[derive(PartialEq)]
 enum LetterSuffixStyle {
     /// "42/A"
     Upper,
     /// "42a"
     Lower,
+}
+
+/// Only needed for Python interop.
+impl TryFrom<i32> for LetterSuffixStyle {
+    type Error = ();
+
+    fn try_from(v: i32) -> Result<Self, Self::Error> {
+        match v {
+            x if x == LetterSuffixStyle::Upper as i32 => Ok(LetterSuffixStyle::Upper),
+            x if x == LetterSuffixStyle::Lower as i32 => Ok(LetterSuffixStyle::Lower),
+            _ => Err(()),
+        }
+    }
 }
 
 #[pyclass]
@@ -324,7 +348,253 @@ impl<'p> PyObjectProtocol<'p> for PyStreet {
     }
 }
 
+/// A house number is a string which remembers what was its provider range.  E.g. the "1-3" string
+/// can generate 3 house numbers, all of them with the same range.
+/// The comment is similar to source, it's ignored during __eq__() and __hash__().
+#[derive(Debug)]
+struct HouseNumber {
+    number: String,
+    source: String,
+    comment: String,
+}
+
+impl HouseNumber {
+    fn new(number: &str, source: &str, comment: &str) -> Self {
+        HouseNumber {
+            number: number.into(),
+            source: source.into(),
+            comment: comment.into(),
+        }
+    }
+
+    /// Returns the house number string.
+    fn get_number(&self) -> &str {
+        &self.number
+    }
+
+    /// Gets a string that is used while diffing.
+    fn get_diff_key(&self) -> String {
+        let re = regex::Regex::new(r"\*$").unwrap();
+        re.replace(&self.number, "").to_string()
+    }
+
+    /// Returns the source range.
+    fn get_source(&self) -> &str {
+        &self.source
+    }
+
+    /// Returns the comment.
+    fn get_comment(&self) -> &str {
+        &self.comment
+    }
+
+    /// Decides if house_number is invalid according to invalids.
+    fn is_invalid(house_number: &str, invalids: &[String]) -> bool {
+        if invalids.contains(&house_number.to_string()) {
+            return true;
+        }
+
+        let mut number: String = "".into();
+        if let Some(cap) = NUMBER_WITH_JUNK.with(|it| it.captures_iter(house_number).next()) {
+            number = cap[1].into();
+        }
+        let mut suffix: String = "".into();
+        // Check for letter suffix.
+        if let Some(cap) = LETTER_SUFFIX.with(|it| it.captures_iter(house_number).next()) {
+            suffix = cap[1].to_string().to_lowercase();
+        }
+        // If not, then try digit suggfix, but then only '/' is OK as a separator.
+        if suffix.is_empty() {
+            NUMBER_SUFFIX.with(|it| {
+                let mut iter = it.captures_iter(house_number);
+                if let Some(cap) = iter.next() {
+                    suffix = "/".into();
+                    suffix += &cap[1].to_string();
+                }
+            })
+        }
+
+        let house_number = number + &suffix;
+        invalids.contains(&house_number)
+    }
+
+    /// Determines if the input is a house number, allowing letter suffixes. This means not only
+    /// '42' is allowed, but also '42a', '42/a' and '42 a'. Everything else is still considered just
+    /// junk after the numbers.
+    fn has_letter_suffix(house_number: &str, source_suffix: &str) -> bool {
+        let mut house_number: String = house_number.into();
+        if !source_suffix.is_empty() {
+            house_number = house_number[..house_number.len() - source_suffix.len()].into();
+        }
+        // Check for letter suffix.
+        if NUMBER_PER_LETTER.with(|it| it.is_match(&house_number)) {
+            return true;
+        }
+        // If not, then try digit suggfix, but then only '/' is OK as a separator.
+        NUMBER_PER_NUMBER.with(|it| it.is_match(&house_number))
+    }
+
+    /// Turn '42A' and '42 A' (and their lowercase versions) into '42/A'.
+    fn normalize_letter_suffix(
+        house_number: &str,
+        source_suffix: &str,
+        style: LetterSuffixStyle,
+    ) -> anyhow::Result<String> {
+        let mut house_number: String = house_number.into();
+        if !source_suffix.is_empty() {
+            house_number = house_number[..house_number.len() - source_suffix.len()].into();
+        }
+        // Check for letter suffix.
+        let re = regex::Regex::new(r"^([0-9]+)( |/)?([A-Za-z])$").unwrap();
+        let is_match = re.is_match(&house_number);
+        let mut digit_match = false;
+        let mut groups: Vec<String> = Vec::new();
+        if is_match {
+            if let Some(cap) = re.captures_iter(&house_number).next() {
+                for index in 1..=3 {
+                    match cap.get(index) {
+                        Some(_) => groups.push(cap[index].to_string()),
+                        None => groups.push(String::from("")),
+                    }
+                }
+            }
+        } else {
+            // If not, then try digit suggfix, but then only '/' is OK as a separator.
+            let re = regex::Regex::new(r"^([0-9]+)(/)([0-9])$").unwrap();
+            let is_match = re.is_match(&house_number);
+            digit_match = true;
+            if !is_match {
+                return Err(anyhow!("ValueError"));
+            }
+            if let Some(cap) = re.captures_iter(&house_number).next() {
+                for index in 1..=3 {
+                    match cap.get(index) {
+                        Some(_) => groups.push(cap[index].to_string()),
+                        None => groups.push(String::from("")),
+                    }
+                }
+            };
+        }
+
+        let mut ret: String = groups[0].clone();
+        if style == LetterSuffixStyle::Upper || digit_match {
+            ret += "/";
+            ret += &groups[2].to_uppercase();
+        } else {
+            ret += &groups[2].to_lowercase();
+        }
+        ret += source_suffix;
+        Ok(ret)
+    }
+}
+
+impl PartialEq for HouseNumber {
+    /// Source is explicitly non-interesting.
+    fn eq(&self, other: &Self) -> bool {
+        self.number == other.number
+    }
+}
+
+impl Hash for HouseNumber {
+    /// Source is explicitly non-interesting.
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.number.hash(state);
+    }
+}
+
+#[pyclass]
+#[derive(Debug)]
+struct PyHouseNumber {
+    house_number: HouseNumber,
+}
+
+#[pymethods]
+impl PyHouseNumber {
+    #[new]
+    fn new(number: &str, source: &str, comment: &str) -> Self {
+        let house_number = HouseNumber::new(number, source, comment);
+        PyHouseNumber { house_number }
+    }
+
+    fn get_number(&self) -> &str {
+        self.house_number.get_number()
+    }
+
+    fn get_diff_key(&self) -> String {
+        self.house_number.get_diff_key()
+    }
+
+    fn get_source(&self) -> &str {
+        self.house_number.get_source()
+    }
+
+    fn get_comment(&self) -> &str {
+        self.house_number.get_comment()
+    }
+
+    #[staticmethod]
+    fn is_invalid(house_number: &str, invalids: Vec<String>) -> bool {
+        HouseNumber::is_invalid(house_number, &invalids)
+    }
+
+    #[staticmethod]
+    fn has_letter_suffix(house_number: &str, source_suffix: &str) -> bool {
+        HouseNumber::has_letter_suffix(house_number, source_suffix)
+    }
+
+    #[staticmethod]
+    fn normalize_letter_suffix(
+        house_number: &str,
+        source_suffix: &str,
+        style: i32,
+    ) -> PyResult<String> {
+        let style: LetterSuffixStyle = match LetterSuffixStyle::try_from(style) {
+            Ok(value) => value,
+            Err(_) => {
+                return Err(pyo3::exceptions::PyOSError::new_err(
+                    "failed to convert style to LetterSuffixStyle",
+                ));
+            }
+        };
+        match HouseNumber::normalize_letter_suffix(
+            house_number,
+            source_suffix,
+            style as LetterSuffixStyle,
+        ) {
+            Ok(value) => Ok(value),
+            Err(err) => Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "normalize_letter_suffix() failed: {}",
+                err.to_string()
+            ))),
+        }
+    }
+}
+
+#[pyproto]
+impl<'p> PyObjectProtocol<'p> for PyHouseNumber {
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("{:?}", self))
+    }
+
+    fn __richcmp__(&'p self, other: PyRef<'p, PyHouseNumber>, op: CompareOp) -> PyResult<PyObject> {
+        match op {
+            CompareOp::Eq => Ok(self
+                .house_number
+                .eq(&(*other).house_number)
+                .into_py(other.py())),
+            _ => Ok(other.py().NotImplemented()),
+        }
+    }
+
+    fn __hash__(&self) -> PyResult<isize> {
+        let mut hasher = DefaultHasher::new();
+        self.house_number.hash(&mut hasher);
+        Ok(hasher.finish() as isize)
+    }
+}
+
 pub fn register_python_symbols(module: &PyModule) -> PyResult<()> {
+    module.add_class::<PyHouseNumber>()?;
     module.add_class::<PyHouseNumberRange>()?;
     module.add_class::<PyLetterSuffixStyle>()?;
     module.add_class::<PyStreet>()?;

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -300,13 +300,13 @@ class TestHouseNumber(unittest.TestCase):
     """Tests the HouseNumber class."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        house_number = util.HouseNumber("1", "1-2")
+        house_number = util.HouseNumber("1", "1-2", "")
         self.assertEqual(house_number.get_number(), "1")
         self.assertEqual(house_number.get_source(), "1-2")
-        self.assertTrue(util.HouseNumber("1", "1-2") != util.HouseNumber("2", "1-2"))
-        self.assertEqual(len(set([util.HouseNumber("1", "1-2"),
-                                  util.HouseNumber("2", "1-2"),
-                                  util.HouseNumber("2", "1-2")])), 2)
+        self.assertTrue(util.HouseNumber("1", "1-2", "") != util.HouseNumber("2", "1-2", ""))
+        self.assertEqual(len(set([util.HouseNumber("1", "1-2", ""),
+                                  util.HouseNumber("2", "1-2", ""),
+                                  util.HouseNumber("2", "1-2", "")])), 2)
 
     def test_is_invalid(self) -> None:
         """Tests is_invalid()."""
@@ -346,14 +346,14 @@ class TestGetHousenumberRanges(unittest.TestCase):
     def test_happy(self) -> None:
         """Tests the happy path."""
         house_numbers = [
-            util.HouseNumber("25", "25"),
-            util.HouseNumber("27", "27-37"),
-            util.HouseNumber("29", "27-37"),
-            util.HouseNumber("31", "27-37"),
-            util.HouseNumber("33", "27-37"),
-            util.HouseNumber("35", "27-37"),
-            util.HouseNumber("37", "27-37"),
-            util.HouseNumber("31*", "31*"),
+            util.HouseNumber("25", "25", ""),
+            util.HouseNumber("27", "27-37", ""),
+            util.HouseNumber("29", "27-37", ""),
+            util.HouseNumber("31", "27-37", ""),
+            util.HouseNumber("33", "27-37", ""),
+            util.HouseNumber("35", "27-37", ""),
+            util.HouseNumber("37", "27-37", ""),
+            util.HouseNumber("31*", "31*", ""),
         ]
         ranges = util.get_housenumber_ranges(house_numbers)
         range_names = [i.get_number() for i in ranges]
@@ -373,23 +373,23 @@ class TestSortNumerically(unittest.TestCase):
     """Tests sort_numerically()."""
     def test_numbers(self) -> None:
         """Tests numbers."""
-        ascending = util.sort_numerically([util.HouseNumber('1', ''),
-                                           util.HouseNumber('20', ''),
-                                           util.HouseNumber('3', '')])
+        ascending = util.sort_numerically([util.HouseNumber('1', '', ''),
+                                           util.HouseNumber('20', '', ''),
+                                           util.HouseNumber('3', '', '')])
         self.assertEqual([i.get_number() for i in ascending], ['1', '3', '20'])
 
     def test_alpha_suffix(self) -> None:
         """Tests numbers with suffixes."""
-        ascending = util.sort_numerically([util.HouseNumber('1a', ''),
-                                           util.HouseNumber('20a', ''),
-                                           util.HouseNumber('3a', '')])
+        ascending = util.sort_numerically([util.HouseNumber('1a', '', ''),
+                                           util.HouseNumber('20a', '', ''),
+                                           util.HouseNumber('3a', '', '')])
         self.assertEqual([i.get_number() for i in ascending], ['1a', '3a', '20a'])
 
     def test_alpha(self) -> None:
         """Tests just suffixes."""
-        ascending = util.sort_numerically([util.HouseNumber('a', ''),
-                                           util.HouseNumber('c', ''),
-                                           util.HouseNumber('b', '')])
+        ascending = util.sort_numerically([util.HouseNumber('a', '', ''),
+                                           util.HouseNumber('c', '', ''),
+                                           util.HouseNumber('b', '', '')])
         self.assertEqual([i.get_number() for i in ascending], ['a', 'b', 'c'])
 
 


### PR DESCRIPTION
Also switch to building optimized Rust, otherwise working with regular
expressions is quite expensive, even if they are only compiled once.

E.g. old time ./missing_housenumbers.py budapest_11:
real    0m25,798s

new:
real    0m2,422s

Change-Id: I2f77a141d9ffb05773354d46fb98f4248481c70c
