### PR TITLE
util: port invalid_refstreets_to_html() to Rust

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -94,7 +94,8 @@ def get_missing_housenumbers_html(ctx: context.Context, relation: areas.Relation
             doc.text(tr("Checklist format"))
 
     doc.append_value(util.html_table_from_list(table).get_value())
-    doc.append_value(util.invalid_refstreets_to_html(relation.get_invalid_refstreets()).get_value())
+    osm_invalids, ref_invalids = relation.get_invalid_refstreets()
+    doc.append_value(util.invalid_refstreets_to_html(osm_invalids, ref_invalids).get_value())
     doc.append_value(util.invalid_filter_keys_to_html(relation.get_invalid_filter_keys()).get_value())
 
     with relation.get_files().get_housenumbers_htmlcache_write_stream(ctx) as stream:
@@ -122,7 +123,8 @@ def get_additional_housenumbers_html(ctx: context.Context, relation: areas.Relat
             doc.text(tr("Filter incorrect information"))
 
     doc.append_value(util.html_table_from_list(table).get_value())
-    doc.append_value(util.invalid_refstreets_to_html(relation.get_invalid_refstreets()).get_value())
+    osm_invalids, ref_invalids = relation.get_invalid_refstreets()
+    doc.append_value(util.invalid_refstreets_to_html(osm_invalids, ref_invalids).get_value())
     doc.append_value(util.invalid_filter_keys_to_html(relation.get_invalid_filter_keys()).get_value())
 
     with relation.get_files().get_additional_housenumbers_htmlcache_write_stream(ctx) as stream:

--- a/rust.pyi
+++ b/rust.pyi
@@ -498,4 +498,24 @@ def py_html_table_from_list(table: List[List[PyDoc]]) -> PyDoc:
     """Produces a HTML table from a list of lists."""
     ...
 
+def py_invalid_refstreets_to_html(osm_invalids: List[str], ref_invalids: List[str]) -> PyDoc:
+    """Produces HTML enumerations for 2 string lists."""
+    ...
+
+def py_invalid_filter_keys_to_html(invalids: List[str]) -> PyDoc:
+    """Produces HTML enumerations for a string list."""
+    ...
+
+def py_get_column(row: List[PyDoc], column_index: int) -> str:
+    """Gets the nth column of row."""
+    ...
+
+def py_natnum(column: str) -> int:
+    """Interpret the content as an integer."""
+    ...
+
+def py_tsv_to_list(stream: PyCsvRead) -> List[List[PyDoc]]:
+    """Turns a tab-separated table into a list of lists."""
+    ...
+
 # vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/src/yattag.rs
+++ b/src/yattag.rs
@@ -34,7 +34,7 @@ impl Doc {
     }
 
     /// Factory of yattag.Doc from a string.
-    fn from_text(text: &str) -> Self {
+    pub fn from_text(text: &str) -> Self {
         let doc = Doc::new();
         doc.text(text);
         doc

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -482,10 +482,10 @@ class TestGetColumn(unittest.TestCase):
             yattag.Doc.from_text("A street"),
             yattag.Doc.from_text("1"),
         ]
-        self.assertEqual(util.get_column(row, 1, natnum=False), "A street")
-        self.assertEqual(util.get_column(row, 2, natnum=True), 1)
+        self.assertEqual(util.get_column(row, 1), "A street")
+        self.assertEqual(util.natnum(util.get_column(row, 2)), 1)
         # Too large column index -> first column.
-        self.assertEqual(util.get_column(row, 3, natnum=False), "42")
+        self.assertEqual(util.get_column(row, 3), "42")
 
     def test_junk(self) -> None:
         """Tests the 'housenumber is junk' case."""
@@ -495,7 +495,7 @@ class TestGetColumn(unittest.TestCase):
             yattag.Doc.from_text("A street"),
             yattag.Doc.from_text("fixme"),
         ]
-        self.assertEqual(util.get_column(row, 2, natnum=True), 0)
+        self.assertEqual(util.natnum(util.get_column(row, 2)), 0)
 
 
 class TestGetTimestamp(unittest.TestCase):

--- a/webframe.py
+++ b/webframe.py
@@ -427,7 +427,7 @@ def handle_invalid_refstreets(ctx: context.Context, relations: areas.Relations) 
             relation_name = relation.get_name()
             with doc.tag("a", [("href", prefix + "/streets/" + relation_name + "/view-result")]):
                 doc.text(relation_name)
-        doc.append_value(util.invalid_refstreets_to_html(invalid_refstreets).get_value())
+        doc.append_value(util.invalid_refstreets_to_html(osm_invalids, ref_invalids).get_value())
         doc.append_value(util.invalid_filter_keys_to_html(key_invalids).get_value())
 
     doc.append_value(get_footer().get_value())

--- a/wsgi.py
+++ b/wsgi.py
@@ -193,7 +193,8 @@ def missing_streets_view_result(ctx: context.Context, relations: areas.Relations
             doc.text(tr("Checklist format"))
 
     doc.append_value(util.html_table_from_list(table).get_value())
-    doc.append_value(util.invalid_refstreets_to_html(relation.get_invalid_refstreets()).get_value())
+    osm_invalids, ref_invalids = relation.get_invalid_refstreets()
+    doc.append_value(util.invalid_refstreets_to_html(osm_invalids, ref_invalids).get_value())
     doc.append_value(util.invalid_filter_keys_to_html(relation.get_invalid_filter_keys()).get_value())
     return doc
 

--- a/wsgi_additional.py
+++ b/wsgi_additional.py
@@ -99,7 +99,8 @@ def additional_streets_view_result(
                 doc.text(tr("Overpass turbo query for the below streets"))
 
         doc.append_value(util.html_table_from_list(table).get_value())
-        doc.append_value(util.invalid_refstreets_to_html(relation.get_invalid_refstreets()).get_value())
+        osm_invalids, ref_invalids = relation.get_invalid_refstreets()
+        doc.append_value(util.invalid_refstreets_to_html(osm_invalids, ref_invalids).get_value())
     return doc
 
 


### PR DESCRIPTION
Also invalid_filter_keys_to_html(), get_column() and tsv_to_list().

Change-Id: I954b8a158b6622141a7ad771804e3f82b550f7ee
