### PR TITLE
make: stop maintaining a list of binary crates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ wsgi.ini
 # Rust
 Cargo.lock
 target
+target-cov
 check-clippy
 check-rustfmt
 


### PR DESCRIPTION
Let cargo do that. That is enough, and avoids the problem that 'make
-j8' invokes 'cargo build' multiple times for no reason.

Change-Id: I2b52375ea6da1b0abde49cda98b68d775999565f
