### PR TITLE
CI: require 100% statement coverage for Rust code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,10 +96,8 @@ check-clippy: Cargo.toml $(RS_OBJECTS)
 $(foreach BINARY_CRATE,$(BINARY_CRATES),target/${TARGET_PATH}/$(BINARY_CRATE)) &: $(RS_OBJECTS) Cargo.toml Makefile
 	cargo build $(foreach BINARY_CRATE,$(BINARY_CRATES),--bin $(BINARY_CRATE)) ${CARGO_OPTIONS}
 
+# Without coverage: cargo test --lib -- --test-threads=1
 check-unit: Cargo.toml $(RS_OBJECTS) locale/hu/LC_MESSAGES/osm-gimmisn.mo testdata data/yamls.cache
-	cargo test --lib ${CARGO_OPTIONS} -- --test-threads=1
-
-check-cov:
 	cargo tarpaulin --lib -v --skip-clean --fail-under 100 --target-dir ${PWD}/target-cov ${CARGO_OPTIONS} -- --test-threads=1
 
 config.ts: wsgi.ini Makefile

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -865,9 +865,8 @@ mod tests {
         }
         let path = ctx.get_abspath("workdir/gazdagret-additional-streets.count");
         let expected: String = "1".into();
-        if file_system.path_exists(&path) {
-            std::fs::remove_file(&path).unwrap();
-        }
+        std::fs::File::create(&path).unwrap();
+        std::fs::remove_file(&path).unwrap();
         update_additional_streets(&mut relations, /*update=*/ true).unwrap();
         let mtime = file_system.getmtime(&path).unwrap();
 

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -14,6 +14,8 @@ if [ -n "${GITHUB_WORKFLOW}" ]; then
     sudo locale-gen hu_HU.UTF-8
 
     sudo apt-get install gettext
+
+    cargo install --version 0.18.5 cargo-tarpaulin
 fi
 make -j$(getconf _NPROCESSORS_ONLN) check RSDEBUG=1
 


### PR DESCRIPTION
This used to be the case for Python code, just got lost during porting.

Change-Id: Ie9923fae22d96c6254f4ca5359a589ccd716b84e
