### PR TITLE
webframe: improve test_handle_stats_cityprogress_well_formed()

### DIFF
--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -15,7 +15,6 @@ use crate::context;
 use crate::i18n::translate as tr;
 use crate::util;
 use crate::yattag;
-use anyhow::anyhow;
 use anyhow::Context;
 use git_version::git_version;
 use std::collections::HashMap;
@@ -606,7 +605,7 @@ pub fn handle_error(
     let status = "500 Internal Server Error";
     let request_uri = environ
         .get("PATH_INFO")
-        .ok_or_else(|| anyhow!("no PATH_INFO in the environment"))?;
+        .context("no PATH_INFO in the environment")?;
     let doc = yattag::Doc::new();
     util::write_html_header(&doc);
     {

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -2653,8 +2653,9 @@ Tűzkő utca	31
 
         let root = test_wsgi.get_dom_for_path("/housenumber-stats/hungary/cityprogress");
 
-        let results = TestWsgi::find_all(&root, "body/table");
-        assert_eq!(results.len(), 1);
+        let results = TestWsgi::find_all(&root, "body/table/tr");
+        // header; also budapest_11 is both in ref and osm
+        assert_eq!(results.len(), 2);
     }
 
     /// Tests handle_stats_zipprogress(): if the output is well-formed.
@@ -2665,10 +2666,22 @@ Tűzkő utca	31
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         test_wsgi.ctx.set_time(&time_arc);
 
+        let mut file_system = context::tests::TestFileSystem::new();
+        let zips_value = context::tests::TestFileSystem::make_file();
+        zips_value.lock().unwrap().write_all(b"1111\t10\n").unwrap();
+        let files = context::tests::TestFileSystem::make_files(
+            &test_wsgi.ctx,
+            &[("workdir/stats/2020-05-10.zipcount", &zips_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        test_wsgi.ctx.set_file_system(&file_system_arc);
+
         let root = test_wsgi.get_dom_for_path("/housenumber-stats/hungary/zipprogress");
 
-        let results = TestWsgi::find_all(&root, "body/table");
-        assert_eq!(results.len(), 1);
+        let results = TestWsgi::find_all(&root, "body/table/tr");
+        // header; also 1111 is both in ref and osm
+        assert_eq!(results.len(), 2);
     }
 
     /// Tests handle_invalid_refstreets(): if the output is well-formed.

--- a/tests/workdir/stats/2020-05-10.citycount
+++ b/tests/workdir/stats/2020-05-10.citycount
@@ -1,3 +1,4 @@
 budapest_01	100
 budapest_02	200
+budapest_11	11
 	42


### PR DESCRIPTION
Test the case when a relation is both in osm and ref, which is the
interesting one.

Improve the zipprogress test similarly.

With this, 100% line coverage is reached in webframe.rs.

Change-Id: I4933b0c0ae25c0433ce7d21151b1506197724319
