### PR TITLE
Rename the 'rust' lib crate to 'osm-gimmisn'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust"
+name = "osm-gimmisn"
 version = "7.2.0"
 edition = "2018"
 

--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,10 @@ check-clippy: Cargo.toml $(RS_OBJECTS)
 	cargo clippy ${CARGO_OPTIONS} && touch $@
 
 $(foreach BINARY_CRATE,$(BINARY_CRATES),target/${TARGET_PATH}/$(BINARY_CRATE)) &: $(RS_OBJECTS) Cargo.toml Makefile
-	cargo build $(foreach BINARY_CRATE,$(BINARY_CRATES),--bin $(BINARY_CRATE)) ${CARGO_OPTIONS} --no-default-features
+	cargo build $(foreach BINARY_CRATE,$(BINARY_CRATES),--bin $(BINARY_CRATE)) ${CARGO_OPTIONS}
 
 check-unit: Cargo.toml $(RS_OBJECTS) locale/hu/LC_MESSAGES/osm-gimmisn.mo testdata data/yamls.cache
-	cargo test --lib --no-default-features ${CARGO_OPTIONS} -- --test-threads=1
+	cargo test --lib ${CARGO_OPTIONS} -- --test-threads=1
 
 config.ts: wsgi.ini Makefile
 	printf 'const uriPrefix = "%s";\nexport { uriPrefix };\n' $(shell grep prefix wsgi.ini |sed 's/uri_prefix = //') > $@

--- a/src/bin/cache_yamls.rs
+++ b/src/bin/cache_yamls.rs
@@ -12,8 +12,8 @@
 
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
-    let ctx = rust::context::Context::new("")?;
-    rust::cache_yamls::main(&args, &ctx)?;
+    let ctx = osm_gimmisn::context::Context::new("")?;
+    osm_gimmisn::cache_yamls::main(&args, &ctx)?;
 
     Ok(())
 }

--- a/src/bin/cron.rs
+++ b/src/bin/cron.rs
@@ -12,9 +12,9 @@
 
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
-    let ctx = rust::context::Context::new("")?;
-    rust::cron::setup_logging(&ctx)?;
-    rust::cron::main(&args, &mut std::io::stdout(), &ctx)?;
+    let ctx = osm_gimmisn::context::Context::new("")?;
+    osm_gimmisn::cron::setup_logging(&ctx)?;
+    osm_gimmisn::cron::main(&args, &mut std::io::stdout(), &ctx)?;
 
     Ok(())
 }

--- a/src/bin/missing_housenumbers.rs
+++ b/src/bin/missing_housenumbers.rs
@@ -12,8 +12,8 @@
 
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
-    let ctx = rust::context::Context::new("")?;
-    rust::missing_housenumbers::main(&args, &mut std::io::stdout(), &ctx)?;
+    let ctx = osm_gimmisn::context::Context::new("")?;
+    osm_gimmisn::missing_housenumbers::main(&args, &mut std::io::stdout(), &ctx)?;
 
     Ok(())
 }

--- a/src/bin/parse_access_log.rs
+++ b/src/bin/parse_access_log.rs
@@ -12,8 +12,8 @@
 
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
-    let ctx = rust::context::Context::new("")?;
-    rust::parse_access_log::main(&args, &mut std::io::stdout(), &ctx)?;
+    let ctx = osm_gimmisn::context::Context::new("")?;
+    osm_gimmisn::parse_access_log::main(&args, &mut std::io::stdout(), &ctx)?;
 
     Ok(())
 }

--- a/src/bin/rouille.rs
+++ b/src/bin/rouille.rs
@@ -10,13 +10,13 @@
 
 //! Provides the glue layer between the Rouille app server and the wsgi module.
 
-use rust::wsgi;
+use osm_gimmisn::wsgi;
 use std::collections::HashMap;
 use std::io::Read;
 
 /// Wraps wsgi::application() to an app for rouille.
 fn app(request: &rouille::Request) -> anyhow::Result<rouille::Response> {
-    let ctx = rust::context::Context::new("")?;
+    let ctx = osm_gimmisn::context::Context::new("")?;
     let mut request_headers: HashMap<String, String> = HashMap::new();
     for (key, value) in request.headers() {
         request_headers.insert(key.to_string(), value.to_string());
@@ -60,7 +60,7 @@ fn app(request: &rouille::Request) -> anyhow::Result<rouille::Response> {
 /// ProxyPass / http://127.0.0.1:8000/
 /// ProxyPassReverse / http://127.0.0.1:8000/
 fn main() -> anyhow::Result<()> {
-    let ctx = rust::context::Context::new("")?;
+    let ctx = osm_gimmisn::context::Context::new("")?;
     let port = ctx.get_ini().get_tcp_port()?;
     let prefix = ctx.get_ini().get_uri_prefix()?;
     // TODO no matching stop message.

--- a/src/bin/validator.rs
+++ b/src/bin/validator.rs
@@ -12,7 +12,7 @@
 
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
-    rust::validator::main(&args, &mut std::io::stdout())?;
+    osm_gimmisn::validator::main(&args, &mut std::io::stdout())?;
 
     Ok(())
 }


### PR DESCRIPTION
This initially made sense when the majority of it was Python, but not
anymore.

Also drop some --no-default-features from the Makefile, that was only
necessary for pyo3.

Change-Id: I1d7c352a6643c49f8c08a8c4e66a2dfa2cf583fd
