### PR TITLE
util: port format_even_odd() to Rust

### DIFF
--- a/areas.py
+++ b/areas.py
@@ -597,7 +597,7 @@ class Relation(RelationBase):
                         doc.text(", ")
                     doc.append_value(util.color_house_number(item).get_value())
             else:
-                util.format_even_odd(number_ranges, doc)
+                doc.append_value(util.format_even_odd_html(number_ranges).get_value())
             row.append(doc)
 
             todo_count += len(number_ranges)

--- a/cache.py
+++ b/cache.py
@@ -163,7 +163,7 @@ def get_missing_housenumbers_txt(ctx: context.Context, relation: areas.Relation)
             result_sorted = sorted(range_strings, key=util.split_house_number)
             row = result[0].get_osm_name() + "\t[" + ", ".join(result_sorted) + "]"
         else:
-            elements = util.format_even_odd(range_list, doc=None)
+            elements = util.format_even_odd(range_list)
             row = result[0].get_osm_name() + "\t[" + "], [".join(elements) + "]"
         table.append(row)
     table.sort(key=util.get_lexical_sort_key())

--- a/rust.pyi
+++ b/rust.pyi
@@ -428,5 +428,18 @@ def py_split_house_number_range(house_number: PyHouseNumberRange) -> Tuple[int, 
     """Wrapper around split_house_number() for HouseNumberRange objects."""
     ...
 
+def py_format_even_odd(only_in_ref: List[PyHouseNumberRange]) -> List[str]:
+    """Formats even and odd numbers."""
+    ...
+
+
+def py_format_even_odd_html(only_in_ref: List[PyHouseNumberRange]) -> PyDoc:
+    """Formats even and odd numbers, HTML version."""
+    ...
+
+
+def py_color_house_number(house_number: PyHouseNumberRange) -> PyDoc:
+    """Colors a house number according to its suffix."""
+    ...
 
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/src/yattag.rs
+++ b/src/yattag.rs
@@ -33,17 +33,17 @@ impl Doc {
     }
 
     /// Gets the escaped value.
-    fn get_value(&self) -> String {
+    pub fn get_value(&self) -> String {
         self.value.lock().unwrap().clone()
     }
 
     /// Appends escaped content to the value.
-    fn append_value(&self, value: String) {
+    pub fn append_value(&self, value: String) {
         self.value.lock().unwrap().push_str(&value)
     }
 
     /// Starts a new tag.
-    fn tag(&self, name: &str, attrs: Vec<(&str, &str)>) -> Tag {
+    pub fn tag(&self, name: &str, attrs: Vec<(&str, &str)>) -> Tag {
         Tag::new(&self.value, name, attrs)
     }
 
@@ -107,7 +107,7 @@ impl PyDoc {
 }
 
 /// Starts a tag, which is closed automatically.
-struct Tag {
+pub struct Tag {
     value: Arc<Mutex<String>>,
     name: String,
 }

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -33,20 +33,19 @@ class TestFormatEvenOdd(unittest.TestCase):
     """Tests format_even_odd()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        self.assertEqual(util.format_even_odd(hnr_list(["1", "2"]), doc=None), ["1", "2"])
+        self.assertEqual(util.format_even_odd(hnr_list(["1", "2"])), ["1", "2"])
 
     def test_only_odd(self) -> None:
         """Tests when we have odd numbers only."""
-        self.assertEqual(util.format_even_odd(hnr_list(["1", "3"]), doc=None), ["1, 3"])
+        self.assertEqual(util.format_even_odd(hnr_list(["1", "3"])), ["1, 3"])
 
     def test_only_even(self) -> None:
         """Tests when we have even numbers only."""
-        self.assertEqual(util.format_even_odd(hnr_list(["2", "4"]), doc=None), ["2, 4"])
+        self.assertEqual(util.format_even_odd(hnr_list(["2", "4"])), ["2, 4"])
 
     def test_html(self) -> None:
         """Tests HTML coloring."""
-        doc = yattag.Doc()
-        util.format_even_odd(hnr_list(["2*", "4"]), doc)
+        doc = util.format_even_odd_html(hnr_list(["2*", "4"]))
         self.assertEqual(doc.get_value(), '<span style="color: blue;">2</span>, 4')
 
     def test_html_comment(self) -> None:
@@ -56,13 +55,12 @@ class TestFormatEvenOdd(unittest.TestCase):
             util.HouseNumberRange("2*", "foo"),
             util.HouseNumberRange("4", ""),
         ]
-        util.format_even_odd(house_numbers, doc)
+        doc = util.format_even_odd_html(house_numbers)
         self.assertEqual(doc.get_value(), '<span style="color: blue;"><abbr title="foo" tabindex="0">2</abbr></span>, 4')
 
     def test_html_multi_odd(self) -> None:
         """Tests HTML output with multiple odd numbers."""
-        doc = yattag.Doc()
-        util.format_even_odd(hnr_list(["1", "3"]), doc)
+        doc = util.format_even_odd_html(hnr_list(["1", "3"]))
         self.assertEqual(doc.get_value(), "1, 3")
 
 

--- a/util.py
+++ b/util.py
@@ -36,6 +36,9 @@ HouseNumber = rust.PyHouseNumber
 CsvIO = rust.PyCsvRead
 split_house_number = rust.py_split_house_number
 split_house_number_range = rust.py_split_house_number_range
+format_even_odd = rust.py_format_even_odd
+format_even_odd_html = rust.py_format_even_odd_html
+color_house_number = rust.py_color_house_number
 
 # Two strings: first is a range, second is an optional comment.
 HouseNumberWithComment = List[str]
@@ -44,54 +47,6 @@ HouseNumberWithComment = List[str]
 HouseNumbers = List[HouseNumber]
 NumberedStreet = Tuple[Street, HouseNumbers]
 NumberedStreets = List[NumberedStreet]
-
-
-def format_even_odd(only_in_ref: List[HouseNumberRange], doc: Optional[yattag.Doc]) -> List[str]:
-    """Separate even and odd numbers, this helps survey in most cases."""
-    key = split_house_number_range
-    even = sorted([i for i in only_in_ref if int(split_house_number(i.get_number())[0]) % 2 == 0], key=key)
-    odd = sorted([i for i in only_in_ref if int(split_house_number(i.get_number())[0]) % 2 == 1], key=key)
-    if doc:
-        if odd:
-            for index, elem in enumerate(odd):
-                if index:
-                    doc.text(", ")
-                doc.append_value(color_house_number(elem).get_value())
-        if even:
-            if odd:
-                doc.stag("br", [])
-            for index, elem in enumerate(even):
-                if index:
-                    doc.text(", ")
-                doc.append_value(color_house_number(elem).get_value())
-        return []
-
-    even_string = ", ".join([i.get_number() for i in even])
-    odd_string = ", ".join([i.get_number() for i in odd])
-    elements = []
-    if odd_string:
-        elements.append(odd_string)
-    if even_string:
-        elements.append(even_string)
-    return elements
-
-
-def color_house_number(house_number: HouseNumberRange) -> yattag.Doc:
-    """Colors a house number according to its suffix."""
-    doc = yattag.Doc()
-    number = house_number.get_number()
-    if not number.endswith("*"):
-        doc.text(number)
-        return doc
-    number = number[:-1]
-    title = house_number.get_comment().replace("&#013;", "\n")
-    with doc.tag("span", [("style", "color: blue;")]):
-        if title:
-            with doc.tag("abbr", [("title", title), ("tabindex", "0")]):
-                doc.text(number)
-        else:
-            doc.text(number)
-    return doc
 
 
 def build_street_reference_cache(local_streets: str) -> Dict[str, Dict[str, HouseNumberWithComment]]:

--- a/wsgi.py
+++ b/wsgi.py
@@ -252,7 +252,7 @@ def missing_housenumbers_view_chkl(
                 row += result[0].get_osm_name() + " [" + ", ".join(result_sorted) + "]"
                 table.append(row)
             else:
-                elements = util.format_even_odd(range_list, doc=None)
+                elements = util.format_even_odd(range_list)
                 if len(elements) > 1 and len(range_list) > get_chkl_split_limit():
                     for element in elements:
                         row = "[ ] " + result[0].get_osm_name() + " [" + element + "]"


### PR DESCRIPTION
Split it up to a plain text and a HTML variant. This also needs porting
color_house_number().

Change-Id: I54a88848827c35939279b879ecba4b546a327fa2
