### PR TITLE
areas: speed up get_missing_housenumbers()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,7 @@ default = ["extension-module"]
 [patch.crates-io]
 rust_icu_ustring = { git = "https://github.com/google/rust_icu", rev = "a859f74400cf7505ca4478d82d4c63bafc8f7290" }
 rust_icu_ucol = { git = "https://github.com/google/rust_icu", rev = "a859f74400cf7505ca4478d82d4c63bafc8f7290" }
+
+# Enable symbols (for callgrind):
+# [profile.release]
+# debug = true

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -63,6 +63,14 @@ To run a single test:
 env PYTHONPATH=.:tests python3 -m unittest tests.test_areas.TestRelationGetOsmHouseNumbers.test_happy
 ----
 
+== Rust performance profiling
+
+Enable symbols in Cargo.toml, then:
+
+----
+valgrind --tool=callgrind python3 ./missing_housenumbers.py budapest_11
+----
+
 == YAML schema
 
 The YAML schema is meant to provide reference documentation in the long run, so doc/README.adoc can


### PR DESCRIPTION
Now that the relevant piece of this is free from Python, callgrind shows
where is the not needed copying.

Old cost for 'time ./missing_housenumbers.py budapest_11':

real    0m12,599s

New cost:

real    0m0,703s

The best Python time was 0m0,943s before we started to pay for the
Python<->Rust copying, so finally this is some real benefit.

Change-Id: I6095714e64860ec2daf58ce73ccc92a5bdb8d365
