### PR TITLE
Port up to tests.test_areas.TestRelationBuildRefHousenumbers.test_missing()

### DIFF
--- a/rust.pyi
+++ b/rust.pyi
@@ -311,10 +311,6 @@ def py_build_street_reference_cache(local_streets: str) -> Dict[str, Dict[str, L
     """Builds an in-memory cache from the reference on-disk TSV (street version)."""
     ...
 
-def py_build_reference_cache(local: str, refcounty: str) -> Dict[str, Dict[str, Dict[str, List[api.HouseNumberWithComment]]]]:
-    """Builds an in-memory cache from the reference on-disk TSV (house number version)."""
-    ...
-
 def py_get_content(path: str) -> bytes:
     """Gets the content of a file in workdir."""
     ...
@@ -533,10 +529,6 @@ class PyRelation:
         from OSM. Uses build_reference_cache() to build an indexed reference, the result will be
         used by get_ref_housenumbers().
         """
-        ...
-
-    def write_missing_streets(self) -> Tuple[int, int, str, List[str]]:
-        """Calculate and write stat for the street coverage of a relation."""
         ...
 
     def write_additional_streets(self) -> List[PyStreet]:

--- a/src/context.rs
+++ b/src/context.rs
@@ -1119,6 +1119,14 @@ pub mod tests {
             }
         }
 
+        pub fn make_file() -> Arc<Mutex<std::io::Cursor<Vec<u8>>>> {
+            Arc::new(Mutex::new(std::io::Cursor::new(Vec::new())))
+        }
+
+        pub fn make_files() -> HashMap<String, Arc<Mutex<std::io::Cursor<Vec<u8>>>>> {
+            HashMap::new()
+        }
+
         /// Sets the hide paths.
         pub fn set_hide_paths(&mut self, hide_paths: &[String]) {
             self.hide_paths = hide_paths.to_vec();

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -396,8 +396,8 @@ pub fn register_python_symbols(module: &PyModule) -> PyResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
     use std::sync::Arc;
-    use std::sync::Mutex;
 
     fn make_test_time_old() -> context::tests::TestTime {
         context::tests::TestTime::new(1970, 1, 1)
@@ -474,9 +474,13 @@ mod tests {
         let today_citycount = b"budapest_01\t100\n\
 budapest_02\t200\n\
 \t42\n";
-        let today_citycount_value: Arc<Mutex<std::io::Cursor<Vec<u8>>>> =
-            Arc::new(Mutex::new(std::io::Cursor::new(today_citycount.to_vec())));
-        let mut files: HashMap<String, Arc<Mutex<std::io::Cursor<Vec<u8>>>>> = HashMap::new();
+        let today_citycount_value = context::tests::TestFileSystem::make_file();
+        today_citycount_value
+            .lock()
+            .unwrap()
+            .write_all(today_citycount)
+            .unwrap();
+        let mut files = context::tests::TestFileSystem::make_files();
         files.insert(
             ctx.get_abspath("workdir/stats/2020-05-10.citycount")
                 .unwrap(),

--- a/src/util.rs
+++ b/src/util.rs
@@ -831,7 +831,7 @@ pub type HouseNumberReferenceCache =
     HashMap<String, HashMap<String, HashMap<String, Vec<HouseNumberWithComment>>>>;
 
 /// Builds an in-memory cache from the reference on-disk TSV (house number version).
-fn build_reference_cache(
+pub fn build_reference_cache(
     local: &str,
     refcounty: &str,
 ) -> anyhow::Result<HouseNumberReferenceCache> {
@@ -883,20 +883,6 @@ fn build_reference_cache(
     serde_json::to_writer(&stream, &memory_cache)?;
 
     Ok(memory_cache)
-}
-
-#[pyfunction]
-fn py_build_reference_cache(
-    local: String,
-    refcounty: String,
-) -> PyResult<HouseNumberReferenceCache> {
-    match build_reference_cache(&local, &refcounty) {
-        Ok(value) => Ok(value),
-        Err(err) => Err(pyo3::exceptions::PyOSError::new_err(format!(
-            "build_reference_cache() failed: {}",
-            err.to_string()
-        ))),
-    }
 }
 
 /// Handles a list of references for build_reference_cache().
@@ -1494,7 +1480,6 @@ pub fn register_python_symbols(module: &PyModule) -> PyResult<()> {
         py_build_street_reference_cache,
         module
     )?)?;
-    module.add_function(pyo3::wrap_pyfunction!(py_build_reference_cache, module)?)?;
     module.add_function(pyo3::wrap_pyfunction!(py_get_content, module)?)?;
     Ok(())
 }

--- a/util.py
+++ b/util.py
@@ -9,18 +9,12 @@
 from typing import Dict
 from typing import List
 
-import api
 import rust
 
 
 def build_street_reference_cache(local_streets: str) -> Dict[str, Dict[str, List[str]]]:
     """Builds an in-memory cache from the reference on-disk TSV (street version)."""
     return rust.py_build_street_reference_cache(local_streets)
-
-
-def build_reference_cache(local: str, refcounty: str) -> Dict[str, Dict[str, Dict[str, List[api.HouseNumberWithComment]]]]:
-    """Builds an in-memory cache from the reference on-disk TSV (house number version)."""
-    return rust.py_build_reference_cache(local, refcounty)
 
 
 def get_content(path: str) -> bytes:


### PR DESCRIPTION
Change-Id: I22aa1ecd286fdd6f60c7e2e6c373ea6dc51c9742
