### PR TITLE
validator: reject number in string with whitespace

### DIFF
--- a/tests/data/relation-gazdagret-filter-range-bad-end2.yaml
+++ b/tests/data/relation-gazdagret-filter-range-bad-end2.yaml
@@ -1,0 +1,4 @@
+filters:
+  'Budaörsi út':
+    ranges:
+      - {start: '137', end: '165 '}

--- a/tests/data/relation-gazdagret-filter-range-bad-start2.yaml
+++ b/tests/data/relation-gazdagret-filter-range-bad-start2.yaml
@@ -1,0 +1,4 @@
+filters:
+  'Budaörsi út':
+    ranges:
+      - {start: '137 ', end: '165'}

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -153,7 +153,7 @@ class TestValidatorMainFailureMsg1(TestValidatorMainFailureMsgBase):
     def test_relation_filters_ranges_bad_end(self) -> None:
         """Tests the relation path: bad filters -> ... -> ranges -> end type."""
         expected = "failed to validate tests/data/relation-gazdagret-filter-range-bad-end.yaml"
-        expected += ": expected value type for 'filters.Budaörsi út.ranges[0].end' is str\n"
+        expected += ": expected value type for 'filters.Budaörsi út.ranges[0].end' is a digit str\n"
         expected += "failed to validate tests/data/relation-gazdagret-filter-range-bad-end.yaml"
         expected += ": expected end >= start for 'filters.Budaörsi út.ranges[0]'\n"
         expected += "failed to validate tests/data/relation-gazdagret-filter-range-bad-end.yaml"
@@ -175,7 +175,7 @@ class TestValidatorMainFailureMsg1(TestValidatorMainFailureMsgBase):
     def test_relation_filters_ranges_bad_start(self) -> None:
         """Tests the relation path: bad filters -> ... -> ranges -> start type."""
         expected = "failed to validate tests/data/relation-gazdagret-filter-range-bad-start.yaml"
-        expected += ": expected value type for 'filters.Budaörsi út.ranges[0].start' is str\n"
+        expected += ": expected value type for 'filters.Budaörsi út.ranges[0].start' is a digit str\n"
         expected += "failed to validate tests/data/relation-gazdagret-filter-range-bad-start.yaml"
         expected += ": expected start % 2 == end % 2 for 'filters.Budaörsi út.ranges[0]'\n"
         self.assert_failure_msg("tests/data/relation-gazdagret-filter-range-bad-start.yaml", expected)
@@ -242,6 +242,18 @@ class TestValidatorMainFailureMsg2(TestValidatorMainFailureMsgBase):
         expected = "failed to validate tests/data/relation-gazdagret-filter-valid-bad-type.yaml"
         expected += ": expected value type for 'filters.Budaörsi út.valid' is list\n"
         self.assert_failure_msg("tests/data/relation-gazdagret-filter-valid-bad-type.yaml", expected)
+
+    def test_start_whitespace(self) -> None:
+        """Tests that we do not accept whitespace in the value of the 'start' key."""
+        expected = "failed to validate tests/data/relation-gazdagret-filter-range-bad-start2.yaml"
+        expected += ": expected value type for 'filters.Budaörsi út.ranges[0].start' is a digit str\n"
+        self.assert_failure_msg("tests/data/relation-gazdagret-filter-range-bad-start2.yaml", expected)
+
+    def test_end_whitespace(self) -> None:
+        """Tests that we do not accept whitespace in the value of the 'end' key."""
+        expected = "failed to validate tests/data/relation-gazdagret-filter-range-bad-end2.yaml"
+        expected += ": expected value type for 'filters.Budaörsi út.ranges[0].end' is a digit str\n"
+        self.assert_failure_msg("tests/data/relation-gazdagret-filter-range-bad-end2.yaml", expected)
 
 
 if __name__ == '__main__':

--- a/validator.py
+++ b/validator.py
@@ -53,11 +53,13 @@ def validate_range(errors: List[str], parent: str, range_data: Dict[str, Any], f
     context = parent + "."
     for key, value in range_data.items():
         if key == "start":
-            if not isinstance(value, str):
-                errors.append("expected value type for '%s%s' is str" % (context, key))
+            # Require a string that can be converted to a number. Whitespace around the number is no
+            # OK.
+            if not isinstance(value, str) or not str.isdigit(value):
+                errors.append("expected value type for '%s%s' is a digit str" % (context, key))
         elif key == "end":
-            if not isinstance(value, str):
-                errors.append("expected value type for '%s%s' is str" % (context, key))
+            if not isinstance(value, str) or not str.isdigit(value):
+                errors.append("expected value type for '%s%s' is a digit str" % (context, key))
         elif key == "refsettlement":
             if not isinstance(value, str):
                 errors.append("expected value type for '%s%s' is str" % (context, key))


### PR DESCRIPTION
It works with Python's int("42 "), but doing the same is an error with
Rust.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/1815>.

Change-Id: Ib76b3356e14cf4431c6c20254770cdd23764e370
