### PR TITLE
areas: guard against XML data when requesting CSV

### DIFF
--- a/areas.py
+++ b/areas.py
@@ -308,6 +308,9 @@ class Relation:
                     first = False
                     continue
                 # 0: @id, 1: name, 6: @type
+                if len(row) < 2:  # pragma: no cover
+                    # data/streets-template.txt requests this, so we got garbage, give up.
+                    return ret
                 street = util.Street(osm_name=row[1], ref_name="", show_ref_street=True, osm_id=int(row[0]))
                 if len(row) > 6:
                     street.set_osm_type(row[6])


### PR DESCRIPTION
main: unhandled exception: Traceback (most recent call last):
  File "/home/osm-gimmisn/git/osm-gimmisn/cron.py", line 351, in our_main
    update_ref_housenumbers(ctx, relations, update)
  File "/home/osm-gimmisn/git/osm-gimmisn/cron.py", line 125, in update_ref_housenumbers
    relation.write_ref_housenumbers(references)
  File "/home/osm-gimmisn/git/osm-gimmisn/areas.py", line 404, in write_ref_housenumbers
    streets = [i.get_osm_name() for i in self.get_osm_streets()]
  File "/home/osm-gimmisn/git/osm-gimmisn/areas.py", line 294, in get_osm_streets
    street = util.Street(osm_name=row[1], ref_name="", show_ref_street=True, osm_id=int(row[0]))
IndexError: list index out of range

workdir/streets-balatonalmadi-vorosbereny.csv is some XHTML error
message, not a CSV.

Change-Id: I84aaa28e0737e7c6d1168d0087d635a9911dafeb
