### PR TITLE
util: port split_house_number() to Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ csv = "1.1.6"
 gettext = "0.4.0"
 git-version = "0.3.5"
 html-escape = "0.2.9"
+lazy_static = "1.4.0"
 regex = "1.5.4"
 reqwest = { version = "0.11.4", features = ["blocking"] }
 

--- a/rust.pyi
+++ b/rust.pyi
@@ -420,5 +420,9 @@ class PyCsvRead:
         """Gets access to the rows of the CSV."""
         ...
 
+def py_split_house_number(house_number: str) -> Tuple[int, str]:
+    """Splits house_number into a numerical and a remainder part."""
+    ...
+
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/util.py
+++ b/util.py
@@ -34,7 +34,7 @@ HouseNumberRange = rust.PyHouseNumberRange
 Street = rust.PyStreet
 HouseNumber = rust.PyHouseNumber
 CsvIO = rust.PyCsvRead
-
+split_house_number = rust.py_split_house_number
 
 # Two strings: first is a range, second is an optional comment.
 HouseNumberWithComment = List[str]
@@ -184,18 +184,6 @@ def build_reference_caches(
 ) -> List[Dict[str, Dict[str, Dict[str, List[HouseNumberWithComment]]]]]:
     """Handles a list of references for build_reference_cache()."""
     return [build_reference_cache(reference, refcounty) for reference in references]
-
-
-def split_house_number(house_number: str) -> Tuple[int, str]:
-    """Splits house_number into a numerical and a remainder part."""
-    match = re.search(r"^([0-9]*)([^0-9].*|)$", house_number)
-    assert match
-    number = 0
-    try:
-        number = int(match.group(1))
-    except ValueError:
-        pass
-    return (number, match.group(2))
 
 
 def parse_filters(tokens: List[str]) -> Dict[str, str]:


### PR DESCRIPTION
Also share those regex instances between threads: they are immutable, so
no need to make them thread-local. This also avoids the need for
somewhat ugly lambdas.

Change-Id: Ibdb3543946946039a03b518edee0d15de5aa8921
