### PR TITLE
context: test what happens when the fallback value of a config key is used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,9 @@ $(foreach BINARY_CRATE,$(BINARY_CRATES),target/${TARGET_PATH}/$(BINARY_CRATE)) &
 check-unit: Cargo.toml $(RS_OBJECTS) locale/hu/LC_MESSAGES/osm-gimmisn.mo testdata data/yamls.cache
 	cargo test --lib ${CARGO_OPTIONS} -- --test-threads=1
 
+check-cov:
+	cargo tarpaulin --lib -v --skip-clean --fail-under 100 --target-dir ${PWD}/target-cov ${CARGO_OPTIONS} -- --test-threads=1
+
 config.ts: wsgi.ini Makefile
 	printf 'const uriPrefix = "%s";\nexport { uriPrefix };\n' $(shell grep prefix wsgi.ini |sed 's/uri_prefix = //') > $@
 

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -243,7 +243,7 @@ housenumber ranges in a sensible way. Here are some examples:
 |13 |42-1 |Defaults |42 because -1 is considered as a suffix
 |=======
 
-See `tests/test_areas.py` for even more details.
+See the tests in `src/areas.rs` for even more details.
 
 === Additional house numbers analysis
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -83,9 +83,8 @@ pub fn get_missing_housenumbers_html(
 ) -> anyhow::Result<yattag::Doc> {
     let doc = yattag::Doc::new();
     if is_missing_housenumbers_html_cached(ctx, relation)? {
-        let stream = relation
-            .get_files()
-            .get_housenumbers_htmlcache_read_stream(ctx)?;
+        let files = relation.get_files();
+        let stream = files.get_housenumbers_htmlcache_read_stream(ctx)?;
         let mut guard = stream.lock().unwrap();
         let mut buffer = Vec::new();
         guard.read_to_end(&mut buffer)?;
@@ -174,9 +173,8 @@ pub fn get_missing_housenumbers_html(
         util::invalid_filter_keys_to_html(&relation.get_invalid_filter_keys()?).get_value(),
     );
 
-    let stream = relation
-        .get_files()
-        .get_housenumbers_htmlcache_write_stream(ctx)?;
+    let files = relation.get_files();
+    let stream = files.get_housenumbers_htmlcache_write_stream(ctx)?;
     let mut guard = stream.lock().unwrap();
     guard.write_all(doc.get_value().as_bytes())?;
 
@@ -190,9 +188,8 @@ pub fn get_additional_housenumbers_html(
 ) -> anyhow::Result<yattag::Doc> {
     let doc = yattag::Doc::new();
     if is_additional_housenumbers_html_cached(ctx, relation)? {
-        let stream = relation
-            .get_files()
-            .get_additional_housenumbers_htmlcache_read_stream(ctx)?;
+        let files = relation.get_files();
+        let stream = files.get_additional_housenumbers_htmlcache_read_stream(ctx)?;
         let mut guard = stream.lock().unwrap();
         let mut buffer: Vec<u8> = Vec::new();
         guard.read_to_end(&mut buffer)?;
@@ -227,9 +224,8 @@ pub fn get_additional_housenumbers_html(
         util::invalid_filter_keys_to_html(&relation.get_invalid_filter_keys()?).get_value(),
     );
 
-    let stream = relation
-        .get_files()
-        .get_additional_housenumbers_htmlcache_write_stream(ctx)?;
+    let files = relation.get_files();
+    let stream = files.get_additional_housenumbers_htmlcache_write_stream(ctx)?;
     let mut guard = stream.lock().unwrap();
     guard.write_all(doc.get_value().as_bytes())?;
 
@@ -260,9 +256,8 @@ pub fn get_missing_housenumbers_txt(
 ) -> anyhow::Result<String> {
     let output: String;
     if is_missing_housenumbers_txt_cached(ctx, relation)? {
-        let stream = relation
-            .get_files()
-            .get_housenumbers_txtcache_read_stream(ctx)?;
+        let files = relation.get_files();
+        let stream = files.get_housenumbers_txtcache_read_stream(ctx)?;
         let mut guard = stream.lock().unwrap();
         let mut buffer = Vec::new();
         guard.read_to_end(&mut buffer)?;
@@ -297,9 +292,8 @@ pub fn get_missing_housenumbers_txt(
     table.sort_by_key(|i| util::get_sort_key(i).unwrap());
     output = table.join("\n");
 
-    let stream = relation
-        .get_files()
-        .get_housenumbers_txtcache_write_stream(ctx)?;
+    let files = relation.get_files();
+    let stream = files.get_housenumbers_txtcache_write_stream(ctx)?;
     let mut guard = stream.lock().unwrap();
     guard.write_all(output.as_bytes())?;
     Ok(output)

--- a/tests/data/relation-nosuchrelation.yaml
+++ b/tests/data/relation-nosuchrelation.yaml
@@ -1,2 +1,2 @@
-# This is not active and parse_access_log.py will suggest no changes to this.
+# This is not active and parse_access_log will suggest no changes to this.
 inactive: true


### PR DESCRIPTION
With this, 100% line coverage is reached in context.rs.

Change-Id: Id8c03ddd431e7c92a409cc61b3e153f683cfa7d0
