### PR TITLE
cron: handle non-CSV response from overpass

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,5 +1,9 @@
 = Version descriptions
 
+== master
+
+- Resolves: gh#1664 re-try overpass when response is XML (an error message) and CSV was requested
+
 == 7.2
 
 - Resolves: gh#964 get_street_from_housenumber: consider addr:place when addr:street is empty

--- a/cron.py
+++ b/cron.py
@@ -80,7 +80,9 @@ def update_osm_streets(ctx: context.Context, relations: areas.Relations, update:
             except OSError as err:
                 info("update_osm_streets: http error: %s", str(err))
                 continue
-            relation.get_files().write_osm_streets(ctx, buf)
+            if relation.get_files().write_osm_streets(ctx, buf) == 0:
+                info("update_osm_streets: short write")
+                continue
             break
         info("update_osm_streets: end: %s", relation_name)
 
@@ -104,7 +106,9 @@ def update_osm_housenumbers(ctx: context.Context, relations: areas.Relations, up
             except OSError as err:
                 info("update_osm_housenumbers: http error: %s", str(err))
                 continue
-            relation.get_files().write_osm_housenumbers(ctx, buf)
+            if relation.get_files().write_osm_housenumbers(ctx, buf) == 0:
+                info("update_osm_housenumbers: short write")
+                continue
             break
         info("update_osm_housenumbers: end: %s", relation_name)
 

--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -327,6 +327,11 @@ impl RelationFiles {
         ctx: &crate::context::Context,
         result: &str,
     ) -> anyhow::Result<usize> {
+        if result.starts_with("<?xml") {
+            // Not a CSV, reject.
+            return Ok(0);
+        }
+
         let write = self.get_osm_streets_write_stream(ctx)?;
         let mut guard = write.lock().unwrap();
         Ok(guard.write(result.as_bytes())?)
@@ -347,6 +352,11 @@ impl RelationFiles {
         ctx: &crate::context::Context,
         result: &str,
     ) -> anyhow::Result<usize> {
+        if result.starts_with("<?xml") {
+            // Not a CSV, reject.
+            return Ok(0);
+        }
+
         let write = self.get_osm_housenumbers_write_stream(ctx)?;
         let mut guard = write.lock().unwrap();
         Ok(guard.write(result.as_bytes())?)

--- a/tests/network/overpass.xml
+++ b/tests/network/overpass.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -245,6 +245,30 @@ class TestUpdateOsmHousenumbers(unittest.TestCase):
         actual = util.get_content(relations.get_workdir() + "/street-housenumbers-gazdagret.csv")
         self.assertEqual(actual, expected)
 
+    def test_xml_as_csv(self) -> None:
+        """Tests the case when we ask for CSV but get XML."""
+        ctx = test_context.make_test_context()
+        routes: List[test_context.URLRoute] = [
+            test_context.URLRoute(url="https://overpass-api.de/api/status",
+                                  data_path="",
+                                  result_path="tests/network/overpass-status-happy.txt"),
+            test_context.URLRoute(url="https://overpass-api.de/api/interpreter",
+                                  data_path="",
+                                  result_path="tests/network/overpass.xml"),
+        ]
+        network = test_context.TestNetwork(routes)
+        ctx.set_network(network)
+        relations = areas.Relations(ctx)
+        for relation_name in relations.get_active_names():
+            if relation_name != "gazdagret":
+                config = relations.get_relation(relation_name).get_config()
+                config.set_active(False)
+                relations.get_relation(relation_name).set_config(config)
+        path = os.path.join(relations.get_workdir(), "street-housenumbers-gazdagret.csv")
+        expected = util.get_content(path)
+        cron.update_osm_housenumbers(ctx, relations, update=True)
+        self.assertEqual(util.get_content(path), expected)
+
 
 class TestUpdateOsmStreets(unittest.TestCase):
     """Tests update_osm_streets()."""
@@ -302,6 +326,30 @@ class TestUpdateOsmStreets(unittest.TestCase):
         # leave the last state unchanged.
         actual = util.get_content(relations.get_workdir() + "/streets-gazdagret.csv")
         self.assertEqual(actual, expected)
+
+    def test_xml_as_csv(self) -> None:
+        """Tests the case when we ask for CSV but get XML."""
+        ctx = test_context.make_test_context()
+        routes: List[test_context.URLRoute] = [
+            test_context.URLRoute(url="https://overpass-api.de/api/status",
+                                  data_path="",
+                                  result_path="tests/network/overpass-status-happy.txt"),
+            test_context.URLRoute(url="https://overpass-api.de/api/interpreter",
+                                  data_path="",
+                                  result_path="tests/network/overpass.xml"),
+        ]
+        network = test_context.TestNetwork(routes)
+        ctx.set_network(network)
+        relations = areas.Relations(ctx)
+        for relation_name in relations.get_active_names():
+            if relation_name != "gazdagret":
+                config = relations.get_relation(relation_name).get_config()
+                config.set_active(False)
+                relations.get_relation(relation_name).set_config(config)
+        path = os.path.join(relations.get_workdir(), "streets-gazdagret.csv")
+        expected = util.get_content(path)
+        cron.update_osm_streets(ctx, relations, update=True)
+        self.assertEqual(util.get_content(path), expected)
 
 
 def create_old_file(path: str) -> None:


### PR DESCRIPTION
Skip it if it looks like XML.

Resolves <https://github.com/vmiklos/osm-gimmisn/issues/1664>.

Change-Id: Iaf5c53081e0a99b5a67ba23917d8eb7722f4971b
