### PR TITLE
Update to Rust 1.57.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.56.1
+          toolchain: 1.57.0
       - name: Rust Cache
         uses: actions/cache@v2
         with:
@@ -25,7 +25,7 @@ jobs:
             ~/.cargo/git/db/
             target/
             target-cov/
-          key: ${{ runner.os }}-cargo-1.56.1-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-1.57.0-${{ hashFiles('**/Cargo.toml') }}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,6 @@ utime = "0.3.1"
 icu = ["rust_icu_ucol", "rust_icu_ustring"]
 default = ["icu"]
 
-# Enable symbols (for callgrind):
-# [profile.release]
-# debug = true
+[profile.symbols]
+inherits = "release"
+debug = true

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -50,10 +50,11 @@ cargo test --lib -- --test-threads=1 wsgi_json::tests::test_missing_streets_upda
 
 == Rust performance profiling
 
-Enable symbols in Cargo.toml, then:
+The symbols profile enables debug symbols while keeping optimizations on:
 
 ----
-valgrind --tool=callgrind target/release/missing_housenumbers budapest_11
+cargo build --profile symbols
+valgrind --tool=callgrind target/symbols/missing_housenumbers budapest_11
 ----
 
 == YAML schema

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1178,7 +1178,6 @@ impl Relation {
 /// A relations object is a container of named relation objects.
 #[derive(Clone)]
 pub struct Relations {
-    workdir: String,
     ctx: context::Context,
     yaml_cache: serde_json::Map<String, serde_json::Value>,
     dict: serde_json::Map<String, serde_json::Value>,
@@ -1190,7 +1189,6 @@ pub struct Relations {
 
 impl Relations {
     pub fn new(ctx: &context::Context) -> anyhow::Result<Self> {
-        let workdir = ctx.get_ini().get_workdir()?;
         let yamls_cache = format!("{}/{}", ctx.get_abspath("data"), "yamls.cache");
         let stream = ctx
             .get_file_system()
@@ -1233,7 +1231,6 @@ impl Relations {
             })
             .collect();
         Ok(Relations {
-            workdir,
             ctx: ctx.clone(),
             yaml_cache: yaml_cache.clone(),
             dict,

--- a/src/util.rs
+++ b/src/util.rs
@@ -851,10 +851,7 @@ pub fn tsv_to_list(csv_read: &mut CsvRead<'_>) -> anyhow::Result<Vec<Vec<yattag:
                 columns.insert(label.into(), index);
             }
         }
-        let mut cells: Vec<yattag::Doc> = row
-            .iter()
-            .map(|cell| yattag::Doc::from_text(cell))
-            .collect();
+        let mut cells: Vec<yattag::Doc> = row.iter().map(yattag::Doc::from_text).collect();
         if !cells.is_empty() && columns.contains_key("@type") {
             // We know the first column is an OSM ID.
             if let Ok(osm_id) = cells[0].get_value().parse::<u64>() {


### PR DESCRIPTION
Which finally allows performance profiling without touching Cargo.toml.

Also remove a redundant closure and an unused field, both are caught by
the new version.

Change-Id: I0955e0f1e705f4de974bf82726d5ed45a0d198ec
