### PR TITLE
Add a way to build on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ lazy_static = "1.4.0"
 log = "0.4.14"
 regex = "1.5.4"
 rouille = "3.3.1"
-rust_icu_ucol = "1.0.1"
-rust_icu_ustring = "1.0.1"
+rust_icu_ucol = { version = "1.0.1", optional = true }
+rust_icu_ustring = { version = "1.0.1", optional = true }
 serde = "1.0.129"
 serde_json = "1.0.66"
 serde_yaml = "0.8.21"
@@ -31,6 +31,10 @@ sxd-xpath = "0.4.2"
 unidecode = "0.3.0"
 url = "2.2.2"
 utime = "0.3.1"
+
+[features]
+icu = ["rust_icu_ucol", "rust_icu_ustring"]
+default = ["icu"]
 
 # Enable symbols (for callgrind):
 # [profile.release]

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -40,6 +40,24 @@ make
 
 Populate the reference directory with TSV files for the house number and street list.
 
+== Install steps (Windows)
+
+- Install `git` and `cargo`.
+
+- Open e.g. the Command Prompt and clone the repo (see above).
+
+- Build the validator:
+
+----
+cargo build --bin validator --release --no-default-features
+----
+
+- Run the validator:
+
+----
+target\release\validator.exe data\relation-budapest_11.yaml
+----
+
 == Developer setup
 
 ----

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,8 +19,6 @@ use crate::yattag;
 use anyhow::anyhow;
 use anyhow::Context;
 use lazy_static::lazy_static;
-use rust_icu_ucol as ucol;
-use rust_icu_ustring as ustring;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::TryFrom;
@@ -1149,11 +1147,21 @@ pub fn get_city_key(
 }
 
 /// Returns a string comparator which allows locale-aware lexical sorting.
+#[cfg(feature = "icu")]
 pub fn get_sort_key(bytes: &str) -> anyhow::Result<Vec<u8>> {
+    use rust_icu_ucol as ucol;
+    use rust_icu_ustring as ustring;
+
     // This is good enough for now, English and Hungarian is all we support and this handles both.
     let collator = ucol::UCollator::try_from("hu")?;
     let string = ustring::UChar::try_from(bytes)?;
     Ok(collator.get_sort_key(&string))
+}
+
+/// Returns the intput as-is to avoid depending on ICU.
+#[cfg(not(feature = "icu"))]
+pub fn get_sort_key(bytes: &str) -> anyhow::Result<Vec<u8>> {
+    Ok(bytes.as_bytes().to_vec())
 }
 
 /// Builds a set of valid settlement names.


### PR DESCRIPTION
The primary motivation is to invoke the validator before pushing. Avoid
ICU for now, since the validator doesn't need it, and it's complicated
to build it on Windows.

Sample output:

https://share.vmiklos.hu/osm-gimmisn/validator-v7.2-293-g109ab66c.exe

Change-Id: I1f66bc6d0eb4fa2e99fa04829a80e606b23475c0
