### PR TITLE
wsgi: fix /filter-for/refcounty/../refsettlement/..

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -90,7 +90,7 @@ impl RelationConfig {
     }
 
     /// Gets the relation's refsettlement identifier from reference.
-    fn get_refsettlement(&self) -> String {
+    pub fn get_refsettlement(&self) -> String {
         self.get_property("refsettlement")
             .unwrap()
             .as_str()

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1000,12 +1000,12 @@ fn create_filter_for_refcounty_refsettlement(
 ) -> Box<RelationFilter> {
     let refcounty_arc = Arc::new(refcounty_filter.to_string());
     let refcounty_filter = refcounty_arc;
-    let refsettlement_arc = Arc::new(refsettlement_filter.parse::<u64>().unwrap());
+    let refsettlement_arc = Arc::new(refsettlement_filter.to_string());
     let refsettlement_filter = refsettlement_arc;
     Box::new(move |_complete, relation| {
         let config = relation.get_config();
         config.get_refcounty() == refcounty_filter.as_str()
-            && config.get_osmrelation().eq(refsettlement_filter.as_ref())
+            && config.get_refsettlement() == refsettlement_filter.as_str()
     })
 }
 

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -666,6 +666,9 @@ class TestMain(TestWsgi):
         root = self.get_dom_for_path("/filter-for/refcounty/01/refsettlement/011")
         results = root.findall("body/table")
         self.assertEqual(len(results), 1)
+        results = root.findall("body/table/tr")
+        # header + 5 relations, was just 1 when the filter was buggy
+        self.assertEqual(len(results), 6)
 
     def test_filter_for_relations(self) -> None:
         """Tests if the /osm/filter-for/relations/... output is well-formed."""


### PR DESCRIPTION
Compare osm vs ref settlement, not the relation id.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/1740>.

Change-Id: Ifbbc5630c6f1e8702decd5dfce0c2a09f002f984
