### PR TITLE
util: optimize sort_numerically()

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1350,11 +1350,7 @@ pub fn git_link(version: &str, prefix: &str) -> yattag::Doc {
 /// Sorts strings according to their numerical value, not alphabetically.
 pub fn sort_numerically(strings: &[HouseNumber]) -> Vec<HouseNumber> {
     let mut ret: Vec<HouseNumber> = strings.to_owned();
-    ret.sort_by(|a, b| {
-        let a_key = split_house_number(a.get_number());
-        let b_key = split_house_number(b.get_number());
-        a_key.cmp(&b_key)
-    });
+    ret.sort_by_cached_key(|i| split_house_number(i.get_number()));
     ret
 }
 


### PR DESCRIPTION
'target/release/missing_housenumbers budapest_11' goes from 221 ms to
195 ms, i.e. 88% of the baseline (19% of Python).

Change-Id: I7266be420ec793b1c3f0e6e6ce9152186555ba7f
