### PR TITLE
webframe: turn compress_response() into a trivial wrapper

### DIFF
--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -511,15 +511,9 @@ pub fn handle_static(
 pub fn compress_response(
     request: &rouille::Request,
     response: rouille::Response,
-) -> anyhow::Result<(u16, Headers, Vec<u8>)> {
-    // Apply content encoding: gzip, etc.
-    let compressed = rouille::content_encoding::apply(request, response);
-
-    // TODO avoid this mapping.
-    let (mut reader, _size) = compressed.data.into_reader_and_size();
-    let mut buffer = Vec::new();
-    reader.read_to_end(&mut buffer)?;
-    Ok((compressed.status_code, compressed.headers, buffer))
+) -> anyhow::Result<rouille::Response> {
+    // TODO clean up this not needed wrapper.
+    Ok(rouille::content_encoding::apply(request, response))
 }
 
 /// Displays an unhandled error on the page.
@@ -540,8 +534,7 @@ pub fn handle_error(request: &rouille::Request, error: &str) -> anyhow::Result<r
         vec![("Content-type".into(), "text/html; charset=utf-8".into())],
         doc.get_value().as_bytes().to_vec(),
     );
-    let (status_code, headers, data) = compress_response(request, response)?;
-    Ok(make_response(status_code, headers, data))
+    compress_response(request, response)
 }
 
 /// Displays a not-found page.

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1464,12 +1464,10 @@ fn our_application(
     }
 
     if ext == "txt" || ext == "chkl" {
-        // TODO return a rouille::Response in the first place.
-        let (status_code, headers, data) = webframe::compress_response(
+        return webframe::compress_response(
             request,
             our_application_txt(ctx, &mut relations, &request_uri)?,
-        )?;
-        return Ok(webframe::make_response(status_code, headers, data));
+        );
     }
 
     let prefix = ctx.get_ini().get_uri_prefix()?;
@@ -1480,9 +1478,7 @@ fn our_application(
             vec![("Content-type".into(), "text/html; charset=utf-8".into())],
             doc.get_value().as_bytes().to_vec(),
         );
-        // TODO return a rouille::Response in the first place.
-        let (status_code, headers, data) = webframe::compress_response(request, response)?;
-        return Ok(webframe::make_response(status_code, headers, data));
+        return webframe::compress_response(request, response);
     }
 
     if request_uri.starts_with(&format!("{}/static/", prefix))
@@ -1492,16 +1488,11 @@ fn our_application(
         let (output, content_type, mut headers) = webframe::handle_static(ctx, &request_uri)?;
         headers.push(("Content-type".into(), content_type.into()));
         let response = webframe::make_response(200_u16, headers, output);
-        // TODO return a rouille::Response in the first place.
-        let (status_code, headers, data) = webframe::compress_response(request, response)?;
-        return Ok(webframe::make_response(status_code, headers, data));
+        return webframe::compress_response(request, response);
     }
 
     if ext == "json" {
-        // TODO return a rouille::Response in the first place.
-        let (status_code, headers, data) =
-            wsgi_json::our_application_json(request, ctx, &mut relations, &request_uri)?;
-        return Ok(webframe::make_response(status_code, headers, data));
+        return wsgi_json::our_application_json(request, ctx, &mut relations, &request_uri);
     }
 
     let doc = yattag::Doc::new();
@@ -1536,9 +1527,7 @@ fn our_application(
         vec![("Content-type".into(), "text/html; charset=utf-8".into())],
         doc.get_value().as_bytes().to_vec(),
     );
-    // TODO return a rouille::Response in the first place.
-    let (status_code, headers, data) = webframe::compress_response(request, response)?;
-    Ok(webframe::make_response(status_code, headers, data))
+    webframe::compress_response(request, response)
 }
 
 /// The entry point of this WSGI app.

--- a/src/wsgi_json.rs
+++ b/src/wsgi_json.rs
@@ -103,7 +103,7 @@ pub fn our_application_json(
     ctx: &context::Context,
     relations: &mut areas::Relations,
     request_uri: &str,
-) -> anyhow::Result<(u16, webframe::Headers, Vec<u8>)> {
+) -> anyhow::Result<rouille::Response> {
     let mut headers: webframe::Headers = Vec::new();
     let prefix = ctx.get_ini().get_uri_prefix()?;
     let output: String;


### PR DESCRIPTION
Avoids pointless conversion between rouille::Response and status code /
headers / data.

Change-Id: I4f6052422b0459f3d4a244ebdd416d45b0bda614
