### PR TITLE
util: fix test_build_reference_cache()

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -201,10 +201,10 @@ fn update_missing_housenumbers(
         let orig_language = i18n::get_language();
         relation.write_missing_housenumbers()?;
         for language in ["en", "hu"] {
-            i18n::set_language(language)?;
+            i18n::set_language(language);
             cache::get_missing_housenumbers_html(ctx, &mut relation)?;
         }
-        i18n::set_language(&orig_language)?;
+        i18n::set_language(&orig_language);
         cache::get_missing_housenumbers_txt(ctx, &mut relation)?;
     }
     log::info!("update_missing_housenumbers: end");

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -352,7 +352,7 @@ fn missing_housenumbers_view_txt(
     let relation_name = tokens.next_back().unwrap();
     let mut relation = relations.get_relation(relation_name)?;
     let mut config = relation.get_config().clone();
-    config.set_letter_suffix_style(util::LetterSuffixStyle::Lower as i32);
+    config.set_letter_suffix_style(util::LetterSuffixStyle::Lower);
     relation.set_config(&config);
 
     let output: String;
@@ -388,7 +388,7 @@ fn missing_housenumbers_view_chkl(
     let relation_name = tokens.next_back().unwrap();
     let mut relation = relations.get_relation(relation_name)?;
     let mut config = relation.get_config().clone();
-    config.set_letter_suffix_style(util::LetterSuffixStyle::Lower as i32);
+    config.set_letter_suffix_style(util::LetterSuffixStyle::Lower);
     relation.set_config(&config);
 
     let output: String;


### PR DESCRIPTION
To actually test the non-cached path. The old cache path was wrong, so
it tested the cached path.

Also add one more test for get_street_from_housenumber().

With this, 100% line coverage is reached in util.rs.

Change-Id: I5a853b650a49d174d58262fefc2747520037a10d
