### PR TITLE
util: fix localization setup

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -3,6 +3,8 @@
 == master
 
 - Resolves: gh#1664 re-try overpass when response is XML (an error message) and CSV was requested
+- Resolves: gh#1740 fix /filter-for/refcounty/../refsettlement/.. filtering out everything
+- Resolves: gh#1746 fix disappeared localized strings
 
 == 7.2
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1056,7 +1056,7 @@ fn py_handle_overpass_error(
 pub fn setup_localization(headers: &[(String, String)]) -> String {
     let mut languages: String = "".into();
     for (key, value) in headers {
-        if key == "HTTP_ACCEPT_LANGUAGE" {
+        if key == "Accept-Language" {
             languages = value.into();
         }
     }

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -55,14 +55,14 @@ class TestSetupLocalization(unittest.TestCase):
     """Tests setup_localization()."""
     def test_happy(self) -> None:
         """Tests the happy path."""
-        environ = {"HTTP_ACCEPT_LANGUAGE": "hu,en;q=0.9,en-US;q=0.8"}
+        environ = {"Accept-Language": "hu,en;q=0.9,en-US;q=0.8"}
         rust.py_set_language("en")
         util.setup_localization(list(environ.items()))
         self.assertEqual(rust.py_get_language(), "hu")
 
     def test_parse_error(self) -> None:
         """Tests the error path."""
-        environ = {"HTTP_ACCEPT_LANGUAGE": ","}
+        environ = {"Accept-Language": ","}
         rust.py_set_language("en")
         util.setup_localization(list(environ.items()))
         self.assertEqual(rust.py_get_language(), "en")


### PR DESCRIPTION
Cherrypy used to map the Accept-Language request header to
HTTP_ACCEPT_LANGUAGE, but rouille exposes it as-is. Adapt the tests to
mimic what rouille sends and the fix the failing code.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/1746>.

Change-Id: Iea5dc364f373ce921a1828b746dda5e2be9f8024
