### PR TITLE
webframe: take a rouille::Request in compress_response()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.56.1
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.3.0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:

--- a/src/wsgi_json.rs
+++ b/src/wsgi_json.rs
@@ -99,7 +99,7 @@ fn missing_streets_update_result_json(
 
 /// Dispatches json requests based on their URIs.
 pub fn our_application_json(
-    environ: &HashMap<String, String>,
+    request: &rouille::Request,
     ctx: &context::Context,
     relations: &mut areas::Relations,
     request_uri: &str,
@@ -120,7 +120,7 @@ pub fn our_application_json(
     }
     let output_bytes = output.as_bytes();
     let response = webframe::Response::new(content_type, "200 OK", output_bytes, &headers);
-    webframe::compress_response(environ, &response)
+    webframe::compress_response(request, &response)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes the problem that we expected the old Python HTTP_ACCEPT_ENCODING
header, while rouille provides the header as-is.

Also allows simplifying webframe::handle_error() and
wsgi::our_application().

Finally give Swatinem/rust-cache a try, perhaps it can speed up the
build somewhat.

Change-Id: I7fc115a9852facdad8f2159aedd180f79e15f28f
