### PR TITLE
Simplify RelationFiles::get_ref_streets_path()

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -12,7 +12,6 @@
 
 use crate::context;
 use crate::i18n;
-use anyhow::anyhow;
 use anyhow::Context;
 use std::io::Read;
 use std::io::Write;
@@ -35,117 +34,74 @@ impl RelationFiles {
     }
 
     /// Build the file name of the reference street list of a relation.
-    pub fn get_ref_streets_path(&self) -> anyhow::Result<String> {
-        let path = std::path::Path::new(&self.workdir);
-        Ok(path
-            .join(format!("streets-reference-{}.lst", self.name))
-            .to_str()
-            .ok_or_else(|| anyhow!("cannot convert path to string"))?
-            .into())
+    pub fn get_ref_streets_path(&self) -> String {
+        format!("{}/streets-reference-{}.lst", self.workdir, self.name)
     }
 
     /// Build the file name of the OSM street list of a relation.
-    pub fn get_osm_streets_path(&self) -> anyhow::Result<String> {
-        let path = std::path::Path::new(&self.workdir);
-        Ok(path
-            .join(format!("streets-{}.csv", self.name))
-            .to_str()
-            .ok_or_else(|| anyhow!("cannot convert path to string"))?
-            .into())
+    pub fn get_osm_streets_path(&self) -> String {
+        format!("{}/streets-{}.csv", self.workdir, self.name)
     }
 
     /// Build the file name of the OSM house number list of a relation.
-    pub fn get_osm_housenumbers_path(&self) -> anyhow::Result<String> {
-        let path = std::path::Path::new(&self.workdir);
-        Ok(path
-            .join(format!("street-housenumbers-{}.csv", self.name))
-            .to_str()
-            .ok_or_else(|| anyhow!("cannot convert path to string"))?
-            .into())
+    pub fn get_osm_housenumbers_path(&self) -> String {
+        format!("{}/street-housenumbers-{}.csv", self.workdir, self.name)
     }
 
     /// Build the file name of the reference house number list of a relation.
-    pub fn get_ref_housenumbers_path(&self) -> anyhow::Result<String> {
-        let path = std::path::Path::new(&self.workdir);
-        Ok(path
-            .join(format!("street-housenumbers-reference-{}.lst", self.name))
-            .to_str()
-            .ok_or_else(|| anyhow!("cannot convert path to string"))?
-            .into())
+    pub fn get_ref_housenumbers_path(&self) -> String {
+        format!(
+            "{}/street-housenumbers-reference-{}.lst",
+            self.workdir, self.name
+        )
     }
 
     /// Builds the file name of the house number percent file of a relation.
-    pub fn get_housenumbers_percent_path(&self) -> anyhow::Result<String> {
-        let path = std::path::Path::new(&self.workdir);
-        Ok(path
-            .join(format!("{}.percent", self.name))
-            .to_str()
-            .ok_or_else(|| anyhow!("cannot convert path to string"))?
-            .into())
+    pub fn get_housenumbers_percent_path(&self) -> String {
+        format!("{}/{}.percent", self.workdir, self.name)
     }
 
     /// Builds the file name of the house number HTML cache file of a relation.
-    pub fn get_housenumbers_htmlcache_path(&self) -> anyhow::Result<String> {
-        let path = std::path::Path::new(&self.workdir);
-        Ok(path
-            .join(format!("{}.htmlcache.{}", self.name, i18n::get_language()))
-            .to_str()
-            .ok_or_else(|| anyhow!("cannot convert path to string"))?
-            .into())
+    pub fn get_housenumbers_htmlcache_path(&self) -> String {
+        format!(
+            "{}/{}.htmlcache.{}",
+            self.workdir,
+            self.name,
+            i18n::get_language()
+        )
     }
 
     /// Builds the file name of the house number plain text cache file of a relation.
-    pub fn get_housenumbers_txtcache_path(&self) -> anyhow::Result<String> {
-        let path = std::path::Path::new(&self.workdir);
-        Ok(path
-            .join(format!("{}.txtcache", self.name))
-            .to_str()
-            .ok_or_else(|| anyhow!("cannot convert path to string"))?
-            .into())
+    pub fn get_housenumbers_txtcache_path(&self) -> String {
+        format!("{}/{}.txtcache", self.workdir, self.name)
     }
 
     /// Builds the file name of the street percent file of a relation.
-    pub fn get_streets_percent_path(&self) -> anyhow::Result<String> {
-        let path = std::path::Path::new(&self.workdir);
-        Ok(path
-            .join(format!("{}-streets.percent", self.name))
-            .to_str()
-            .ok_or_else(|| anyhow!("cannot convert path to string"))?
-            .into())
+    pub fn get_streets_percent_path(&self) -> String {
+        format!("{}/{}-streets.percent", self.workdir, self.name)
     }
 
     /// Builds the file name of the street additional count file of a relation.
-    pub fn get_streets_additional_count_path(&self) -> anyhow::Result<String> {
-        let path = std::path::Path::new(&self.workdir);
-        Ok(path
-            .join(format!("{}-additional-streets.count", self.name))
-            .to_str()
-            .ok_or_else(|| anyhow!("cannot convert path to string"))?
-            .into())
+    pub fn get_streets_additional_count_path(&self) -> String {
+        format!("{}/{}-additional-streets.count", self.workdir, self.name)
     }
 
     /// Builds the file name of the housenumber additional count file of a relation.
-    pub fn get_housenumbers_additional_count_path(&self) -> anyhow::Result<String> {
-        let path = std::path::Path::new(&self.workdir);
-        Ok(path
-            .join(format!("{}-additional-housenumbers.count", self.name))
-            .to_str()
-            .ok_or_else(|| anyhow!("cannot convert path to string"))?
-            .into())
+    pub fn get_housenumbers_additional_count_path(&self) -> String {
+        format!(
+            "{}/{}-additional-housenumbers.count",
+            self.workdir, self.name
+        )
     }
 
     /// Builds the file name of the additional house number HTML cache file of a relation.
-    pub fn get_additional_housenumbers_htmlcache_path(&self) -> anyhow::Result<String> {
-        let path = std::path::Path::new(&self.workdir);
-        Ok(path
-            .join(format!(
-                "{}.additional-htmlcache.{}",
-                self.name,
-                i18n::get_language()
-            ))
-            .to_str()
-            .ok_or_else(|| anyhow!("cannot convert path to string"))?
-            .into())
+    pub fn get_additional_housenumbers_htmlcache_path(&self) -> String {
+        format!(
+            "{}/{}.additional-htmlcache.{}",
+            self.workdir,
+            self.name,
+            i18n::get_language()
+        )
     }
 
     /// Opens the reference street list of a relation for reading.
@@ -153,7 +109,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Read + Send>>> {
-        let path = self.get_ref_streets_path()?;
+        let path = self.get_ref_streets_path();
         ctx.get_file_system().open_read(&path)
     }
 
@@ -162,7 +118,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Write + Send>>> {
-        let path = self.get_ref_streets_path()?;
+        let path = self.get_ref_streets_path();
         ctx.get_file_system().open_write(&path)
     }
 
@@ -171,7 +127,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Read + Send>>> {
-        let path = self.get_osm_streets_path()?;
+        let path = self.get_osm_streets_path();
         ctx.get_file_system().open_read(&path)
     }
 
@@ -180,7 +136,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Read + Send>>> {
-        let path = self.get_osm_housenumbers_path()?;
+        let path = self.get_osm_housenumbers_path();
         ctx.get_file_system().open_read(&path)
     }
 
@@ -189,7 +145,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Read + Send>>> {
-        let path = self.get_ref_housenumbers_path()?;
+        let path = self.get_ref_housenumbers_path();
         ctx.get_file_system().open_read(&path)
     }
 
@@ -198,7 +154,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Write + Send>>> {
-        let path = self.get_ref_housenumbers_path()?;
+        let path = self.get_ref_housenumbers_path();
         ctx.get_file_system()
             .open_write(&path)
             .context("open_write() failed")
@@ -209,7 +165,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Read + Send>>> {
-        let path = self.get_housenumbers_percent_path()?;
+        let path = self.get_housenumbers_percent_path();
         ctx.get_file_system().open_read(&path)
     }
 
@@ -218,7 +174,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Write + Send>>> {
-        let path = self.get_housenumbers_percent_path()?;
+        let path = self.get_housenumbers_percent_path();
         ctx.get_file_system()
             .open_write(&path)
             .with_context(|| format!("failed to open {} for writing", path))
@@ -229,7 +185,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Read + Send>>> {
-        let path = self.get_housenumbers_htmlcache_path()?;
+        let path = self.get_housenumbers_htmlcache_path();
         ctx.get_file_system().open_read(&path)
     }
 
@@ -238,7 +194,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Write + Send>>> {
-        let path = self.get_housenumbers_htmlcache_path()?;
+        let path = self.get_housenumbers_htmlcache_path();
         ctx.get_file_system().open_write(&path)
     }
 
@@ -247,7 +203,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Read + Send>>> {
-        let path = self.get_housenumbers_txtcache_path()?;
+        let path = self.get_housenumbers_txtcache_path();
         ctx.get_file_system().open_read(&path)
     }
 
@@ -256,7 +212,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Write + Send>>> {
-        let path = self.get_housenumbers_txtcache_path()?;
+        let path = self.get_housenumbers_txtcache_path();
         ctx.get_file_system().open_write(&path)
     }
 
@@ -265,7 +221,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Read + Send>>> {
-        let path = self.get_streets_percent_path()?;
+        let path = self.get_streets_percent_path();
         ctx.get_file_system().open_read(&path)
     }
 
@@ -274,7 +230,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Write + Send>>> {
-        let path = self.get_streets_percent_path()?;
+        let path = self.get_streets_percent_path();
         ctx.get_file_system().open_write(&path)
     }
 
@@ -283,7 +239,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Read + Send>>> {
-        let path = self.get_streets_additional_count_path()?;
+        let path = self.get_streets_additional_count_path();
         ctx.get_file_system().open_read(&path)
     }
 
@@ -292,7 +248,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Write + Send>>> {
-        let path = self.get_streets_additional_count_path()?;
+        let path = self.get_streets_additional_count_path();
         ctx.get_file_system().open_write(&path)
     }
 
@@ -301,7 +257,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Read + Send>>> {
-        let path = self.get_housenumbers_additional_count_path()?;
+        let path = self.get_housenumbers_additional_count_path();
         ctx.get_file_system().open_read(&path)
     }
 
@@ -310,7 +266,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Write + Send>>> {
-        let path = self.get_housenumbers_additional_count_path()?;
+        let path = self.get_housenumbers_additional_count_path();
         ctx.get_file_system().open_write(&path)
     }
 
@@ -319,7 +275,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Write + Send>>> {
-        let path = self.get_osm_streets_path()?;
+        let path = self.get_osm_streets_path();
         ctx.get_file_system().open_write(&path)
     }
 
@@ -340,7 +296,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Write + Send>>> {
-        let path = self.get_osm_housenumbers_path()?;
+        let path = self.get_osm_housenumbers_path();
         ctx.get_file_system().open_write(&path)
     }
 
@@ -365,7 +321,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Read + Send>>> {
-        let path = self.get_additional_housenumbers_htmlcache_path()?;
+        let path = self.get_additional_housenumbers_htmlcache_path();
         ctx.get_file_system().open_read(&path)
     }
 
@@ -374,7 +330,7 @@ impl RelationFiles {
         &self,
         ctx: &context::Context,
     ) -> anyhow::Result<Arc<Mutex<dyn Write + Send>>> {
-        let path = self.get_additional_housenumbers_htmlcache_path()?;
+        let path = self.get_additional_housenumbers_htmlcache_path();
         ctx.get_file_system().open_write(&path)
     }
 }

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -505,7 +505,7 @@ impl Relation {
             street.set_source(&tr("street"));
             ret.push(street)
         }
-        let path = self.file.get_osm_housenumbers_path()?;
+        let path = self.file.get_osm_housenumbers_path();
         if std::path::Path::new(&path).exists() {
             let stream: Arc<Mutex<dyn Read + Send>> =
                 self.file.get_osm_housenumbers_read_stream(&self.ctx)?;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -45,13 +45,13 @@ fn is_missing_housenumbers_html_cached(
     ctx: &context::Context,
     relation: &areas::Relation,
 ) -> anyhow::Result<bool> {
-    let cache_path = relation.get_files().get_housenumbers_htmlcache_path()?;
+    let cache_path = relation.get_files().get_housenumbers_htmlcache_path();
     let datadir = ctx.get_abspath("data")?;
     let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
     let dependencies = vec![
-        relation.get_files().get_osm_streets_path()?,
-        relation.get_files().get_osm_housenumbers_path()?,
-        relation.get_files().get_ref_housenumbers_path()?,
+        relation.get_files().get_osm_streets_path(),
+        relation.get_files().get_osm_housenumbers_path(),
+        relation.get_files().get_ref_housenumbers_path(),
         relation_path,
     ];
     is_cache_outdated(ctx, &cache_path, &dependencies)
@@ -64,13 +64,13 @@ fn is_additional_housenumbers_html_cached(
 ) -> anyhow::Result<bool> {
     let cache_path = relation
         .get_files()
-        .get_additional_housenumbers_htmlcache_path()?;
+        .get_additional_housenumbers_htmlcache_path();
     let datadir = ctx.get_abspath("data")?;
     let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
     let dependencies = vec![
-        relation.get_files().get_osm_streets_path()?,
-        relation.get_files().get_osm_housenumbers_path()?,
-        relation.get_files().get_ref_housenumbers_path()?,
+        relation.get_files().get_osm_streets_path(),
+        relation.get_files().get_osm_housenumbers_path(),
+        relation.get_files().get_ref_housenumbers_path(),
         relation_path,
     ];
     is_cache_outdated(ctx, &cache_path, &dependencies)
@@ -241,13 +241,13 @@ fn is_missing_housenumbers_txt_cached(
     ctx: &context::Context,
     relation: &areas::Relation,
 ) -> anyhow::Result<bool> {
-    let cache_path = relation.get_files().get_housenumbers_txtcache_path()?;
+    let cache_path = relation.get_files().get_housenumbers_txtcache_path();
     let datadir = ctx.get_abspath("data")?;
     let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
     let dependencies = vec![
-        relation.get_files().get_osm_streets_path()?,
-        relation.get_files().get_osm_housenumbers_path()?,
-        relation.get_files().get_ref_housenumbers_path()?,
+        relation.get_files().get_osm_streets_path(),
+        relation.get_files().get_osm_housenumbers_path(),
+        relation.get_files().get_ref_housenumbers_path(),
         relation_path,
     ];
     is_cache_outdated(ctx, &cache_path, &dependencies)
@@ -331,10 +331,7 @@ mod tests {
         let mut relations = areas::Relations::new(&ctx).unwrap();
         let mut relation = relations.get_relation("gazdagret").unwrap();
         get_missing_housenumbers_html(&ctx, &mut relation).unwrap();
-        let cache_path = relation
-            .get_files()
-            .get_housenumbers_htmlcache_path()
-            .unwrap();
+        let cache_path = relation.get_files().get_housenumbers_htmlcache_path();
 
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[cache_path]);
@@ -353,11 +350,8 @@ mod tests {
         let mut relations = areas::Relations::new(&ctx).unwrap();
         let mut relation = relations.get_relation("gazdagret").unwrap();
         get_missing_housenumbers_html(&ctx, &mut relation).unwrap();
-        let cache_path = relation
-            .get_files()
-            .get_housenumbers_htmlcache_path()
-            .unwrap();
-        let osm_housenumbers_path = relation.get_files().get_osm_housenumbers_path().unwrap();
+        let cache_path = relation.get_files().get_housenumbers_htmlcache_path();
+        let osm_housenumbers_path = relation.get_files().get_osm_housenumbers_path();
 
         let mut file_system = context::tests::TestFileSystem::new();
         let mut mtimes: HashMap<String, f64> = HashMap::new();
@@ -383,11 +377,8 @@ mod tests {
         let mut relations = areas::Relations::new(&ctx).unwrap();
         let mut relation = relations.get_relation("gazdagret").unwrap();
         get_missing_housenumbers_html(&ctx, &mut relation).unwrap();
-        let cache_path = relation
-            .get_files()
-            .get_housenumbers_htmlcache_path()
-            .unwrap();
-        let ref_housenumbers_path = relation.get_files().get_ref_housenumbers_path().unwrap();
+        let cache_path = relation.get_files().get_housenumbers_htmlcache_path();
+        let ref_housenumbers_path = relation.get_files().get_ref_housenumbers_path();
 
         let mut file_system = context::tests::TestFileSystem::new();
         let mut mtimes: HashMap<String, f64> = HashMap::new();
@@ -413,10 +404,7 @@ mod tests {
         let mut relations = areas::Relations::new(&ctx).unwrap();
         let mut relation = relations.get_relation("gazdagret").unwrap();
         get_missing_housenumbers_html(&ctx, &mut relation).unwrap();
-        let cache_path = relation
-            .get_files()
-            .get_housenumbers_htmlcache_path()
-            .unwrap();
+        let cache_path = relation.get_files().get_housenumbers_htmlcache_path();
         let datadir = ctx.get_abspath("data").unwrap();
         let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
 

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -75,7 +75,7 @@ fn update_osm_streets(
         .context("get_active_names() failed")?
     {
         let relation = relations.get_relation(&relation_name)?;
-        if !update && std::path::Path::new(&relation.get_files().get_osm_streets_path()?).exists() {
+        if !update && std::path::Path::new(&relation.get_files().get_osm_streets_path()).exists() {
             continue;
         }
         log::info!("update_osm_streets: start: {}", relation_name);
@@ -115,7 +115,7 @@ fn update_osm_housenumbers(
     for relation_name in relations.get_active_names()? {
         let relation = relations.get_relation(&relation_name)?;
         if !update
-            && std::path::Path::new(&relation.get_files().get_osm_housenumbers_path()?).exists()
+            && std::path::Path::new(&relation.get_files().get_osm_housenumbers_path()).exists()
         {
             continue;
         }
@@ -156,7 +156,7 @@ fn update_ref_housenumbers(
     for relation_name in relations.get_active_names()? {
         let relation = relations.get_relation(&relation_name)?;
         if !update
-            && std::path::Path::new(&relation.get_files().get_ref_housenumbers_path()?).exists()
+            && std::path::Path::new(&relation.get_files().get_ref_housenumbers_path()).exists()
         {
             continue;
         }
@@ -185,7 +185,7 @@ fn update_ref_streets(
 ) -> anyhow::Result<()> {
     for relation_name in relations.get_active_names()? {
         let relation = relations.get_relation(&relation_name)?;
-        if !update && std::path::Path::new(&relation.get_files().get_ref_streets_path()?).exists() {
+        if !update && std::path::Path::new(&relation.get_files().get_ref_streets_path()).exists() {
             continue;
         }
         let reference = ctx.get_ini().get_reference_street_path()?;
@@ -212,7 +212,7 @@ fn update_missing_housenumbers(
     for relation_name in relations.get_active_names()? {
         let mut relation = relations.get_relation(&relation_name)?;
         if !update
-            && std::path::Path::new(&relation.get_files().get_housenumbers_percent_path()?).exists()
+            && std::path::Path::new(&relation.get_files().get_housenumbers_percent_path()).exists()
         {
             continue;
         }
@@ -241,7 +241,7 @@ fn update_missing_streets(relations: &mut areas::Relations, update: bool) -> any
     for relation_name in relations.get_active_names()? {
         let relation = relations.get_relation(&relation_name)?;
         if !update
-            && std::path::Path::new(&relation.get_files().get_streets_percent_path()?).exists()
+            && std::path::Path::new(&relation.get_files().get_streets_percent_path()).exists()
         {
             continue;
         }
@@ -263,7 +263,7 @@ fn update_additional_streets(relations: &mut areas::Relations, update: bool) -> 
     for relation_name in relations.get_active_names()? {
         let relation = relations.get_relation(&relation_name)?;
         if !update
-            && std::path::Path::new(&relation.get_files().get_streets_additional_count_path()?)
+            && std::path::Path::new(&relation.get_files().get_streets_additional_count_path())
                 .exists()
         {
             continue;

--- a/src/parse_access_log.rs
+++ b/src/parse_access_log.rs
@@ -27,12 +27,12 @@ fn is_complete_relation(
     relation_name: &str,
 ) -> anyhow::Result<bool> {
     let relation = relations.get_relation(relation_name)?;
-    if !std::path::Path::new(&relation.get_files().get_housenumbers_percent_path()?).exists() {
+    if !std::path::Path::new(&relation.get_files().get_housenumbers_percent_path()).exists() {
         return Ok(false);
     }
 
     let percent = String::from_utf8(util::get_content(
-        &relation.get_files().get_housenumbers_percent_path()?,
+        &relation.get_files().get_housenumbers_percent_path(),
     )?)?;
     Ok(percent == "100.00")
 }

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -876,7 +876,7 @@ fn handle_invalid_refstreets(
     for relation in relations.get_relations()? {
         if !ctx
             .get_file_system()
-            .path_exists(&relation.get_files().get_osm_streets_path()?)
+            .path_exists(&relation.get_files().get_osm_streets_path())
         {
             continue;
         }

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -35,7 +35,7 @@ fn get_last_modified(path: &str) -> String {
 /// Gets the update date of streets for a relation.
 fn get_streets_last_modified(relation: &areas::Relation) -> anyhow::Result<String> {
     Ok(get_last_modified(
-        &relation.get_files().get_osm_streets_path()?,
+        &relation.get_files().get_osm_streets_path(),
     ))
 }
 
@@ -108,7 +108,7 @@ fn handle_streets(
 /// Gets the update date of house numbers for a relation.
 fn get_housenumbers_last_modified(relation: &areas::Relation) -> anyhow::Result<String> {
     Ok(get_last_modified(
-        &relation.get_files().get_osm_housenumbers_path()?,
+        &relation.get_files().get_osm_housenumbers_path(),
     ))
 }
 
@@ -163,7 +163,7 @@ fn handle_street_housenumbers(
         // assume view-result
         if !ctx
             .get_file_system()
-            .path_exists(&relation.get_files().get_osm_housenumbers_path()?)
+            .path_exists(&relation.get_files().get_osm_housenumbers_path())
         {
             let _div = doc.tag("div", &[("id", "no-osm-housenumbers")]);
             doc.text(&tr("No existing house numbers"));
@@ -222,17 +222,17 @@ fn missing_housenumbers_view_res(
     let prefix = ctx.get_ini().get_uri_prefix()?;
     if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_osm_streets_path()?)
+        .path_exists(&relation.get_files().get_osm_streets_path())
     {
         doc = webframe::handle_no_osm_streets(&prefix, relation_name);
     } else if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_osm_housenumbers_path()?)
+        .path_exists(&relation.get_files().get_osm_housenumbers_path())
     {
         doc = webframe::handle_no_osm_housenumbers(&prefix, relation_name);
     } else if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_ref_housenumbers_path()?)
+        .path_exists(&relation.get_files().get_ref_housenumbers_path())
     {
         doc = webframe::handle_no_ref_housenumbers(&prefix, relation_name);
     } else {
@@ -257,7 +257,7 @@ fn missing_streets_view_result(
     let prefix = ctx.get_ini().get_uri_prefix()?;
     if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_osm_streets_path()?)
+        .path_exists(&relation.get_files().get_osm_streets_path())
     {
         doc.append_value(webframe::handle_no_osm_streets(&prefix, relation_name).get_value());
         return Ok(doc);
@@ -265,7 +265,7 @@ fn missing_streets_view_result(
 
     if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_ref_streets_path()?)
+        .path_exists(&relation.get_files().get_ref_streets_path())
     {
         doc.append_value(webframe::handle_no_ref_streets(&prefix, relation_name).get_value());
         return Ok(doc);
@@ -358,17 +358,17 @@ fn missing_housenumbers_view_txt(
     let output: String;
     if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_osm_streets_path()?)
+        .path_exists(&relation.get_files().get_osm_streets_path())
     {
         output = tr("No existing streets");
     } else if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_osm_housenumbers_path()?)
+        .path_exists(&relation.get_files().get_osm_housenumbers_path())
     {
         output = tr("No existing house numbers");
     } else if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_ref_housenumbers_path()?)
+        .path_exists(&relation.get_files().get_ref_housenumbers_path())
     {
         output = tr("No reference house numbers");
     } else {
@@ -394,17 +394,17 @@ fn missing_housenumbers_view_chkl(
     let output: String;
     if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_osm_streets_path()?)
+        .path_exists(&relation.get_files().get_osm_streets_path())
     {
         output = tr("No existing streets");
     } else if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_osm_housenumbers_path()?)
+        .path_exists(&relation.get_files().get_osm_housenumbers_path())
     {
         output = tr("No existing house numbers");
     } else if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_ref_housenumbers_path()?)
+        .path_exists(&relation.get_files().get_ref_housenumbers_path())
     {
         output = tr("No reference house numbers");
     } else {
@@ -465,12 +465,12 @@ fn missing_streets_view_txt(
     let output: String;
     if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_osm_streets_path()?)
+        .path_exists(&relation.get_files().get_osm_streets_path())
     {
         output = tr("No existing streets");
     } else if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_ref_streets_path()?)
+        .path_exists(&relation.get_files().get_ref_streets_path())
     {
         output = tr("No reference streets");
     } else {
@@ -529,8 +529,8 @@ fn ref_housenumbers_last_modified(
     name: &str,
 ) -> anyhow::Result<String> {
     let relation = relations.get_relation(name)?;
-    let t_ref = util::get_timestamp(&relation.get_files().get_ref_housenumbers_path()?);
-    let t_housenumbers = util::get_timestamp(&relation.get_files().get_osm_housenumbers_path()?);
+    let t_ref = util::get_timestamp(&relation.get_files().get_ref_housenumbers_path());
+    let t_housenumbers = util::get_timestamp(&relation.get_files().get_osm_housenumbers_path());
     Ok(webframe::format_timestamp(std::cmp::max(
         t_ref as i64,
         t_housenumbers as i64,
@@ -573,7 +573,7 @@ fn handle_missing_housenumbers(
             guard.read_to_end(&mut buffer)?;
             doc.text(&String::from_utf8(buffer)?);
         }
-        date = get_last_modified(&relation.get_files().get_ref_housenumbers_path()?);
+        date = get_last_modified(&relation.get_files().get_ref_housenumbers_path());
     } else if action == "update-result" {
         doc.append_value(missing_housenumbers_update(ctx, relations, relation_name)?.get_value())
     } else {
@@ -619,8 +619,9 @@ fn missing_streets_view_turbo(
 
 /// Gets the update date for missing/additional streets.
 fn streets_diff_last_modified(relation: &areas::Relation) -> anyhow::Result<String> {
-    let t_ref = util::get_timestamp(&relation.get_files().get_ref_streets_path()?) as i64;
-    let t_osm = util::get_timestamp(&relation.get_files().get_osm_streets_path()?) as i64;
+    let t_ref = util::get_timestamp(&relation.get_files().get_ref_streets_path()) as i64;
+    let t_osm = util::get_timestamp(&relation.get_files().get_osm_streets_path()) as i64;
+    // TODO this can't fail
     Ok(webframe::format_timestamp(std::cmp::max(t_ref, t_osm)))
 }
 
@@ -714,8 +715,9 @@ fn handle_additional_streets(
 
 /// Gets the update date for missing/additional housenumbers.
 fn housenumbers_diff_last_modified(relation: &areas::Relation) -> anyhow::Result<String> {
-    let t_ref = util::get_timestamp(&relation.get_files().get_ref_housenumbers_path()?) as i64;
-    let t_osm = util::get_timestamp(&relation.get_files().get_osm_housenumbers_path()?) as i64;
+    let t_ref = util::get_timestamp(&relation.get_files().get_ref_housenumbers_path()) as i64;
+    let t_osm = util::get_timestamp(&relation.get_files().get_osm_housenumbers_path()) as i64;
+    // TODO this can never fail
     Ok(webframe::format_timestamp(std::cmp::max(t_ref, t_osm)))
 }
 
@@ -769,7 +771,7 @@ fn handle_main_housenr_percent(
     let mut percent: String = "N/A".into();
     if ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_housenumbers_percent_path()?)
+        .path_exists(&relation.get_files().get_housenumbers_percent_path())
     {
         let stream = relation
             .get_files()
@@ -782,7 +784,7 @@ fn handle_main_housenr_percent(
 
     let doc = yattag::Doc::new();
     if percent != "N/A" {
-        let date = get_last_modified(&relation.get_files().get_housenumbers_percent_path()?);
+        let date = get_last_modified(&relation.get_files().get_housenumbers_percent_path());
         let _strong = doc.tag("strong", &[]);
         let _a = doc.tag(
             "a",
@@ -815,7 +817,7 @@ fn handle_main_street_percent(
     let mut percent: String = "N/A".into();
     if ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_streets_percent_path()?)
+        .path_exists(&relation.get_files().get_streets_percent_path())
     {
         let stream = relation.get_files().get_streets_percent_read_stream(ctx)?;
         let mut guard = stream.lock().unwrap();
@@ -826,7 +828,7 @@ fn handle_main_street_percent(
 
     let doc = yattag::Doc::new();
     if percent != "N/A" {
-        let date = get_last_modified(&relation.get_files().get_streets_percent_path()?);
+        let date = get_last_modified(&relation.get_files().get_streets_percent_path());
         let _strong = doc.tag("strong", &[]);
         let _a = doc.tag(
             "a",
@@ -859,7 +861,7 @@ fn handle_main_street_additional_count(
     let mut additional_count: String = "".into();
     if ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_streets_additional_count_path()?)
+        .path_exists(&relation.get_files().get_streets_additional_count_path())
     {
         let stream = relation
             .get_files()
@@ -872,7 +874,7 @@ fn handle_main_street_additional_count(
 
     let doc = yattag::Doc::new();
     if !additional_count.is_empty() {
-        let date = get_last_modified(&relation.get_files().get_streets_additional_count_path()?);
+        let date = get_last_modified(&relation.get_files().get_streets_additional_count_path());
         let _strong = doc.tag("strong", &[]);
         let _a = doc.tag(
             "a",
@@ -910,7 +912,7 @@ pub fn handle_main_housenr_additional_count(
     if ctx.get_file_system().path_exists(
         &relation
             .get_files()
-            .get_housenumbers_additional_count_path()?,
+            .get_housenumbers_additional_count_path(),
     ) {
         let stream = relation
             .get_files()
@@ -926,7 +928,7 @@ pub fn handle_main_housenr_additional_count(
         let date = get_last_modified(
             &relation
                 .get_files()
-                .get_housenumbers_additional_count_path()?,
+                .get_housenumbers_additional_count_path(),
         );
         let _strong = doc.tag("strong", &[]);
         let _a = doc.tag(
@@ -1877,7 +1879,7 @@ pub mod tests {
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_osm_streets_path().unwrap();
+        let hide_path = relation.get_files().get_osm_streets_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -1893,7 +1895,7 @@ pub mod tests {
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_osm_housenumbers_path().unwrap();
+        let hide_path = relation.get_files().get_osm_housenumbers_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -1909,7 +1911,7 @@ pub mod tests {
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_ref_housenumbers_path().unwrap();
+        let hide_path = relation.get_files().get_ref_housenumbers_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -2035,7 +2037,7 @@ Tűzkő utca	31
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_osm_streets_path().unwrap();
+        let hide_path = relation.get_files().get_osm_streets_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -2050,7 +2052,7 @@ Tűzkő utca	31
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_osm_housenumbers_path().unwrap();
+        let hide_path = relation.get_files().get_osm_housenumbers_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -2065,7 +2067,7 @@ Tűzkő utca	31
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_ref_housenumbers_path().unwrap();
+        let hide_path = relation.get_files().get_ref_housenumbers_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -2080,7 +2082,7 @@ Tűzkő utca	31
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_osm_streets_path().unwrap();
+        let hide_path = relation.get_files().get_osm_streets_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -2095,7 +2097,7 @@ Tűzkő utca	31
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_osm_housenumbers_path().unwrap();
+        let hide_path = relation.get_files().get_osm_housenumbers_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -2110,7 +2112,7 @@ Tűzkő utca	31
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_ref_housenumbers_path().unwrap();
+        let hide_path = relation.get_files().get_ref_housenumbers_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -2247,7 +2249,7 @@ Tűzkő utca	31
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_osm_housenumbers_path().unwrap();
+        let hide_path = relation.get_files().get_osm_housenumbers_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -2313,7 +2315,7 @@ Tűzkő utca	31
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_osm_streets_path().unwrap();
+        let hide_path = relation.get_files().get_osm_streets_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -2329,7 +2331,7 @@ Tűzkő utca	31
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_ref_streets_path().unwrap();
+        let hide_path = relation.get_files().get_ref_streets_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -2361,7 +2363,7 @@ Tűzkő utca	31
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_osm_streets_path().unwrap();
+        let hide_path = relation.get_files().get_osm_streets_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -2378,7 +2380,7 @@ Tűzkő utca	31
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_ref_streets_path().unwrap();
+        let hide_path = relation.get_files().get_ref_streets_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -2686,7 +2688,7 @@ Tűzkő utca	31
         let mut test_wsgi = TestWsgi::new();
         let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_osm_streets_path().unwrap();
+        let hide_path = relation.get_files().get_osm_streets_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);

--- a/src/wsgi_additional.rs
+++ b/src/wsgi_additional.rs
@@ -36,12 +36,12 @@ pub fn additional_streets_view_txt(
     let output: String;
     if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_osm_streets_path()?)
+        .path_exists(&relation.get_files().get_osm_streets_path())
     {
         output = tr("No existing streets");
     } else if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_ref_streets_path()?)
+        .path_exists(&relation.get_files().get_ref_streets_path())
     {
         output = tr("No reference streets");
     } else {
@@ -75,12 +75,12 @@ pub fn additional_streets_view_result(
     let prefix = ctx.get_ini().get_uri_prefix()?;
     if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_osm_streets_path()?)
+        .path_exists(&relation.get_files().get_osm_streets_path())
     {
         doc.append_value(webframe::handle_no_osm_streets(&prefix, relation_name).get_value());
     } else if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_ref_streets_path()?)
+        .path_exists(&relation.get_files().get_ref_streets_path())
     {
         doc.append_value(webframe::handle_no_ref_streets(&prefix, relation_name).get_value());
     } else {
@@ -185,17 +185,17 @@ pub fn additional_housenumbers_view_result(
     let prefix = ctx.get_ini().get_uri_prefix()?;
     if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_osm_streets_path()?)
+        .path_exists(&relation.get_files().get_osm_streets_path())
     {
         doc = webframe::handle_no_osm_streets(&prefix, relation_name);
     } else if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_osm_housenumbers_path()?)
+        .path_exists(&relation.get_files().get_osm_housenumbers_path())
     {
         doc = webframe::handle_no_osm_housenumbers(&prefix, relation_name);
     } else if !ctx
         .get_file_system()
-        .path_exists(&relation.get_files().get_ref_housenumbers_path()?)
+        .path_exists(&relation.get_files().get_ref_housenumbers_path())
     {
         doc = webframe::handle_no_ref_housenumbers(&prefix, relation_name);
     } else {
@@ -260,7 +260,7 @@ mod tests {
         let mut test_wsgi = wsgi::tests::TestWsgi::new();
         let mut relations = areas::Relations::new(test_wsgi.get_ctx()).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_osm_streets_path().unwrap();
+        let hide_path = relation.get_files().get_osm_streets_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -277,7 +277,7 @@ mod tests {
         let mut test_wsgi = wsgi::tests::TestWsgi::new();
         let mut relations = areas::Relations::new(test_wsgi.get_ctx()).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_ref_streets_path().unwrap();
+        let hide_path = relation.get_files().get_ref_streets_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -315,8 +315,7 @@ mod tests {
         let relation = relations.get_relation("budafok").unwrap();
         let hide_path = relation
             .get_files()
-            .get_housenumbers_additional_count_path()
-            .unwrap();
+            .get_housenumbers_additional_count_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -343,7 +342,7 @@ mod tests {
         let mut test_wsgi = wsgi::tests::TestWsgi::new();
         let mut relations = areas::Relations::new(test_wsgi.get_ctx()).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_osm_streets_path().unwrap();
+        let hide_path = relation.get_files().get_osm_streets_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -359,7 +358,7 @@ mod tests {
         let mut test_wsgi = wsgi::tests::TestWsgi::new();
         let mut relations = areas::Relations::new(test_wsgi.get_ctx()).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_osm_housenumbers_path().unwrap();
+        let hide_path = relation.get_files().get_osm_housenumbers_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -377,7 +376,7 @@ mod tests {
         let mut test_wsgi = wsgi::tests::TestWsgi::new();
         let mut relations = areas::Relations::new(test_wsgi.get_ctx()).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_ref_housenumbers_path().unwrap();
+        let hide_path = relation.get_files().get_ref_housenumbers_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -466,7 +465,7 @@ mod tests {
         let mut test_wsgi = wsgi::tests::TestWsgi::new();
         let mut relations = areas::Relations::new(test_wsgi.get_ctx()).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_osm_streets_path().unwrap();
+        let hide_path = relation.get_files().get_osm_streets_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -484,7 +483,7 @@ mod tests {
         let mut test_wsgi = wsgi::tests::TestWsgi::new();
         let mut relations = areas::Relations::new(test_wsgi.get_ctx()).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
-        let hide_path = relation.get_files().get_ref_streets_path().unwrap();
+        let hide_path = relation.get_files().get_ref_streets_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);


### PR DESCRIPTION
Avoid the string -> path -> string roundtrip, which means this can never
fail.

Also do the same for a number of other RelationFiles functions:

- get_osm_streets_path()
- get_osm_housenumbers_path()
- get_ref_housenumbers_path()
- get_housenumbers_percent_path()
- get_housenumbers_htmlcache_path()
- get_housenumbers_txtcache_path()
- get_streets_percent_path()
- get_streets_additional_count_path()
- get_housenumbers_additional_count_path()
- get_additional_housenumbers_htmlcache_path()

Change-Id: I685a2a0600f90de9136693d247d1c0e715d6dd10
