### PR TITLE
yattag: test escaping

### DIFF
--- a/src/yattag.rs
+++ b/src/yattag.rs
@@ -109,3 +109,22 @@ impl Drop for Tag {
             .push_str(&format!("</{}>", self.name));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests the required escaping.
+    #[test]
+    fn test_escape() {
+        let doc = Doc::default();
+        {
+            let _a = doc.tag("a", &[("href", r#"https://www.example.com/"x"#)]);
+            doc.text("here>y");
+        }
+        assert_eq!(
+            doc.get_value(),
+            r#"<a href="https://www.example.com/&quot;x">here&gt;y</a>"#
+        );
+    }
+}


### PR DESCRIPTION
With this, 100% line coverage is reached in yattag.rs.

Change-Id: Ib8d87860dc4d74e8064e2296e0c87eb376460e6e
