### PR TITLE
cron: test update of ref housenumbers when osm street list is broken

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1356,9 +1356,9 @@ impl Relations {
     }
 
     /// If refsettlement is not None, forget about all relations outside that refsettlement.
-    pub fn limit_to_refsettlement(&mut self, refsettlement: &Option<String>) -> anyhow::Result<()> {
+    pub fn limit_to_refsettlement(&mut self, refsettlement: &Option<&str>) -> anyhow::Result<()> {
         let refsettlement: String = match refsettlement {
-            Some(value) => value.clone(),
+            Some(value) => value.to_string(),
             None => {
                 return Ok(());
             }
@@ -3080,9 +3080,7 @@ way{color:blue; width:4;}
                 .contains(&"nosuchrefsettlement".to_string()),
             true
         );
-        relations
-            .limit_to_refsettlement(&Some("99".to_string()))
-            .unwrap();
+        relations.limit_to_refsettlement(&Some("99")).unwrap();
         assert_eq!(
             relations
                 .get_active_names()

--- a/src/bin/cron.rs
+++ b/src/bin/cron.rs
@@ -10,10 +10,31 @@
 
 //! Provides the 'cron' cmdline tool.
 
+/// Sets up logging.
+pub fn setup_logging(ctx: &osm_gimmisn::context::Context) -> anyhow::Result<()> {
+    let config = simplelog::ConfigBuilder::new()
+        .set_time_format("%Y-%m-%d %H:%M:%S".into())
+        .set_time_to_local(true)
+        .build();
+    let logpath = ctx.get_abspath("workdir/cron.log")?;
+    let file = std::fs::File::create(logpath)?;
+    simplelog::CombinedLogger::init(vec![
+        simplelog::TermLogger::new(
+            simplelog::LevelFilter::Info,
+            config.clone(),
+            simplelog::TerminalMode::Stdout,
+            simplelog::ColorChoice::Never,
+        ),
+        simplelog::WriteLogger::new(simplelog::LevelFilter::Info, config, file),
+    ])?;
+
+    Ok(())
+}
+
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
     let ctx = osm_gimmisn::context::Context::new("")?;
-    osm_gimmisn::cron::setup_logging(&ctx)?;
+    setup_logging(&ctx)?;
     osm_gimmisn::cron::main(&args, &mut std::io::stdout(), &ctx)?;
 
     Ok(())

--- a/src/overpass_query.rs
+++ b/src/overpass_query.rs
@@ -34,12 +34,8 @@ pub fn overpass_query_need_sleep(ctx: &context::Context) -> i32 {
         if line.starts_with("Slot available after:") {
             let re = regex::Regex::new(r".*in (-?\d+) seconds.*").unwrap();
             for cap in re.captures_iter(line) {
-                sleep = match cap[1].parse::<i32>() {
-                    Ok(value) => value,
-                    _ => {
-                        return 0;
-                    }
-                };
+                // This should neve fail since the regex only allows numbers.
+                sleep = cap[1].parse::<i32>().expect("parse() to i32 failed");
                 // Wait one more second just to be safe.
                 sleep += 1;
                 if sleep <= 0 {


### PR DESCRIPTION
Make sure that the function doesn't fail for all relations just because
one relation is broken.

With this, 100% line coverage is reached in cron.rs.

Change-Id: Idff9edf57b693a56e443e63744e8a4b0074f0aad
