### PR TITLE
context: make get_abspath() just return a String

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -517,7 +517,7 @@ impl Relation {
     pub fn get_osm_streets_query(&self) -> anyhow::Result<String> {
         let contents = std::fs::read_to_string(format!(
             "{}/{}",
-            self.ctx.get_abspath("data")?,
+            self.ctx.get_abspath("data"),
             "streets-template.txt"
         ))?;
         Ok(util::process_template(
@@ -1118,7 +1118,7 @@ impl Relation {
     pub fn get_osm_housenumbers_query(&self) -> anyhow::Result<String> {
         let contents = std::fs::read_to_string(format!(
             "{}/{}",
-            self.ctx.get_abspath("data")?,
+            self.ctx.get_abspath("data"),
             "street-housenumbers-template.txt"
         ))?;
         Ok(util::process_template(
@@ -1191,7 +1191,7 @@ pub struct Relations {
 impl Relations {
     pub fn new(ctx: &context::Context) -> anyhow::Result<Self> {
         let workdir = ctx.get_ini().get_workdir()?;
-        let yamls_cache = format!("{}/{}", ctx.get_abspath("data")?, "yamls.cache");
+        let yamls_cache = format!("{}/{}", ctx.get_abspath("data"), "yamls.cache");
         let stream = ctx
             .get_file_system()
             .open_read(&yamls_cache)
@@ -2594,7 +2594,7 @@ way{color:blue; width:4;}
         let relation_name = "gazdagret";
         let mut relation = relations.get_relation(relation_name).unwrap();
         let expected = String::from_utf8(
-            util::get_content(&ctx.get_abspath("workdir/gazdagret.percent").unwrap()).unwrap(),
+            util::get_content(&ctx.get_abspath("workdir/gazdagret.percent")).unwrap(),
         )
         .unwrap();
 
@@ -2734,11 +2734,7 @@ way{color:blue; width:4;}
         let relation_name = "gazdagret";
         let relation = relations.get_relation(relation_name).unwrap();
         let expected = String::from_utf8(
-            util::get_content(
-                &ctx.get_abspath("workdir/gazdagret-streets.percent")
-                    .unwrap(),
-            )
-            .unwrap(),
+            util::get_content(&ctx.get_abspath("workdir/gazdagret-streets.percent")).unwrap(),
         )
         .unwrap();
 
@@ -2786,7 +2782,7 @@ way{color:blue; width:4;}
     #[test]
     fn test_relation_build_ref_housenumbers() {
         let ctx = context::tests::make_test_context().unwrap();
-        let refdir = ctx.get_abspath("refdir").unwrap();
+        let refdir = ctx.get_abspath("refdir");
         let mut relations = Relations::new(&ctx).unwrap();
         let refpath = format!("{}/hazszamok_20190511.tsv", refdir);
         let memory_cache = util::build_reference_cache(&refpath, "01").unwrap();
@@ -2810,7 +2806,7 @@ way{color:blue; width:4;}
     fn test_relation_build_ref_housenumbers_missing() {
         let ctx = context::tests::make_test_context().unwrap();
         let mut relations = Relations::new(&ctx).unwrap();
-        let refdir = ctx.get_abspath("refdir").unwrap();
+        let refdir = ctx.get_abspath("refdir");
         let refpath = format!("{}/hazszamok_20190511.tsv", refdir);
         let memory_cache = util::build_reference_cache(&refpath, "01").unwrap();
         let relation_name = "gazdagret";
@@ -2826,7 +2822,7 @@ way{color:blue; width:4;}
     #[test]
     fn test_relation_build_ref_streets() {
         let ctx = context::tests::make_test_context().unwrap();
-        let refdir = ctx.get_abspath("refdir").unwrap();
+        let refdir = ctx.get_abspath("refdir");
         let refpath = format!("{}/utcak_20190514.tsv", refdir);
         let memory_cache = util::build_street_reference_cache(&refpath).unwrap();
         let mut relations = Relations::new(&ctx).unwrap();
@@ -2852,7 +2848,7 @@ way{color:blue; width:4;}
     #[test]
     fn test_relation_writer_ref_housenumbers() {
         let mut ctx = context::tests::make_test_context().unwrap();
-        let refdir = ctx.get_abspath("refdir").unwrap();
+        let refdir = ctx.get_abspath("refdir");
         let refpath = format!("{}/hazszamok_20190511.tsv", refdir);
         let refpath2 = format!("{}/hazszamok_kieg_20190808.tsv", refdir);
         let mut file_system = context::tests::TestFileSystem::new();
@@ -2871,8 +2867,7 @@ way{color:blue; width:4;}
         let relation_name = "gazdagret";
         let expected = String::from_utf8(
             util::get_content(
-                &ctx.get_abspath("workdir/street-housenumbers-reference-gazdagret.lst")
-                    .unwrap(),
+                &ctx.get_abspath("workdir/street-housenumbers-reference-gazdagret.lst"),
             )
             .unwrap(),
         )
@@ -2894,7 +2889,7 @@ way{color:blue; width:4;}
     #[test]
     fn test_relation_writer_ref_housenumbers_nosuchrefcounty() {
         let mut ctx = context::tests::make_test_context().unwrap();
-        let refdir = ctx.get_abspath("refdir").unwrap();
+        let refdir = ctx.get_abspath("refdir");
         let refpath = format!("{}/hazszamok_20190511.tsv", refdir);
         let mut file_system = context::tests::TestFileSystem::new();
         let ref_value = context::tests::TestFileSystem::make_file();
@@ -2919,7 +2914,7 @@ way{color:blue; width:4;}
     #[test]
     fn test_relation_writer_ref_housenumbers_nosuchrefsettlement() {
         let mut ctx = context::tests::make_test_context().unwrap();
-        let refdir = ctx.get_abspath("refdir").unwrap();
+        let refdir = ctx.get_abspath("refdir");
         let refpath = format!("{}/hazszamok_20190511.tsv", refdir);
         let mut file_system = context::tests::TestFileSystem::new();
         let ref_value = context::tests::TestFileSystem::make_file();
@@ -2953,17 +2948,13 @@ way{color:blue; width:4;}
         file_system.set_files(&files);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
         ctx.set_file_system(&file_system_arc);
-        let refdir = ctx.get_abspath("refdir").unwrap();
+        let refdir = ctx.get_abspath("refdir");
         let refpath = format!("{}/utcak_20190514.tsv", refdir);
         let mut relations = Relations::new(&ctx).unwrap();
         let relation_name = "gazdagret";
         let relation = relations.get_relation(relation_name).unwrap();
         let expected = String::from_utf8(
-            util::get_content(
-                &ctx.get_abspath("workdir/streets-reference-gazdagret.lst")
-                    .unwrap(),
-            )
-            .unwrap(),
+            util::get_content(&ctx.get_abspath("workdir/streets-reference-gazdagret.lst")).unwrap(),
         )
         .unwrap();
 

--- a/src/bin/cron.rs
+++ b/src/bin/cron.rs
@@ -16,7 +16,7 @@ pub fn setup_logging(ctx: &osm_gimmisn::context::Context) -> anyhow::Result<()> 
         .set_time_format("%Y-%m-%d %H:%M:%S".into())
         .set_time_to_local(true)
         .build();
-    let logpath = ctx.get_abspath("workdir/cron.log")?;
+    let logpath = ctx.get_abspath("workdir/cron.log");
     let file = std::fs::File::create(logpath)?;
     simplelog::CombinedLogger::init(vec![
         simplelog::TermLogger::new(

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -46,7 +46,7 @@ fn is_missing_housenumbers_html_cached(
     relation: &areas::Relation,
 ) -> anyhow::Result<bool> {
     let cache_path = relation.get_files().get_housenumbers_htmlcache_path();
-    let datadir = ctx.get_abspath("data")?;
+    let datadir = ctx.get_abspath("data");
     let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
     let dependencies = vec![
         relation.get_files().get_osm_streets_path(),
@@ -65,7 +65,7 @@ fn is_additional_housenumbers_html_cached(
     let cache_path = relation
         .get_files()
         .get_additional_housenumbers_htmlcache_path();
-    let datadir = ctx.get_abspath("data")?;
+    let datadir = ctx.get_abspath("data");
     let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
     let dependencies = vec![
         relation.get_files().get_osm_streets_path(),
@@ -238,7 +238,7 @@ fn is_missing_housenumbers_txt_cached(
     relation: &areas::Relation,
 ) -> anyhow::Result<bool> {
     let cache_path = relation.get_files().get_housenumbers_txtcache_path();
-    let datadir = ctx.get_abspath("data")?;
+    let datadir = ctx.get_abspath("data");
     let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
     let dependencies = vec![
         relation.get_files().get_osm_streets_path(),
@@ -399,7 +399,7 @@ mod tests {
         let mut relation = relations.get_relation("gazdagret").unwrap();
         get_missing_housenumbers_html(&ctx, &mut relation).unwrap();
         let cache_path = relation.get_files().get_housenumbers_htmlcache_path();
-        let datadir = ctx.get_abspath("data").unwrap();
+        let datadir = ctx.get_abspath("data");
         let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
 
         let mut file_system = context::tests::TestFileSystem::new();

--- a/src/cache_yamls.rs
+++ b/src/cache_yamls.rs
@@ -18,7 +18,7 @@ use std::ops::DerefMut;
 /// Commandline interface.
 pub fn main(argv: &[String], ctx: &context::Context) -> anyhow::Result<()> {
     let mut cache: HashMap<String, serde_json::Value> = HashMap::new();
-    let datadir = ctx.get_abspath(&argv[1])?;
+    let datadir = ctx.get_abspath(&argv[1]);
     let entries =
         std::fs::read_dir(&datadir).context(format!("failed to read_dir() {}", datadir))?;
     let mut yaml_paths: Vec<String> = Vec::new();
@@ -87,7 +87,7 @@ mod tests {
     #[test]
     fn test_main() {
         let mut ctx = context::tests::make_test_context().unwrap();
-        let cache_path = ctx.get_abspath("data/yamls.cache").unwrap();
+        let cache_path = ctx.get_abspath("data/yamls.cache");
         let argv = vec!["".to_string(), "data".to_string(), "workdir".to_string()];
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[cache_path]);
@@ -113,7 +113,7 @@ mod tests {
             assert_eq!(guard.seek(SeekFrom::Current(0)).unwrap() > 0, true);
         }
 
-        let relation_ids_path = ctx.get_abspath("workdir/stats/relations.json").unwrap();
+        let relation_ids_path = ctx.get_abspath("workdir/stats/relations.json");
         let file = std::fs::File::open(relation_ids_path).unwrap();
         let relation_ids: serde_json::Value = serde_json::from_reader(&file).unwrap();
         let relation_ids: Vec<_> = relation_ids

--- a/src/context.rs
+++ b/src/context.rs
@@ -315,9 +315,8 @@ impl Context {
     }
 
     /// Make a path absolute, taking the repo root as a base dir.
-    pub fn get_abspath(&self, rel_path: &str) -> anyhow::Result<String> {
-        // TODO not needed Result in return type
-        Ok(format!("{}/{}", self.root, rel_path))
+    pub fn get_abspath(&self, rel_path: &str) -> String {
+        format!("{}/{}", self.root, rel_path)
     }
 
     /// Gets the ini file.
@@ -417,7 +416,7 @@ pub mod tests {
             let mut ret = HashMap::new();
             for file in files {
                 let (path, content) = file;
-                ret.insert(ctx.get_abspath(path).unwrap(), (*content).clone());
+                ret.insert(ctx.get_abspath(path), (*content).clone());
             }
             ret
         }

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -310,7 +310,7 @@ fn write_zip_count_path(
 
 /// Counts the # of all house numbers as of today.
 fn update_stats_count(ctx: &context::Context, today: &str) -> anyhow::Result<()> {
-    let statedir = ctx.get_abspath("workdir/stats")?;
+    let statedir = ctx.get_abspath("workdir/stats");
     let csv_path = format!("{}/{}.csv", statedir, today);
     if !ctx.get_file_system().path_exists(&csv_path) {
         return Ok(());
@@ -361,7 +361,7 @@ fn update_stats_count(ctx: &context::Context, today: &str) -> anyhow::Result<()>
 
 /// Counts the top housenumber editors as of today.
 fn update_stats_topusers(ctx: &context::Context, today: &str) -> anyhow::Result<()> {
-    let statedir = ctx.get_abspath("workdir/stats")?;
+    let statedir = ctx.get_abspath("workdir/stats");
     let csv_path = format!("{}/{}.csv", statedir, today);
     if !ctx.get_file_system().path_exists(&csv_path) {
         return Ok(());
@@ -435,9 +435,9 @@ fn update_stats(ctx: &context::Context, overpass: bool) -> anyhow::Result<()> {
     // Fetch house numbers for the whole country.
     log::info!("update_stats: start, updating whole-country csv");
     let query = String::from_utf8(util::get_content(
-        &ctx.get_abspath("data/street-housenumbers-hungary.txt")?,
+        &ctx.get_abspath("data/street-housenumbers-hungary.txt"),
     )?)?;
-    let statedir = ctx.get_abspath("workdir/stats")?;
+    let statedir = ctx.get_abspath("workdir/stats");
     std::fs::create_dir_all(&statedir)?;
     let now = chrono::NaiveDateTime::from_timestamp(ctx.get_time().now(), 0);
     let today = now.format("%Y-%m-%d").to_string();
@@ -684,9 +684,7 @@ mod tests {
                 relations.set_relation(&relation_name, &relation);
             }
         }
-        let path = ctx
-            .get_abspath("workdir/street-housenumbers-reference-gazdagret.lst")
-            .unwrap();
+        let path = ctx.get_abspath("workdir/street-housenumbers-reference-gazdagret.lst");
         let expected = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
         std::fs::remove_file(&path).unwrap();
 
@@ -715,9 +713,7 @@ mod tests {
         let actual = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
         assert_eq!(actual, expected);
         // Make sure housenumber ref is not created for the streets=only case.
-        let ujbuda_path = ctx
-            .get_abspath("workdir/street-housenumbers-reference-ujbuda.lst")
-            .unwrap();
+        let ujbuda_path = ctx.get_abspath("workdir/street-housenumbers-reference-ujbuda.lst");
         assert_eq!(std::path::Path::new(&ujbuda_path).exists(), false);
     }
 
@@ -736,9 +732,7 @@ mod tests {
                 relations.set_relation(&relation_name, &relation);
             }
         }
-        let path = ctx
-            .get_abspath("workdir/streets-reference-gazdagret.lst")
-            .unwrap();
+        let path = ctx.get_abspath("workdir/streets-reference-gazdagret.lst");
         let expected = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
         std::fs::remove_file(&path).unwrap();
 
@@ -767,9 +761,7 @@ mod tests {
         let actual = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
         assert_eq!(actual, expected);
         // Make sure street ref is not created for the streets=no case.
-        let ujbuda_path = ctx
-            .get_abspath("workdir/street-reference-ujbuda.lst")
-            .unwrap();
+        let ujbuda_path = ctx.get_abspath("workdir/street-reference-ujbuda.lst");
         assert_eq!(std::path::Path::new(&ujbuda_path).exists(), false);
     }
 
@@ -788,7 +780,7 @@ mod tests {
                 relations.set_relation(&relation_name, &relation);
             }
         }
-        let path = ctx.get_abspath("workdir/gazdagret.percent").unwrap();
+        let path = ctx.get_abspath("workdir/gazdagret.percent");
         let expected = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
         std::fs::remove_file(&path).unwrap();
 
@@ -837,9 +829,7 @@ mod tests {
                 relations.set_relation(&relation_name, &relation);
             }
         }
-        let path = ctx
-            .get_abspath("workdir/gazdagret-streets.percent")
-            .unwrap();
+        let path = ctx.get_abspath("workdir/gazdagret-streets.percent");
         let expected = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
         std::fs::remove_file(&path).unwrap();
         update_missing_streets(&mut relations, /*update=*/ true).unwrap();
@@ -852,10 +842,7 @@ mod tests {
         assert_eq!(actual, expected);
         // Make sure street stat is not created for the streets=no case.
         assert_eq!(
-            file_system.path_exists(
-                &ctx.get_abspath("workdir/gellerthegy-streets.percent")
-                    .unwrap()
-            ),
+            file_system.path_exists(&ctx.get_abspath("workdir/gellerthegy-streets.percent")),
             false
         );
     }
@@ -876,9 +863,7 @@ mod tests {
                 relations.set_relation(&relation_name, &relation);
             }
         }
-        let path = ctx
-            .get_abspath("workdir/gazdagret-additional-streets.count")
-            .unwrap();
+        let path = ctx.get_abspath("workdir/gazdagret-additional-streets.count");
         let expected: String = "1".into();
         if file_system.path_exists(&path) {
             std::fs::remove_file(&path).unwrap();
@@ -893,10 +878,8 @@ mod tests {
         assert_eq!(actual, expected);
         // Make sure street stat is not created for the streets=no case.
         assert_eq!(
-            file_system.path_exists(
-                &ctx.get_abspath("workdir/gellerthegy-additional-streets.count")
-                    .unwrap()
-            ),
+            file_system
+                .path_exists(&ctx.get_abspath("workdir/gellerthegy-additional-streets.count")),
             false
         );
     }
@@ -930,9 +913,7 @@ mod tests {
                 relations.set_relation(&relation_name, &relation);
             }
         }
-        let path = ctx
-            .get_abspath("workdir/street-housenumbers-gazdagret.csv")
-            .unwrap();
+        let path = ctx.get_abspath("workdir/street-housenumbers-gazdagret.csv");
         let expected = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
         std::fs::remove_file(&path).unwrap();
         update_osm_housenumbers(&ctx, &mut relations, /*update=*/ true).unwrap();
@@ -974,9 +955,7 @@ mod tests {
                 relations.set_relation(&relation_name, &relation);
             }
         }
-        let path = ctx
-            .get_abspath("workdir/street-housenumbers-gazdagret.csv")
-            .unwrap();
+        let path = ctx.get_abspath("workdir/street-housenumbers-gazdagret.csv");
         let expected = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
         update_osm_housenumbers(&ctx, &mut relations, /*update=*/ true).unwrap();
         // Make sure that in case we keep getting errors we give up at some stage and
@@ -1014,9 +993,7 @@ mod tests {
                 relations.set_relation(&relation_name, &relation);
             }
         }
-        let path = ctx
-            .get_abspath("workdir/street-housenumbers-gazdagret.csv")
-            .unwrap();
+        let path = ctx.get_abspath("workdir/street-housenumbers-gazdagret.csv");
         let expected = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
         update_osm_housenumbers(&ctx, &mut relations, /*update=*/ true).unwrap();
         let actual = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
@@ -1052,7 +1029,7 @@ mod tests {
                 relations.set_relation(&relation_name, &relation);
             }
         }
-        let path = ctx.get_abspath("workdir/streets-gazdagret.csv").unwrap();
+        let path = ctx.get_abspath("workdir/streets-gazdagret.csv");
         let expected = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
         std::fs::remove_file(&path).unwrap();
         update_osm_streets(&ctx, &mut relations, /*update=*/ true).unwrap();
@@ -1094,7 +1071,7 @@ mod tests {
                 relations.set_relation(&relation_name, &relation);
             }
         }
-        let path = ctx.get_abspath("workdir/streets-gazdagret.csv").unwrap();
+        let path = ctx.get_abspath("workdir/streets-gazdagret.csv");
         let expected = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
 
         update_osm_streets(&ctx, &mut relations, /*update=*/ true).unwrap();
@@ -1134,7 +1111,7 @@ mod tests {
                 relations.set_relation(&relation_name, &relation);
             }
         }
-        let path = ctx.get_abspath("workdir/streets-gazdagret.csv").unwrap();
+        let path = ctx.get_abspath("workdir/streets-gazdagret.csv");
         let expected = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
 
         update_osm_streets(&ctx, &mut relations, /*update=*/ true).unwrap();
@@ -1194,14 +1171,12 @@ mod tests {
         ctx.set_file_system(&file_system_arc);
 
         // Create a CSV that is definitely old enough to be removed.
-        let old_path = ctx.get_abspath("workdir/stats/old.csv").unwrap();
+        let old_path = ctx.get_abspath("workdir/stats/old.csv");
         create_old_file(&old_path);
 
         let now = chrono::NaiveDateTime::from_timestamp(ctx.get_time().now(), 0);
         let today = now.format("%Y-%m-%d").to_string();
-        let path = ctx
-            .get_abspath(&format!("workdir/stats/{}.csv", today))
-            .unwrap();
+        let path = ctx.get_abspath(&format!("workdir/stats/{}.csv", today));
 
         update_stats(&ctx, /*overpass=*/ true).unwrap();
 
@@ -1215,12 +1190,11 @@ mod tests {
         // Make sure that the old CSV is removed.
         assert_eq!(ctx.get_file_system().path_exists(&old_path), false);
 
-        let num_ref: i64 =
-            std::fs::read_to_string(&ctx.get_abspath("workdir/stats/ref.count").unwrap())
-                .unwrap()
-                .trim()
-                .parse()
-                .unwrap();
+        let num_ref: i64 = std::fs::read_to_string(&ctx.get_abspath("workdir/stats/ref.count"))
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
         assert_eq!(num_ref, 300);
     }
 
@@ -1255,7 +1229,7 @@ mod tests {
         file_system.set_files(&files);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
         ctx.set_file_system(&file_system_arc);
-        let stats_path = ctx.get_abspath("workdir/stats/stats.json").unwrap();
+        let stats_path = ctx.get_abspath("workdir/stats/stats.json");
         if std::path::Path::new(&stats_path).exists() {
             std::fs::remove_file(&stats_path).unwrap();
         }
@@ -1592,7 +1566,7 @@ mod tests {
             ],
         );
         file_system.set_files(&files);
-        file_system.set_hide_paths(&[ctx.get_abspath("workdir/stats/2020-05-10.csv").unwrap()]);
+        file_system.set_hide_paths(&[ctx.get_abspath("workdir/stats/2020-05-10.csv")]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
         ctx.set_file_system(&file_system_arc);
 
@@ -1666,7 +1640,7 @@ mod tests {
             ],
         );
         file_system.set_files(&files);
-        file_system.set_hide_paths(&[ctx.get_abspath("workdir/stats/2020-05-10.csv").unwrap()]);
+        file_system.set_hide_paths(&[ctx.get_abspath("workdir/stats/2020-05-10.csv")]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
         ctx.set_file_system(&file_system_arc);
 

--- a/src/parse_access_log.rs
+++ b/src/parse_access_log.rs
@@ -119,7 +119,7 @@ fn get_relation_create_dates(
     ctx: &context::Context,
 ) -> anyhow::Result<HashMap<String, chrono::NaiveDateTime>> {
     let mut ret: HashMap<String, chrono::NaiveDateTime> = HashMap::new();
-    let relations_path = ctx.get_abspath("data/relations.yaml")?;
+    let relations_path = ctx.get_abspath("data/relations.yaml");
     let process_stdout = ctx.get_subprocess().run(vec![
         "git".into(),
         "blame".into(),
@@ -332,7 +332,7 @@ baz\t2\n";
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let relations_path = ctx.get_abspath("data/relations.yaml").unwrap();
+        let relations_path = ctx.get_abspath("data/relations.yaml");
         // 2020-05-09, so this will be recent
         let expected_args = format!("git blame --line-porcelain {}", relations_path);
         let expected_out = "\n\

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -395,7 +395,7 @@ mod tests {
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         handle_progress(&ctx, &src_root, &mut j).unwrap();
         let progress = &j.as_object().unwrap()["progress"];
@@ -411,7 +411,7 @@ mod tests {
         let time = make_test_time_old();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         handle_progress(&ctx, &src_root, &mut j).unwrap();
         let progress = &j.as_object().unwrap()["progress"];
@@ -425,7 +425,7 @@ mod tests {
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         handle_topusers(&ctx, &src_root, &mut j).unwrap();
         let topusers = &j.as_object().unwrap()["topusers"].as_array().unwrap();
@@ -440,7 +440,7 @@ mod tests {
         let time = make_test_time_old();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         handle_topusers(&ctx, &src_root, &mut j).unwrap();
         let topusers = &j.as_object().unwrap()["topusers"].as_array().unwrap();
@@ -454,7 +454,7 @@ mod tests {
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut file_system = context::tests::TestFileSystem::new();
         let today_citycount = b"budapest_01\t100\n\
 budapest_02\t200\n\
@@ -487,7 +487,7 @@ budapest_02\t200\n\
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         // From now on, today is 2020-05-10, so this will read 2020-04-26, 2020-04-27, etc
         // (till a file is missing.)
@@ -504,7 +504,7 @@ budapest_02\t200\n\
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         handle_daily_new(&ctx, &src_root, &mut j, /*day_range=*/ -1).unwrap();
         let daily = &j.as_object().unwrap()["daily"].as_array().unwrap();
@@ -518,7 +518,7 @@ budapest_02\t200\n\
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         handle_monthly_new(&ctx, &src_root, &mut j, /*month_range=*/ 12).unwrap();
         let monthly = &j.as_object().unwrap()["monthly"].as_array().unwrap();
@@ -536,7 +536,7 @@ budapest_02\t200\n\
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         handle_monthly_new(&ctx, &src_root, &mut j, /*month_range=*/ -1).unwrap();
         let monthly = &j.as_object().unwrap()["monthly"].as_array().unwrap();
@@ -550,10 +550,10 @@ budapest_02\t200\n\
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         // This would be the data for the current state of the last, incomplete month.
-        let hide_path = ctx.get_abspath("workdir/stats/2020-05-10.count").unwrap();
+        let hide_path = ctx.get_abspath("workdir/stats/2020-05-10.count");
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -574,7 +574,7 @@ budapest_02\t200\n\
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         handle_daily_total(&ctx, &src_root, &mut j, /*day_range=*/ 13).unwrap();
         let dailytotal = &j.as_object().unwrap()["dailytotal"].as_array().unwrap();
@@ -589,7 +589,7 @@ budapest_02\t200\n\
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         handle_daily_total(&ctx, &src_root, &mut j, /*day_range=*/ -1).unwrap();
         let dailytotal = &j.as_object().unwrap()["dailytotal"].as_array().unwrap();
@@ -603,7 +603,7 @@ budapest_02\t200\n\
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         handle_user_total(&ctx, &src_root, &mut j, /*day_range=*/ 13).unwrap();
         let usertotal = &j.as_object().unwrap()["usertotal"].as_array().unwrap();
@@ -618,7 +618,7 @@ budapest_02\t200\n\
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         handle_user_total(&ctx, &src_root, &mut j, /*day_range=*/ -1).unwrap();
         let usertotal = &j.as_object().unwrap()["usertotal"].as_array().unwrap();
@@ -632,7 +632,7 @@ budapest_02\t200\n\
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         handle_monthly_total(&ctx, &src_root, &mut j, /*month_range=*/ 11).unwrap();
         let monthlytotal = &j.as_object().unwrap()["monthlytotal"].as_array().unwrap();
@@ -647,7 +647,7 @@ budapest_02\t200\n\
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         handle_monthly_total(&ctx, &src_root, &mut j, /*month_range=*/ -1).unwrap();
         let monthlytotal = &j.as_object().unwrap()["monthlytotal"].as_array().unwrap();
@@ -661,7 +661,7 @@ budapest_02\t200\n\
         let time = context::tests::make_test_time();
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         let mut j = serde_json::json!({});
         handle_monthly_total(&ctx, &src_root, &mut j, /*month_range=*/ 0).unwrap();
         let monthlytotal = &j.as_object().unwrap()["monthlytotal"].as_array().unwrap();
@@ -691,7 +691,7 @@ budapest_02\t200\n\
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
         let mut file_system = context::tests::TestFileSystem::new();
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         file_system.set_hide_paths(&vec![format!("{}/2020-04-10.citycount", src_root)]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
         ctx.set_file_system(&file_system_arc);
@@ -707,7 +707,7 @@ budapest_02\t200\n\
         let time_arc: Arc<dyn context::Time> = Arc::new(time);
         ctx.set_time(&time_arc);
         let mut file_system = context::tests::TestFileSystem::new();
-        let src_root = ctx.get_abspath("workdir/stats").unwrap();
+        let src_root = ctx.get_abspath("workdir/stats");
         file_system.set_hide_paths(&vec![format!("{}/2020-05-10.citycount", src_root)]);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
         ctx.set_file_system(&file_system_arc);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1782,7 +1782,7 @@ A street\t9",
     #[test]
     fn test_get_content() {
         let ctx = context::tests::make_test_context().unwrap();
-        let workdir = ctx.get_abspath("workdir").unwrap();
+        let workdir = ctx.get_abspath("workdir");
         let actual =
             String::from_utf8(get_content(&format!("{}/gazdagret.percent", workdir)).unwrap())
                 .unwrap();

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -473,7 +473,7 @@ pub fn handle_static(
     if request_uri.ends_with(".js") {
         let content_type = "application/x-javascript";
         let (content, extra_headers) =
-            util::get_content_with_meta(&ctx.get_abspath(&format!("builddir/{}", path))?)?;
+            util::get_content_with_meta(&ctx.get_abspath(&format!("builddir/{}", path)))?;
         return Ok((content, content_type.into(), extra_headers));
     }
     if request_uri.ends_with(".css") {
@@ -493,12 +493,12 @@ pub fn handle_static(
     }
     if request_uri.ends_with(".ico") {
         let content_type = "image/x-icon";
-        let (content, extra_headers) = util::get_content_with_meta(&ctx.get_abspath(path)?)?;
+        let (content, extra_headers) = util::get_content_with_meta(&ctx.get_abspath(path))?;
         return Ok((content, content_type.into(), extra_headers));
     }
     if request_uri.ends_with(".svg") {
         let content_type = "image/svg+xml";
-        let (content, extra_headers) = util::get_content_with_meta(&ctx.get_abspath(path)?)?;
+        let (content, extra_headers) = util::get_content_with_meta(&ctx.get_abspath(path))?;
         return Ok((content, content_type.into(), extra_headers));
     }
 
@@ -1268,7 +1268,7 @@ pub fn handle_github_webhook(data: Vec<u8>, ctx: &context::Context) -> anyhow::R
         ctx.get_subprocess().run(vec![
             "make".into(),
             "-C".into(),
-            ctx.get_abspath("")?,
+            ctx.get_abspath(""),
             "deploy".into(),
         ])?;
         // Nominally a failure, so the service gets restarted.

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1405,7 +1405,7 @@ fn our_application_txt(
             ));
             data = output.as_bytes().to_vec();
         } else if request_uri.ends_with("robots.txt") {
-            data = util::get_content(&ctx.get_abspath("data/robots.txt")?)?;
+            data = util::get_content(&ctx.get_abspath("data/robots.txt"))?;
         } else {
             // assume txt
             let output = missing_housenumbers_view_txt(ctx, relations, request_uri)?;
@@ -1840,10 +1840,7 @@ pub mod tests {
         // Make sure the cache is outdated.
         let mut mtimes: HashMap<String, f64> = HashMap::new();
         mtimes.insert(
-            test_wsgi
-                .ctx
-                .get_abspath("workdir/gazdagret.htmlcache.en")
-                .unwrap(),
+            test_wsgi.ctx.get_abspath("workdir/gazdagret.htmlcache.en"),
             0_f64,
         );
         file_system.set_mtimes(&mtimes);
@@ -1934,10 +1931,7 @@ pub mod tests {
     #[test]
     fn test_missing_housenumbers_view_result_txt_even_odd() {
         let mut test_wsgi = TestWsgi::new();
-        let cache_path = test_wsgi
-            .ctx
-            .get_abspath("workdir/gazdagret.txtcache")
-            .unwrap();
+        let cache_path = test_wsgi.ctx.get_abspath("workdir/gazdagret.txtcache");
         if std::path::Path::new(&cache_path).exists() {
             std::fs::remove_file(&cache_path).unwrap();
         }
@@ -2571,7 +2565,7 @@ Tűzkő utca	31
             .finish();
         let mut test_wsgi = TestWsgi::new();
         test_wsgi.bytes = query_string.as_bytes().to_vec();
-        let expected_args = format!("make -C {} deploy", test_wsgi.ctx.get_abspath("").unwrap());
+        let expected_args = format!("make -C {} deploy", test_wsgi.ctx.get_abspath(""));
         let outputs: HashMap<_, _> = vec![(expected_args, "".to_string())].into_iter().collect();
         let subprocess = context::tests::TestSubprocess::new(&outputs);
         let subprocess_arc: Arc<dyn context::Subprocess> = Arc::new(subprocess);


### PR DESCRIPTION
I.e. make it never fail, it was just a leftover.

Change-Id: I1ed60a43c7b184a181c14afa255db98f2df8ed2d
