### PR TITLE
areas: trim start/end of range before convert to number

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -531,6 +531,7 @@ impl Relation {
                         .unwrap()
                         .as_str()
                         .unwrap()
+                        .trim()
                         .parse::<i64>()
                         .unwrap();
                     let end = start_end_obj
@@ -538,6 +539,7 @@ impl Relation {
                         .unwrap()
                         .as_str()
                         .unwrap()
+                        .trim()
                         .parse::<i64>()
                         .unwrap();
                     i.push(ranges::Range::new(start, end, interpolation));


### PR DESCRIPTION
It seems Python accepted a whitespace suffix, but Rust does not.

data/relation-balatonalmadi-budatava.yaml:36:      - {start: '18', end: '198    '}

Just adjust the Rust side for now.

Change-Id: I1f7d666918cd0850648629bdd97f6965c05195b8
