### PR TITLE
Revert "fix indent"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,14 +104,12 @@ ifndef V
 	QUIET_PYLINT = @echo '   ' PYLINT $@;
 	QUIET_ESLINT = @echo '   ' ESLINT $@;
 	QUIET_VALIDATOR = @echo '   ' VALIDATOR $@;
-	QUIET_YAMLLINT = @echo '   ' YAMLLINT $@;
 endif
 
 all: rust.so builddir/bundle.js css wsgi.ini data/yamls.cache locale/hu/LC_MESSAGES/osm-gimmisn.mo $(foreach BINARY_CRATE,$(BINARY_CRATES),target/$(TARGET_PATH)/$(BINARY_CRATE))
 
 clean:
 	rm -f config.ts
-	rm -f $(patsubst %.yaml,%.yamllint,$(filter-out .github/workflows/tests.yml,$(YAML_OBJECTS)))
 	rm -f $(patsubst %.yaml,%.validyaml,$(YAML_SAFE_OBJECTS))
 	rm -f $(patsubst %.py,%.flake8,$(PYTHON_OBJECTS))
 	rm -f $(patsubst %.py,%.pylint,$(PYTHON_OBJECTS))
@@ -187,10 +185,6 @@ data/yamls.cache: target/${TARGET_PATH}/cache_yamls rust.so $(YAML_OBJECTS)
 tests/data/yamls.cache: target/${TARGET_PATH}/cache_yamls rust.so $(YAML_TEST_OBJECTS)
 	target/${TARGET_PATH}/cache_yamls tests/data tests/workdir
 
-check-filters: check-filters-syntax check-filters-schema
-
-check-filters-syntax: $(patsubst %.yaml,%.yamllint,$(YAML_OBJECTS))
-
 check-flake8: $(patsubst %.py,%.flake8,$(PYTHON_OBJECTS))
 
 check-pylint: $(patsubst %.py,%.pylint,$(PYTHON_OBJECTS))
@@ -209,13 +203,10 @@ check-mypy: $(PYTHON_OBJECTS)
 %.flake8: %.py Makefile setup.cfg
 	$(QUIET_FLAKE8)flake8 $< && touch $@
 
-check-filters-schema: $(patsubst %.yaml,%.validyaml,$(YAML_SAFE_OBJECTS))
+check-filters: $(patsubst %.yaml,%.validyaml,$(YAML_SAFE_OBJECTS))
 
 %.validyaml : %.yaml validator.py
 	$(QUIET_VALIDATOR)./validator.py $< && touch $@
-
-%.yamllint : %.yaml Makefile .yamllint
-	$(QUIET_YAMLLINT)yamllint --strict $< && touch $@
 
 # Make sure that the current directory is *not* the repo root but something else to catch
 # non-absolute paths.

--- a/data/relation-balatonoszod.yaml
+++ b/data/relation-balatonoszod.yaml
@@ -38,8 +38,8 @@ filters:
     # 86: sima 86 nincs, csak 86/A, 86/B.
     # 174: a páros oldalon a 172 az utolsó házszám.
     invalid: ['13a', '61/1', '75', '2a', '40a', '42', '86', '174']
-# Szabadság tér:
-#   2: nem találtam meg, nincs kitáblázva.
+  # Szabadság tér:
+  #   2: nem találtam meg, nincs kitáblázva.
 street-filters:
   # hiányzók
   # Kismetszés köz

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ mypy==0.812
 pylint==2.9.3
 pyyaml==5.4.1
 unidecode==1.2.0
-yamllint==1.26.1


### PR DESCRIPTION
This reverts commit 42397f24fffe0ef35a86acc05f930cca1098664f. It was
only a workaround to please yamllint, but now yamllint is broken on
Windows with python-3.10, so rather restore the correct indent and drop
yamllint.

The validator will do a parsing check check on the yaml files anyway.

Change-Id: Icb3083100cd7494eabd84c964d6538b65493a8fd
