### PR TITLE
webframe: change Response to match the header format of rouille

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           toolchain: 1.56.1
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v1.3.0
+        uses: Swatinem/rust-cache@v1
       - name: Setup Node
         uses: actions/setup-node@v1
         with:

--- a/src/bin/rouille.rs
+++ b/src/bin/rouille.rs
@@ -17,18 +17,6 @@ fn app(request: &rouille::Request) -> anyhow::Result<rouille::Response> {
     let ctx = osm_gimmisn::context::Context::new("")?;
     // TODO return a rouille::Response in the first place.
     let (status_code, headers, data) = wsgi::application(request, &ctx)?;
-    let headers: Vec<(
-        std::borrow::Cow<'static, str>,
-        std::borrow::Cow<'static, str>,
-    )> = headers
-        .iter()
-        .map(|(key, value)| {
-            (
-                std::borrow::Cow::Owned(key.into()),
-                std::borrow::Cow::Owned(value.into()),
-            )
-        })
-        .collect();
     Ok(rouille::Response {
         status_code,
         headers,

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,6 +19,7 @@ use crate::yattag;
 use anyhow::anyhow;
 use anyhow::Context;
 use lazy_static::lazy_static;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::TryFrom;
@@ -1018,7 +1019,8 @@ pub fn get_content(path: &str) -> anyhow::Result<Vec<u8>> {
     Ok(std::fs::read(path)?)
 }
 
-type HttpHeaders = Vec<(String, String)>;
+// TODO move to webframe and avoid the duplication with webframe::Headers.
+type HttpHeaders = Vec<(Cow<'static, str>, Cow<'static, str>)>;
 
 /// Gets the content of a file in workdir with metadata.
 pub fn get_content_with_meta(path: &str) -> anyhow::Result<(Vec<u8>, HttpHeaders)> {
@@ -1028,7 +1030,7 @@ pub fn get_content_with_meta(path: &str) -> anyhow::Result<(Vec<u8>, HttpHeaders
     let modified = metadata.modified()?;
     let modified_utc: chrono::DateTime<chrono::offset::Utc> = modified.into();
 
-    let extra_headers = vec![("Last-Modified".to_string(), modified_utc.to_rfc2822())];
+    let extra_headers = vec![("Last-Modified".into(), modified_utc.to_rfc2822().into())];
     Ok((buf, extra_headers))
 }
 

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1367,7 +1367,7 @@ fn our_application_txt(
     request_uri: &str,
 ) -> anyhow::Result<webframe::Response> {
     let mut content_type = "text/plain";
-    let mut headers: Vec<(String, String)> = Vec::new();
+    let mut headers: webframe::Headers = Vec::new();
     let prefix = ctx.get_ini().get_uri_prefix()?;
     let mut chkl = false;
     if let Some(value) = std::path::Path::new(request_uri).extension() {
@@ -1380,7 +1380,7 @@ fn our_application_txt(
             content_type = "application/octet-stream";
             headers.push((
                 "Content-Disposition".into(),
-                format!(r#"attachment;filename="{}.txt""#, relation_name),
+                format!(r#"attachment;filename="{}.txt""#, relation_name).into(),
             ));
         }
         data = output.as_bytes().to_vec();
@@ -1391,7 +1391,7 @@ fn our_application_txt(
             content_type = "application/octet-stream";
             headers.push((
                 "Content-Disposition".into(),
-                format!(r#"attachment;filename="{}.txt""#, relation_name),
+                format!(r#"attachment;filename="{}.txt""#, relation_name).into(),
             ));
         }
         data = output.as_bytes().to_vec();
@@ -1403,7 +1403,7 @@ fn our_application_txt(
             content_type = "application/octet-stream";
             headers.push((
                 "Content-Disposition".into(),
-                format!(r#"attachment;filename="{}.txt""#, relation_name),
+                format!(r#"attachment;filename="{}.txt""#, relation_name).into(),
             ));
             data = output.as_bytes().to_vec();
         } else if request_uri.ends_with("robots.txt") {


### PR DESCRIPTION
This allows eliminating the untested conversion code in
src/bin/rouille.rs.

Change-Id: I873e291f84c3b802fb613f614acdd90b7ecccee2
