### PR TITLE
webframe: clean up not needed compress_response()

### DIFF
--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -507,15 +507,6 @@ pub fn handle_static(
     Ok((bytes, "".into(), extra_headers))
 }
 
-/// Turns an output string into a byte array and sends it.
-pub fn compress_response(
-    request: &rouille::Request,
-    response: rouille::Response,
-) -> anyhow::Result<rouille::Response> {
-    // TODO clean up this not needed wrapper.
-    Ok(rouille::content_encoding::apply(request, response))
-}
-
 /// Displays an unhandled error on the page.
 pub fn handle_error(request: &rouille::Request, error: &str) -> anyhow::Result<rouille::Response> {
     let doc = yattag::Doc::new();
@@ -529,12 +520,12 @@ pub fn handle_error(request: &rouille::Request, error: &str) -> anyhow::Result<r
         ));
         doc.text(error);
     }
-    let response = make_response(
+    // TODO this never fails
+    Ok(make_response(
         500_u16,
         vec![("Content-type".into(), "text/html; charset=utf-8".into())],
         doc.get_value().as_bytes().to_vec(),
-    );
-    compress_response(request, response)
+    ))
 }
 
 /// Displays a not-found page.

--- a/src/wsgi_json.rs
+++ b/src/wsgi_json.rs
@@ -99,7 +99,6 @@ fn missing_streets_update_result_json(
 
 /// Dispatches json requests based on their URIs.
 pub fn our_application_json(
-    request: &rouille::Request,
     ctx: &context::Context,
     relations: &mut areas::Relations,
     request_uri: &str,
@@ -122,8 +121,7 @@ pub fn our_application_json(
         "Content-type".into(),
         "application/json; charset=utf-8".into(),
     ));
-    let response = webframe::make_response(200_u16, headers, output_bytes);
-    webframe::compress_response(request, response)
+    Ok(webframe::make_response(200_u16, headers, output_bytes))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Use rouille directly, and only at a single place.

Change-Id: Iae6ec9950331399c8aa8e530c0dafe9b712f761e
