### PR TITLE
util: optimize HouseNumber::get_diff_key()

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -530,8 +530,13 @@ impl HouseNumber {
 
 impl Diff for HouseNumber {
     fn get_diff_key(&self) -> String {
-        let re = regex::Regex::new(r"\*$").unwrap();
-        re.replace(&self.number, "").to_string()
+        if self.number.ends_with('*') {
+            let mut chars = self.number.chars();
+            chars.next_back();
+            return chars.as_str().into();
+        }
+
+        self.number.clone()
     }
 }
 


### PR DESCRIPTION
missing_housenumbers budapest_11: 703ms -> 372ms (53% of baseline)

Change-Id: I137903bad3067cf0fd6756625e2c163cbc9c37d2
