### PR TITLE
util: port build_street_reference_cache() to Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ html-escape = "0.2.9"
 lazy_static = "1.4.0"
 regex = "1.5.4"
 reqwest = { version = "0.11.4", features = ["blocking"] }
+serde = "1.0.129"
+serde_json = "1.0.66"
 
 [dependencies.pyo3]
 version = "0.13.2"

--- a/api.py
+++ b/api.py
@@ -82,4 +82,7 @@ class Unit:
         ...
 
 
+# Two strings: first is a range, second is an optional comment.
+HouseNumberWithComment = List[str]
+
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/areas.py
+++ b/areas.py
@@ -17,6 +17,7 @@ import json
 import yattag
 
 from rust import py_translate as tr
+import api
 import area_files
 import context
 import rust
@@ -360,7 +361,7 @@ class RelationBase:
 
     def build_ref_housenumbers(
             self,
-            reference: Dict[str, Dict[str, Dict[str, List[util.HouseNumberWithComment]]]],
+            reference: Dict[str, Dict[str, Dict[str, List[api.HouseNumberWithComment]]]],
             street: str,
             suffix: str
     ) -> List[str]:

--- a/rust.pyi
+++ b/rust.pyi
@@ -442,4 +442,23 @@ def py_color_house_number(house_number: PyHouseNumberRange) -> PyDoc:
     """Colors a house number according to its suffix."""
     ...
 
+def py_build_street_reference_cache(local_streets: str) -> Dict[str, Dict[str, List[str]]]:
+    """Builds an in-memory cache from the reference on-disk TSV (street version)."""
+    ...
+
+def py_get_reference_cache_path(local: str, refcounty: str) -> str:
+    """Gets the filename of the (house number) reference cache file."""
+    ...
+
+def py_build_reference_cache(local: str, refcounty: str) -> Dict[str, Dict[str, Dict[str, List[api.HouseNumberWithComment]]]]:
+    """Builds an in-memory cache from the reference on-disk TSV (house number version)."""
+    ...
+
+def py_build_reference_caches(
+        references: List[str],
+        refcounty: str
+) -> List[Dict[str, Dict[str, Dict[str, List[api.HouseNumberWithComment]]]]]:
+    """Handles a list of references for build_reference_cache()."""
+    ...
+
 # vim:set shiftwidth=4 softtabstop=4 expandtab:


### PR DESCRIPTION
Also port get_reference_cache_path(), build_reference_cache() and
build_reference_caches().

Finally fix util::format_even_odd_html: one break is enough, between the
odd and the even line.

Change-Id: Ie1ddf6d6635ad3b0ada7372633e344024d7d08ad
