### PR TITLE
yattag: associate text with its tag explicitly

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -97,34 +97,34 @@ pub fn get_missing_housenumbers_html(
         .context("write_missing_housenumbers() failed")?;
 
     {
-        let _p = doc.tag("p", &[]);
+        let p = doc.tag("p", &[]);
         let prefix = ctx.get_ini().get_uri_prefix()?;
         let relation_name = relation.get_name();
-        doc.text(
+        p.text(
             &tr("OpenStreetMap is possibly missing the below {0} house numbers for {1} streets.")
                 .replace("{0}", &todo_count.to_string())
                 .replace("{1}", &todo_street_count.to_string()),
         );
-        doc.text(
+        p.text(
             &tr(" (existing: {0}, ready: {1}).")
                 .replace("{0}", &done_count.to_string())
                 .replace("{1}", &util::format_percent(&percent)?),
         );
-        doc.stag("br", &[]);
+        doc.stag("br");
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
                     "https://github.com/vmiklos/osm-gimmisn/tree/master/doc",
                 )],
             );
-            doc.text(&tr("Filter incorrect information"));
+            a.text(&tr("Filter incorrect information"));
         }
         doc.text(".");
-        doc.stag("br", &[]);
+        doc.stag("br");
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
@@ -134,11 +134,11 @@ pub fn get_missing_housenumbers_html(
                     ),
                 )],
             );
-            doc.text(&tr("Overpass turbo query for the below streets"));
+            a.text(&tr("Overpass turbo query for the below streets"));
         }
-        doc.stag("br", &[]);
+        doc.stag("br");
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
@@ -148,11 +148,11 @@ pub fn get_missing_housenumbers_html(
                     ),
                 )],
             );
-            doc.text(&tr("Plain text format"));
+            a.text(&tr("Plain text format"));
         }
-        doc.stag("br", &[]);
+        doc.stag("br");
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
@@ -162,7 +162,7 @@ pub fn get_missing_housenumbers_html(
                     ),
                 )],
             );
-            doc.text(&tr("Checklist format"));
+            a.text(&tr("Checklist format"));
         }
     }
 
@@ -200,21 +200,21 @@ pub fn get_additional_housenumbers_html(
     let (todo_street_count, todo_count, table) = relation.write_additional_housenumbers()?;
 
     {
-        let _p = doc.tag("p", &[]);
-        doc.text(
+        let p = doc.tag("p", &[]);
+        p.text(
             &tr("OpenStreetMap additionally has the below {0} house numbers for {1} streets.")
                 .replace("{0}", &todo_count.to_string())
                 .replace("{1}", &todo_street_count.to_string()),
         );
-        doc.stag("br", &[]);
-        let _a = doc.tag(
+        doc.stag("br");
+        let a = doc.tag(
             "a",
             &[(
                 "href",
                 "https://github.com/vmiklos/osm-gimmisn/tree/master/doc",
             )],
         );
-        doc.text(&tr("Filter incorrect information"));
+        a.text(&tr("Filter incorrect information"));
     }
 
     doc.append_value(util::html_table_from_list(&table).get_value());

--- a/src/util.rs
+++ b/src/util.rs
@@ -170,7 +170,7 @@ impl Street {
         let doc = yattag::Doc::new();
         doc.text(&self.osm_name);
         if self.osm_name != self.ref_name && self.show_ref_street {
-            doc.stag("br", &[]);
+            doc.stag("br");
             doc.text("(");
             doc.text(&self.ref_name);
             doc.text(")");
@@ -469,7 +469,7 @@ pub fn format_even_odd_html(only_in_ref: &[HouseNumberRange]) -> yattag::Doc {
         doc.append_value(color_house_number(elem).get_value());
     }
     if !even.is_empty() && !odd.is_empty() {
-        doc.stag("br", &[]);
+        doc.stag("br");
     }
     for (index, elem) in even.iter().enumerate() {
         if index > 0 {
@@ -492,14 +492,14 @@ pub fn color_house_number(house_number: &HouseNumberRange) -> yattag::Doc {
     chars.next_back();
     let number = chars.as_str();
     let title = house_number.get_comment().replace("&#013;", "\n");
-    let _span = doc.tag("span", &[("style", "color: blue;")]);
+    let span = doc.tag("span", &[("style", "color: blue;")]);
     if !title.is_empty() {
         {
-            let _abbr = doc.tag("abbr", &[("title", title.as_str()), ("tabindex", "0")]);
-            doc.text(number);
+            let abbr = doc.tag("abbr", &[("title", title.as_str()), ("tabindex", "0")]);
+            abbr.text(number);
         }
     } else {
-        doc.text(number);
+        span.text(number);
     }
     doc
 }
@@ -660,11 +660,11 @@ pub fn parse_filters(tokens: &[String]) -> HashMap<String, String> {
 /// Handles a HTTP error from Overpass.
 pub fn handle_overpass_error(ctx: &context::Context, http_error: &str) -> yattag::Doc {
     let doc = yattag::Doc::new();
-    let _div = doc.tag("div", &[("id", "overpass-error")]);
-    doc.text(&tr("Overpass error: {0}").replace("{0}", http_error));
+    let div = doc.tag("div", &[("id", "overpass-error")]);
+    div.text(&tr("Overpass error: {0}").replace("{0}", http_error));
     let sleep = overpass_query::overpass_query_need_sleep(ctx);
     if sleep > 0 {
-        doc.stag("br", &[]);
+        doc.stag("br");
         doc.text(&tr("Note: wait for {} seconds").replace("{}", &sleep.to_string()));
     }
     doc
@@ -692,8 +692,8 @@ pub fn setup_localization(headers: rouille::HeadersIter<'_>) -> String {
 /// Generates a link to a URL with a given label.
 pub fn gen_link(url: &str, label: &str) -> yattag::Doc {
     let doc = yattag::Doc::new();
-    let _a = doc.tag("a", &[("href", url)]);
-    doc.text(&(label.to_string() + "..."));
+    let a = doc.tag("a", &[("href", url)]);
+    a.text(&(label.to_string() + "..."));
     doc
 }
 
@@ -743,17 +743,17 @@ pub fn should_expand_range(numbers: &[i64], street_is_even_odd: bool) -> (bool, 
 /// Produces a HTML table from a list of lists.
 pub fn html_table_from_list(table: &[Vec<yattag::Doc>]) -> yattag::Doc {
     let doc = yattag::Doc::new();
-    let _table = doc.tag("table", &[("class", "sortable")]);
+    let table_tag = doc.tag("table", &[("class", "sortable")]);
     for (row_index, row_content) in table.iter().enumerate() {
-        let _tr = doc.tag("tr", &[]);
+        let tr = table_tag.tag("tr", &[]);
         for cell in row_content {
             if row_index == 0 {
-                let _th = doc.tag("th", &[]);
-                let _a = doc.tag("a", &[("href", "#")]);
-                doc.text(&cell.get_value());
+                let th = tr.tag("th", &[]);
+                let a = th.tag("a", &[("href", "#")]);
+                a.text(&cell.get_value());
             } else {
-                let _td = doc.tag("td", &[]);
-                doc.append_value(cell.get_value())
+                let td = tr.tag("td", &[]);
+                td.append_value(cell.get_value())
             }
         }
     }
@@ -764,31 +764,31 @@ pub fn html_table_from_list(table: &[Vec<yattag::Doc>]) -> yattag::Doc {
 pub fn invalid_refstreets_to_html(osm_invalids: &[String], ref_invalids: &[String]) -> yattag::Doc {
     let doc = yattag::Doc::new();
     if !osm_invalids.is_empty() {
-        doc.stag("br", &[]);
-        let _div = doc.tag("div", &[("id", "osm-invalids-container")]);
-        doc.text(&tr(
+        doc.stag("br");
+        let div = doc.tag("div", &[("id", "osm-invalids-container")]);
+        div.text(&tr(
             "Warning: broken OSM <-> reference mapping, the following OSM names are invalid:",
         ));
-        let _ul = doc.tag("ul", &[]);
+        let ul = doc.tag("ul", &[]);
         for osm_invalid in osm_invalids {
-            let _li = doc.tag("li", &[]);
-            doc.text(osm_invalid);
+            let li = ul.tag("li", &[]);
+            li.text(osm_invalid);
         }
     }
     if !ref_invalids.is_empty() {
-        doc.stag("br", &[]);
-        let _div = doc.tag("div", &[("id", "ref-invalids-container")]);
-        doc.text(&tr(
+        doc.stag("br");
+        let div = doc.tag("div", &[("id", "ref-invalids-container")]);
+        div.text(&tr(
             "Warning: broken OSM <-> reference mapping, the following reference names are invalid:",
         ));
-        let _ul = doc.tag("ul", &[]);
+        let ul = doc.tag("ul", &[]);
         for ref_invalid in ref_invalids {
-            let _li = doc.tag("li", &[]);
-            doc.text(ref_invalid);
+            let li = ul.tag("li", &[]);
+            li.text(ref_invalid);
         }
     }
     if !osm_invalids.is_empty() || !ref_invalids.is_empty() {
-        doc.stag("br", &[]);
+        doc.stag("br");
         doc.text(&tr(
             "Note: an OSM name is invalid if it's not in the OSM database.",
         ));
@@ -803,15 +803,15 @@ pub fn invalid_refstreets_to_html(osm_invalids: &[String], ref_invalids: &[Strin
 pub fn invalid_filter_keys_to_html(invalids: &[String]) -> yattag::Doc {
     let doc = yattag::Doc::new();
     if !invalids.is_empty() {
-        doc.stag("br", &[]);
-        let _div = doc.tag("div", &[("id", "osm-filter-key-invalids-container")]);
-        doc.text(&tr(
+        doc.stag("br");
+        let div = doc.tag("div", &[("id", "osm-filter-key-invalids-container")]);
+        div.text(&tr(
             "Warning: broken filter key name, the following key names are not OSM names:",
         ));
-        let _ul = doc.tag("ul", &[]);
+        let ul = doc.tag("ul", &[]);
         for invalid in invalids {
-            let _li = doc.tag("li", &[]);
-            doc.text(invalid);
+            let li = ul.tag("li", &[]);
+            li.text(invalid);
         }
     }
     doc
@@ -859,8 +859,8 @@ pub fn tsv_to_list(csv_read: &mut CsvRead<'_>) -> anyhow::Result<Vec<Vec<yattag:
                 let doc = yattag::Doc::new();
                 let href = format!("https://www.openstreetmap.org/{}/{}", osm_type, osm_id);
                 {
-                    let _a = doc.tag("a", &[("href", href.as_str()), ("target", "_blank")]);
-                    doc.text(&osm_id.to_string());
+                    let a = doc.tag("a", &[("href", href.as_str()), ("target", "_blank")]);
+                    a.text(&osm_id.to_string());
                 }
                 cells[0] = doc;
             }
@@ -962,11 +962,11 @@ pub fn git_link(version: &str, prefix: &str) -> yattag::Doc {
         commit_hash = cap[1].into();
     }
     let doc = yattag::Doc::new();
-    let _a = doc.tag(
+    let a = doc.tag(
         "a",
         &[("href", (prefix.to_string() + &commit_hash).as_str())],
     );
-    doc.text(version);
+    a.text(version);
     doc
 }
 

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -48,14 +48,14 @@ pub fn get_footer(last_updated: &str) -> yattag::Doc {
         }
     }
     let doc = yattag::Doc::new();
-    doc.stag("hr", &[]);
+    doc.stag("hr");
     {
-        let _div = doc.tag("div", &[]);
+        let div = doc.tag("div", &[]);
         for (index, item) in items.iter().enumerate() {
             if index > 0 {
-                doc.text(" ¦ ");
+                div.text(" ¦ ");
             }
-            doc.append_value(item.get_value());
+            div.append_value(item.get_value());
         }
     }
     doc
@@ -75,11 +75,11 @@ fn fill_header_function(
         // to update OSM house numbers first.
         let doc = yattag::Doc::new();
         {
-            let _span = doc.tag("span", &[("id", "trigger-street-housenumbers-update")]);
+            let span = doc.tag("span", &[("id", "trigger-street-housenumbers-update")]);
             {
                 // TODO consider using HTTP POST here, see
                 // https://stackoverflow.com/questions/1367409/how-to-make-button-look-like-a-link
-                let _a = doc.tag(
+                let a = span.tag(
                     "a",
                     &[(
                         "href",
@@ -89,16 +89,16 @@ fn fill_header_function(
                         ),
                     )],
                 );
-                doc.text(&tr("Update from OSM"));
+                a.text(&tr("Update from OSM"));
             }
         }
         items.push(doc);
 
         let doc = yattag::Doc::new();
         {
-            let _span = doc.tag("span", &[("id", "trigger-missing-housenumbers-update")]);
+            let span = doc.tag("span", &[("id", "trigger-missing-housenumbers-update")]);
             {
-                let _a = doc.tag(
+                let a = span.tag(
                     "a",
                     &[(
                         "href",
@@ -108,7 +108,7 @@ fn fill_header_function(
                         ),
                     )],
                 );
-                doc.text(&tr("Update from reference"));
+                a.text(&tr("Update from reference"));
             }
         }
         items.push(doc);
@@ -117,41 +117,41 @@ fn fill_header_function(
         // to update OSM streets first.
         let doc = yattag::Doc::new();
         {
-            let _span = doc.tag("span", &[("id", "trigger-streets-update")]);
+            let span = doc.tag("span", &[("id", "trigger-streets-update")]);
             {
-                let _a = doc.tag(
+                let a = span.tag(
                     "a",
                     &[(
                         "href",
                         &format!("{}/streets/{}/update-result", prefix, relation_name),
                     )],
                 );
-                doc.text(&tr("Update from OSM"));
+                a.text(&tr("Update from OSM"));
             }
         }
         items.push(doc);
 
         let doc = yattag::Doc::new();
         {
-            let _span = doc.tag("span", &[("id", "trigger-missing-streets-update")]);
+            let span = doc.tag("span", &[("id", "trigger-missing-streets-update")]);
             {
-                let _a = doc.tag(
+                let a = span.tag(
                     "a",
                     &[(
                         "href",
                         &format!("{}/missing-streets/{}/update-result", prefix, relation_name),
                     )],
                 );
-                doc.text(&tr("Update from reference"));
+                a.text(&tr("Update from reference"));
             }
         }
         items.push(doc);
     } else if function == "street-housenumbers" {
         let doc = yattag::Doc::new();
         {
-            let _span = doc.tag("span", &[("id", "trigger-street-housenumbers-update")]);
+            let span = doc.tag("span", &[("id", "trigger-street-housenumbers-update")]);
             {
-                let _a = doc.tag(
+                let a = span.tag(
                     "a",
                     &[(
                         "href",
@@ -161,13 +161,13 @@ fn fill_header_function(
                         ),
                     )],
                 );
-                doc.text(&tr("Call Overpass to update"));
+                a.text(&tr("Call Overpass to update"));
             }
         }
         items.push(doc);
         let doc = yattag::Doc::new();
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
@@ -177,35 +177,35 @@ fn fill_header_function(
                     ),
                 )],
             );
-            doc.text(&tr("View query"));
+            a.text(&tr("View query"));
         }
         items.push(doc);
     } else if function == "streets" {
         let doc = yattag::Doc::new();
         {
-            let _span = doc.tag("span", &[("id", "trigger-streets-update")]);
+            let span = doc.tag("span", &[("id", "trigger-streets-update")]);
             {
-                let _a = doc.tag(
+                let a = span.tag(
                     "a",
                     &[(
                         "href",
                         &format!("{}/streets/{}/update-result", prefix, relation_name),
                     )],
                 );
-                doc.text(&tr("Call Overpass to update"));
+                a.text(&tr("Call Overpass to update"));
             }
         }
         items.push(doc);
         let doc = yattag::Doc::new();
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
                     &format!("{}/streets/{}/view-query", prefix, relation_name),
                 )],
             );
-            doc.text(&tr("View query"));
+            a.text(&tr("View query"));
         }
         items.push(doc);
     }
@@ -225,7 +225,7 @@ fn fill_missing_header_items(
     if streets != "only" {
         let doc = yattag::Doc::new();
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
@@ -235,14 +235,14 @@ fn fill_missing_header_items(
                     ),
                 )],
             );
-            doc.text(&tr("Missing house numbers"));
+            a.text(&tr("Missing house numbers"));
         }
         items.push(doc);
 
         if additional_housenumbers {
             let doc = yattag::Doc::new();
             {
-                let _a = doc.tag(
+                let a = doc.tag(
                     "a",
                     &[(
                         "href",
@@ -252,7 +252,7 @@ fn fill_missing_header_items(
                         ),
                     )],
                 );
-                doc.text(&tr("Additional house numbers"));
+                a.text(&tr("Additional house numbers"));
             }
             items.push(doc);
         }
@@ -260,19 +260,19 @@ fn fill_missing_header_items(
     if streets != "no" {
         let doc = yattag::Doc::new();
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
                     &format!("{}/missing-streets/{}/view-result", prefix, relation_name),
                 )],
             );
-            doc.text(&tr("Missing streets"));
+            a.text(&tr("Missing streets"));
         }
         items.push(doc);
         let doc = yattag::Doc::new();
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
@@ -282,7 +282,7 @@ fn fill_missing_header_items(
                     ),
                 )],
             );
-            doc.text(&tr("Additional streets"));
+            a.text(&tr("Additional streets"));
         }
         items.push(doc);
     }
@@ -301,7 +301,7 @@ fn fill_existing_header_items(
     if streets != "only" {
         let doc = yattag::Doc::new();
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
@@ -311,21 +311,21 @@ fn fill_existing_header_items(
                     ),
                 )],
             );
-            doc.text(&tr("Existing house numbers"));
+            a.text(&tr("Existing house numbers"));
         }
         items.push(doc);
     }
 
     let doc = yattag::Doc::new();
     {
-        let _a = doc.tag(
+        let a = doc.tag(
             "a",
             &[(
                 "href",
                 &format!("{}/streets/{}/view-result", prefix, relation_name),
             )],
         );
-        doc.text(&tr("Existing streets"));
+        a.text(&tr("Existing streets"));
     }
     items.push(doc);
     Ok(items)
@@ -333,9 +333,10 @@ fn fill_existing_header_items(
 
 /// Emit localized strings for JS purposes.
 pub fn emit_l10n_strings_for_js(doc: &yattag::Doc, string_pairs: &[(&str, String)]) {
-    let _div = doc.tag("div", &[("style", "display: none;")]);
+    let div = doc.tag("div", &[("style", "display: none;")]);
     for (key, value) in string_pairs {
-        let _div = doc.tag("div", &[("id", key), ("data-value", value)]);
+        let div = div.tag("div", &[("id", key), ("data-value", value)]);
+        drop(div);
     }
 }
 
@@ -365,8 +366,8 @@ pub fn get_toolbar(
 
     let doc = yattag::Doc::new();
     {
-        let _a = doc.tag("a", &[("href", &(ctx.get_ini().get_uri_prefix()? + "/"))]);
-        doc.text(&tr("Area list"))
+        let a = doc.tag("a", &[("href", &(ctx.get_ini().get_uri_prefix()? + "/"))]);
+        a.text(&tr("Area list"))
     }
     items.push(doc);
 
@@ -400,63 +401,63 @@ pub fn get_toolbar(
     emit_l10n_strings_for_js(&doc, string_pairs);
 
     {
-        let _a = doc.tag("a", &[("href", "https://overpass-turbo.eu/")]);
-        doc.text(&tr("Overpass turbo"));
+        let a = doc.tag("a", &[("href", "https://overpass-turbo.eu/")]);
+        a.text(&tr("Overpass turbo"));
     }
     items.push(doc);
 
     let doc = yattag::Doc::new();
     if relation_osmid > 0 {
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
                     &format!("https://www.openstreetmap.org/relation/{}", relation_osmid),
                 )],
             );
-            doc.text(&tr("Area boundary"))
+            a.text(&tr("Area boundary"))
         }
         items.push(doc);
     } else {
         // These are on the main page only.
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
                     &(ctx.get_ini().get_uri_prefix()? + "/housenumber-stats/hungary/"),
                 )],
             );
-            doc.text(&tr("Statistics"));
+            a.text(&tr("Statistics"));
         }
         items.push(doc);
 
         let doc = yattag::Doc::new();
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
                     "https://github.com/vmiklos/osm-gimmisn/tree/master/doc",
                 )],
             );
-            doc.text(&tr("Documentation"));
+            a.text(&tr("Documentation"));
         }
         items.push(doc);
     }
 
     let doc = yattag::Doc::new();
     {
-        let _div = doc.tag("div", &[("id", "toolbar")]);
+        let div = doc.tag("div", &[("id", "toolbar")]);
         for (index, item) in items.iter().enumerate() {
             if index > 0 {
-                doc.text(" ¦ ");
+                div.text(" ¦ ");
             }
-            doc.append_value(item.get_value());
+            div.append_value(item.get_value());
         }
     }
-    doc.stag("hr", &[]);
+    doc.stag("hr");
     Ok(doc)
 }
 
@@ -509,13 +510,13 @@ pub fn handle_error(request: &rouille::Request, error: &str) -> rouille::Respons
     let doc = yattag::Doc::new();
     util::write_html_header(&doc);
     {
-        let _pre = doc.tag("pre", &[]);
+        let pre = doc.tag("pre", &[]);
         let url = request.url();
-        doc.text(&format!(
+        pre.text(&format!(
             "{}\n",
             tr("Internal error when serving {0}").replace("{0}", &url)
         ));
-        doc.text(error);
+        pre.text(error);
     }
     make_response(
         500_u16,
@@ -529,16 +530,16 @@ pub fn handle_404() -> yattag::Doc {
     let doc = yattag::Doc::new();
     util::write_html_header(&doc);
     {
-        let _html = doc.tag("html", &[]);
+        let html = doc.tag("html", &[]);
         {
-            let _body = doc.tag("body", &[]);
+            let body = html.tag("body", &[]);
             {
-                let _h1 = doc.tag("h1", &[]);
-                doc.text(&tr("Not Found"));
+                let h1 = body.tag("h1", &[]);
+                h1.text(&tr("Not Found"));
             }
             {
-                let _p = doc.tag("p", &[]);
-                doc.text(&tr("The requested URL was not found on this server."));
+                let p = doc.tag("p", &[]);
+                p.text(&tr("The requested URL was not found on this server."));
             }
         }
     }
@@ -641,12 +642,12 @@ fn handle_stats_cityprogress(
     doc.append_value(util::html_table_from_list(&table).get_value());
 
     {
-        let _h2 = doc.tag("h2", &[]);
-        doc.text(&tr("Note"));
+        let h2 = doc.tag("h2", &[]);
+        h2.text(&tr("Note"));
     }
     {
-        let _div = doc.tag("div", &[]);
-        doc.text(&tr(
+        let div = doc.tag("div", &[]);
+        div.text(&tr(
             r#"These statistics are estimates, not taking house number filters into account.
 Only cities with house numbers in OSM are considered."#,
         ));
@@ -743,12 +744,12 @@ fn handle_stats_zipprogress(
     doc.append_value(util::html_table_from_list(&table).get_value());
 
     {
-        let _h2 = doc.tag("h2", &[]);
-        doc.text(&tr("Note"));
+        let h2 = doc.tag("h2", &[]);
+        h2.text(&tr("Note"));
     }
     {
-        let _div = doc.tag("div", &[]);
-        doc.text(&tr(
+        let div = doc.tag("div", &[]);
+        div.text(&tr(
             r#"These statistics are estimates, not taking house number filters into account.
 Only zip codes with house numbers in OSM are considered."#,
         ));
@@ -791,17 +792,17 @@ fn handle_invalid_refstreets(
             continue;
         }
         {
-            let _h1 = doc.tag("h1", &[]);
+            let h1 = doc.tag("h1", &[]);
             let relation_name = relation.get_name();
             {
-                let _a = doc.tag(
+                let a = h1.tag(
                     "a",
                     &[(
                         "href",
                         &format!("{}/streets/{}/view-result", prefix, relation_name),
                     )],
                 );
-                doc.text(&relation_name);
+                a.text(&relation_name);
             }
         }
         doc.append_value(
@@ -921,45 +922,45 @@ pub fn handle_stats(
     ];
 
     {
-        let _ul = doc.tag("ul", &[]);
+        let ul = doc.tag("ul", &[]);
         for (title, identifier) in title_ids {
             let identifier = identifier.to_string();
-            let _li = doc.tag("li", &[]);
+            let li = ul.tag("li", &[]);
             if identifier == "cityprogress" {
-                let _a = doc.tag(
+                let a = li.tag(
                     "a",
                     &[(
                         "href",
                         &format!("{}/housenumber-stats/hungary/cityprogress", prefix),
                     )],
                 );
-                doc.text(title);
+                a.text(title);
                 continue;
             }
             if identifier == "zipprogress" {
-                let _a = doc.tag(
+                let a = li.tag(
                     "a",
                     &[(
                         "href",
                         &format!("{}/housenumber-stats/hungary/zipprogress", prefix),
                     )],
                 );
-                doc.text(title);
+                a.text(title);
                 continue;
             }
             if identifier == "invalid-relations" {
-                let _a = doc.tag(
+                let a = li.tag(
                     "a",
                     &[(
                         "href",
                         &format!("{}/housenumber-stats/hungary/invalid-relations", prefix),
                     )],
                 );
-                doc.text(title);
+                a.text(title);
                 continue;
             }
-            let _a = doc.tag("a", &[("href", &format!("#_{}", identifier))]);
-            doc.text(title);
+            let a = li.tag("a", &[("href", &format!("#_{}", identifier))]);
+            a.text(title);
         }
     }
 
@@ -972,21 +973,22 @@ pub fn handle_stats(
             continue;
         }
         {
-            let _h2 = doc.tag("h2", &[("id", &format!("_{}", identifier))]);
-            doc.text(title);
+            let h2 = doc.tag("h2", &[("id", &format!("_{}", identifier))]);
+            h2.text(title);
         }
 
-        let _div = doc.tag("div", &[("class", "canvasblock js")]);
-        let _canvas = doc.tag("canvas", &[("id", &identifier)]);
+        let div = doc.tag("div", &[("class", "canvasblock js")]);
+        let canvas = div.tag("canvas", &[("id", &identifier)]);
+        drop(canvas);
     }
 
     {
-        let _h2 = doc.tag("h2", &[]);
-        doc.text(&tr("Note"));
+        let h2 = doc.tag("h2", &[]);
+        h2.text(&tr("Note"));
     }
     {
-        let _div = doc.tag("div", &[]);
-        doc.text(&tr(
+        let div = doc.tag("div", &[]);
+        div.text(&tr(
             r#"These statistics are provided purely for interested editors, and are not
 intended to reflect quality of work done by any given editor in OSM. If you want to use
 them to motivate yourself, that's fine, but keep in mind that a bit of useful work is
@@ -1061,8 +1063,8 @@ pub fn check_existing_relation(
     }
 
     {
-        let _div = doc.tag("div", &[("id", "no-such-relation-error")]);
-        doc.text(&tr("No such relation: {0}").replace("{0}", relation_name));
+        let div = doc.tag("div", &[("id", "no-such-relation-error")]);
+        div.text(&tr("No such relation: {0}").replace("{0}", relation_name));
     }
     Ok(doc)
 }
@@ -1072,9 +1074,9 @@ pub fn handle_no_osm_streets(prefix: &str, relation_name: &str) -> yattag::Doc {
     let doc = yattag::Doc::new();
     let link = format!("{}/streets/{}/uppdate-result", prefix, relation_name);
     {
-        let _div = doc.tag("div", &[("id", "no-osm-streets")]);
-        let _a = doc.tag("a", &[("href", &link)]);
-        doc.text(&tr("No existing streets: call Overpass to create..."));
+        let div = doc.tag("div", &[("id", "no-osm-streets")]);
+        let a = div.tag("a", &[("href", &link)]);
+        a.text(&tr("No existing streets: call Overpass to create..."));
     }
     let string_pairs = &[
         (
@@ -1095,9 +1097,9 @@ pub fn handle_no_osm_housenumbers(prefix: &str, relation_name: &str) -> yattag::
         prefix, relation_name
     );
     {
-        let _div = doc.tag("div", &[("id", "no-osm-housenumbers")]);
-        let _a = doc.tag("a", &[("href", &link)]);
-        doc.text(&tr("No existing house numbers: call Overpass to create..."));
+        let div = doc.tag("div", &[("id", "no-osm-housenumbers")]);
+        let a = div.tag("a", &[("href", &link)]);
+        a.text(&tr("No existing house numbers: call Overpass to create..."));
     }
     // Emit localized strings for JS purposes.
     let string_pairs = &[
@@ -1119,9 +1121,9 @@ pub fn handle_no_ref_housenumbers(prefix: &str, relation_name: &str) -> yattag::
         prefix, relation_name
     );
     {
-        let _div = doc.tag("div", &[("id", "no-ref-housenumbers")]);
-        let _a = doc.tag("a", &[("href", &link)]);
-        doc.text(&tr("No reference house numbers: create from reference..."));
+        let div = doc.tag("div", &[("id", "no-ref-housenumbers")]);
+        let a = div.tag("a", &[("href", &link)]);
+        a.text(&tr("No reference house numbers: create from reference..."));
     }
     // Emit localized strings for JS purposes.
     let string_pairs = &[
@@ -1140,9 +1142,9 @@ pub fn handle_no_ref_streets(prefix: &str, relation_name: &str) -> yattag::Doc {
     let doc = yattag::Doc::new();
     let link = format!("{}/missing-streets/{}/update-result", prefix, relation_name);
     {
-        let _div = doc.tag("div", &[("id", "no-ref-streets")]);
-        let _a = doc.tag("a", &[("href", &link)]);
-        doc.text(&tr("No street list: create from reference..."));
+        let div = doc.tag("div", &[("id", "no-ref-streets")]);
+        let a = div.tag("a", &[("href", &link)]);
+        a.text(&tr("No street list: create from reference..."));
     }
     let string_pairs = &[
         (

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -66,8 +66,8 @@ fn handle_streets(
     );
 
     if action == "view-query" {
-        let _pre = doc.tag("pre", &[]);
-        doc.text(&relation.get_osm_streets_query()?);
+        let pre = doc.tag("pre", &[]);
+        pre.text(&relation.get_osm_streets_query()?);
     } else if action == "update-result" {
         let query = relation.get_osm_streets_query()?;
         match overpass_query::overpass_query(ctx, query) {
@@ -140,8 +140,8 @@ fn handle_street_housenumbers(
 
     let prefix = ctx.get_ini().get_uri_prefix()?;
     if action == "view-query" {
-        let _pre = doc.tag("pre", &[]);
-        doc.text(&relation.get_osm_housenumbers_query()?);
+        let pre = doc.tag("pre", &[]);
+        pre.text(&relation.get_osm_housenumbers_query()?);
     } else if action == "update-result" {
         let query = relation.get_osm_housenumbers_query()?;
         match overpass_query::overpass_query(ctx, query) {
@@ -166,8 +166,8 @@ fn handle_street_housenumbers(
             .get_file_system()
             .path_exists(&relation.get_files().get_osm_housenumbers_path())
         {
-            let _div = doc.tag("div", &[("id", "no-osm-housenumbers")]);
-            doc.text(&tr("No existing house numbers"));
+            let div = doc.tag("div", &[("id", "no-osm-housenumbers")]);
+            div.text(&tr("No existing house numbers"));
         } else {
             let stream = relation.get_files().get_osm_housenumbers_read_stream(ctx)?;
             let mut guard = stream.borrow_mut();
@@ -203,8 +203,8 @@ fn missing_housenumbers_view_turbo(
     }
     let query = areas::make_turbo_query_for_streets(&relation, &streets);
 
-    let _pre = doc.tag("pre", &[]);
-    doc.text(&query);
+    let pre = doc.tag("pre", &[]);
+    pre.text(&query);
     Ok(doc)
 }
 
@@ -280,32 +280,32 @@ fn missing_streets_view_result(
     }
 
     {
-        let _p = doc.tag("p", &[]);
-        doc.text(
+        let p = doc.tag("p", &[]);
+        p.text(
             &tr("OpenStreetMap is possibly missing the below {0} streets.")
                 .replace("{0}", &todo_count.to_string()),
         );
-        doc.text(
+        p.text(
             &tr(" (existing: {0}, ready: {1}).")
                 .replace("{0}", &done_count.to_string())
                 .replace("{1}", &util::format_percent(&percent)?),
         );
-        doc.stag("br", &[]);
+        p.stag("br", &[]);
         {
-            let _a = doc.tag(
+            let a = p.tag(
                 "a",
                 &[(
                     "href",
                     &format!("{}/missing-streets/{}/view-turbo", prefix, relation_name),
                 )],
             );
-            doc.text(&tr(
+            a.text(&tr(
                 "Overpass turbo query for streets with questionable names",
             ));
         }
-        doc.stag("br", &[]);
+        p.stag("br", &[]);
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
@@ -315,11 +315,11 @@ fn missing_streets_view_result(
                     ),
                 )],
             );
-            doc.text(&tr("Plain text format"));
+            a.text(&tr("Plain text format"));
         }
-        doc.stag("br", &[]);
+        p.stag("br", &[]);
         {
-            let _a = doc.tag(
+            let a = doc.tag(
                 "a",
                 &[(
                     "href",
@@ -329,7 +329,7 @@ fn missing_streets_view_result(
                     ),
                 )],
             );
-            doc.text(&tr("Checklist format"));
+            a.text(&tr("Checklist format"));
         }
     }
 
@@ -519,8 +519,8 @@ fn missing_streets_update(
     let relation = relations.get_relation(relation_name)?;
     relation.write_ref_streets(&ctx.get_ini().get_reference_street_path()?)?;
     let doc = yattag::Doc::new();
-    let _div = doc.tag("div", &[("id", "update-success")]);
-    doc.text(&tr("Update successful."));
+    let div = doc.tag("div", &[("id", "update-success")]);
+    div.text(&tr("Update successful."));
     Ok(doc)
 }
 
@@ -567,12 +567,12 @@ fn handle_missing_housenumbers(
         doc.append_value(missing_housenumbers_view_turbo(relations, request_uri)?.get_value());
     } else if action == "view-query" {
         {
-            let _pre = doc.tag("pre", &[]);
+            let pre = doc.tag("pre", &[]);
             let stream = relation.get_files().get_ref_housenumbers_read_stream(ctx)?;
             let mut guard = stream.borrow_mut();
             let mut buffer: Vec<u8> = Vec::new();
             guard.read_to_end(&mut buffer)?;
-            doc.text(&String::from_utf8(buffer)?);
+            pre.text(&String::from_utf8(buffer)?);
         }
         date = get_last_modified(&relation.get_files().get_ref_housenumbers_path());
     } else if action == "update-result" {
@@ -613,8 +613,8 @@ fn missing_streets_view_turbo(
     }
     let query = areas::make_turbo_query_for_streets(&relation, &streets);
 
-    let _pre = doc.tag("pre", &[]);
-    doc.text(&query);
+    let pre = doc.tag("pre", &[]);
+    pre.text(&query);
     Ok(doc)
 }
 
@@ -653,12 +653,12 @@ fn handle_missing_streets(
     if action == "view-turbo" {
         doc.append_value(missing_streets_view_turbo(relations, request_uri)?.get_value());
     } else if action == "view-query" {
-        let _pre = doc.tag("pre", &[]);
+        let pre = doc.tag("pre", &[]);
         let stream = relation.get_files().get_ref_streets_read_stream(ctx)?;
         let mut guard = stream.borrow_mut();
         let mut buffer: Vec<u8> = Vec::new();
         guard.read_to_end(&mut buffer)?;
-        doc.text(&String::from_utf8(buffer)?);
+        pre.text(&String::from_utf8(buffer)?);
     } else if action == "update-result" {
         doc.append_value(missing_streets_update(ctx, relations, relation_name)?.get_value());
     } else {
@@ -783,21 +783,21 @@ fn handle_main_housenr_percent(
     let doc = yattag::Doc::new();
     if percent != "N/A" {
         let date = get_last_modified(&files.get_housenumbers_percent_path());
-        let _strong = doc.tag("strong", &[]);
-        let _a = doc.tag(
+        let strong = doc.tag("strong", &[]);
+        let a = strong.tag(
             "a",
             &[
                 ("href", &url),
                 ("title", &format!("{} {}", tr("updated"), date)),
             ],
         );
-        doc.text(&util::format_percent(&percent)?);
+        a.text(&util::format_percent(&percent)?);
         return Ok((doc, percent));
     }
 
-    let _strong = doc.tag("strong", &[]);
-    let _a = doc.tag("a", &[("href", &url)]);
-    doc.text(&tr("missing house numbers"));
+    let strong = doc.tag("strong", &[]);
+    let a = strong.tag("a", &[("href", &url)]);
+    a.text(&tr("missing house numbers"));
     Ok((doc, "0".into()))
 }
 
@@ -827,21 +827,21 @@ fn handle_main_street_percent(
     let doc = yattag::Doc::new();
     if percent != "N/A" {
         let date = get_last_modified(&relation.get_files().get_streets_percent_path());
-        let _strong = doc.tag("strong", &[]);
-        let _a = doc.tag(
+        let strong = doc.tag("strong", &[]);
+        let a = strong.tag(
             "a",
             &[
                 ("href", &url),
                 ("title", &format!("{} {}", tr("updated"), date)),
             ],
         );
-        doc.text(&util::format_percent(&percent)?);
+        a.text(&util::format_percent(&percent)?);
         return Ok((doc, percent));
     }
 
-    let _strong = doc.tag("strong", &[]);
-    let _a = doc.tag("a", &[("href", &url)]);
-    doc.text(&tr("missing streets"));
+    let strong = doc.tag("strong", &[]);
+    let a = strong.tag("a", &[("href", &url)]);
+    a.text(&tr("missing streets"));
     Ok((doc, "0".into()))
 }
 
@@ -872,21 +872,21 @@ fn handle_main_street_additional_count(
     let doc = yattag::Doc::new();
     if !additional_count.is_empty() {
         let date = get_last_modified(&files.get_streets_additional_count_path());
-        let _strong = doc.tag("strong", &[]);
-        let _a = doc.tag(
+        let strong = doc.tag("strong", &[]);
+        let a = strong.tag(
             "a",
             &[
                 ("href", &url),
                 ("title", &format!("{} {}", tr("updated"), date)),
             ],
         );
-        doc.text(&tr("{} streets").replace("{}", &additional_count));
+        a.text(&tr("{} streets").replace("{}", &additional_count));
         return Ok(doc);
     }
 
-    let _strong = doc.tag("strong", &[]);
-    let _a = doc.tag("a", &[("href", &url)]);
-    doc.text(&tr("additional streets"));
+    let strong = doc.tag("strong", &[]);
+    let a = strong.tag("a", &[("href", &url)]);
+    a.text(&tr("additional streets"));
     Ok(doc)
 }
 
@@ -930,21 +930,21 @@ pub fn handle_main_housenr_additional_count(
     let doc = yattag::Doc::new();
     if !additional_count.is_empty() {
         let date = get_last_modified(&files.get_housenumbers_additional_count_path());
-        let _strong = doc.tag("strong", &[]);
-        let _a = doc.tag(
+        let strong = doc.tag("strong", &[]);
+        let a = strong.tag(
             "a",
             &[
                 ("href", &url),
                 ("title", &format!("{} {}", tr("updated"), date)),
             ],
         );
-        doc.text(&tr("{} house numbers").replace("{}", &additional_count));
+        a.text(&tr("{} house numbers").replace("{}", &additional_count));
         return Ok(doc);
     }
 
-    let _strong = doc.tag("strong", &[]);
-    let _a = doc.tag("a", &[("href", &url)]);
-    doc.text(&tr("additional house numbers"));
+    let strong = doc.tag("strong", &[]);
+    let a = strong.tag("a", &[("href", &url)]);
+    a.text(&tr("additional house numbers"));
     Ok(doc)
 }
 
@@ -1047,14 +1047,14 @@ fn handle_main_filters_refcounty(
 
     let prefix = ctx.get_ini().get_uri_prefix()?;
     {
-        let _a = doc.tag(
+        let a = doc.tag(
             "a",
             &[(
                 "href",
                 &format!("{}/filter-for/refcounty/{}/whole-county", prefix, refcounty),
             )],
         );
-        doc.text(&name);
+        a.text(&name);
     }
     if !refcounty_id.is_empty() && refcounty == refcounty_id {
         let refsettlement_ids = relations.refcounty_get_refsettlement_ids(refcounty_id);
@@ -1068,8 +1068,8 @@ fn handle_main_filters_refcounty(
                         "{}/filter-for/refcounty/{}/refsettlement/{}",
                         prefix, refcounty, refsettlement_id
                     );
-                    let _a = name_doc.tag("a", &[("href", &href)]);
-                    name_doc.text(&name);
+                    let a = name_doc.tag("a", &[("href", &href)]);
+                    a.text(&name);
                 }
                 names.push(name_doc);
             }
@@ -1096,20 +1096,20 @@ fn handle_main_filters(
 
     let mut doc = yattag::Doc::new();
     {
-        let _span = doc.tag("span", &[("id", "filter-based-on-position")]);
-        let _a = doc.tag("a", &[("href", "#")]);
-        doc.text(&tr("Based on position"))
+        let span = doc.tag("span", &[("id", "filter-based-on-position")]);
+        let a = span.tag("a", &[("href", "#")]);
+        a.text(&tr("Based on position"))
     }
     items.push(doc);
 
     doc = yattag::Doc::new();
     let prefix = ctx.get_ini().get_uri_prefix()?;
     {
-        let _a = doc.tag(
+        let a = doc.tag(
             "a",
             &[("href", &format!("{}/filter-for/everything", prefix))],
         );
-        doc.text(&tr("Show complete areas"));
+        a.text(&tr("Show complete areas"));
     }
     items.push(doc);
 
@@ -1131,12 +1131,12 @@ fn handle_main_filters(
     }
     doc = yattag::Doc::new();
     {
-        let _h1 = doc.tag("h1", &[]);
-        doc.text(&tr("Where to map?"));
+        let h1 = doc.tag("h1", &[]);
+        h1.text(&tr("Where to map?"));
     }
     {
-        let _p = doc.tag("p", &[]);
-        doc.text(&format!("{} ", tr("Filters:")));
+        let p = doc.tag("p", &[]);
+        p.text(&format!("{} ", tr("Filters:")));
         for (index, item) in items.iter().enumerate() {
             if index > 0 {
                 doc.text(" ¦ ");
@@ -1203,7 +1203,7 @@ fn handle_main_relation(
 
     let doc = yattag::Doc::new();
     {
-        let _a = doc.tag(
+        let a = doc.tag(
             "a",
             &[(
                 "href",
@@ -1213,7 +1213,7 @@ fn handle_main_relation(
                 ),
             )],
         );
-        doc.text(&tr("area boundary"));
+        a.text(&tr("area boundary"));
     }
     row.push(doc);
 
@@ -1263,15 +1263,15 @@ fn handle_main(
     }
     doc.append_value(util::html_table_from_list(&table).get_value());
     {
-        let _p = doc.tag("p", &[]);
-        let _a = doc.tag(
+        let p = doc.tag("p", &[]);
+        let a = p.tag(
             "a",
             &[(
                 "href",
                 "https://github.com/vmiklos/osm-gimmisn/tree/master/doc",
             )],
         );
-        doc.text(&tr("Add new area"));
+        a.text(&tr("Add new area"));
     }
 
     doc.append_value(webframe::get_footer(/*last_updated=*/ "").get_value());
@@ -1300,11 +1300,11 @@ fn get_html_title(request_uri: &str) -> String {
 }
 
 /// Produces the <head> tag and its contents.
-fn write_html_head(ctx: &context::Context, doc: &yattag::Doc, title: &str) -> anyhow::Result<()> {
+fn write_html_head(ctx: &context::Context, doc: &yattag::Tag, title: &str) -> anyhow::Result<()> {
     let prefix = ctx.get_ini().get_uri_prefix()?;
-    let _head = doc.tag("head", &[]);
-    doc.stag("meta", &[("charset", "UTF-8")]);
-    doc.stag(
+    let head = doc.tag("head", &[]);
+    head.stag("meta", &[("charset", "UTF-8")]);
+    head.stag(
         "meta",
         &[
             ("name", "viewport"),
@@ -1312,10 +1312,10 @@ fn write_html_head(ctx: &context::Context, doc: &yattag::Doc, title: &str) -> an
         ],
     );
     {
-        let _title = doc.tag("title", &[]);
-        doc.text(&format!("{}{}", tr("Where to map?"), title))
+        let title_tag = head.tag("title", &[]);
+        title_tag.text(&format!("{}{}", tr("Where to map?"), title))
     }
-    doc.stag(
+    head.stag(
         "link",
         &[
             ("rel", "icon"),
@@ -1324,7 +1324,7 @@ fn write_html_head(ctx: &context::Context, doc: &yattag::Doc, title: &str) -> an
             ("href", &format!("{}/favicon.ico", prefix)),
         ],
     );
-    doc.stag(
+    head.stag(
         "link",
         &[
             ("rel", "icon"),
@@ -1337,24 +1337,25 @@ fn write_html_head(ctx: &context::Context, doc: &yattag::Doc, title: &str) -> an
     let css_path = format!("{}/{}", ctx.get_ini().get_workdir()?, "osm.min.css");
     let contents = std::fs::read_to_string(css_path)?;
     {
-        let _style = doc.tag("style", &[]);
-        doc.text(&contents);
+        let style = head.tag("style", &[]);
+        style.text(&contents);
     }
 
     {
-        let _noscript = doc.tag("noscript", &[]);
-        let _style = doc.tag("style", &[("type", "text/css")]);
-        doc.text(".no-js { display: block; }");
-        doc.text(".js { display: none; }");
+        let noscript = head.tag("noscript", &[]);
+        let style = noscript.tag("style", &[("type", "text/css")]);
+        style.text(".no-js { display: block; }");
+        style.text(".js { display: none; }");
     }
 
-    let _script = doc.tag(
+    let script = head.tag(
         "script",
         &[
             ("defer", ""),
             ("src", &format!("{}/static/bundle.js", prefix)),
         ],
     );
+    drop(script);
     Ok(())
 }
 
@@ -1491,23 +1492,23 @@ fn our_application(
     let doc = yattag::Doc::new();
     util::write_html_header(&doc);
     {
-        let _html = doc.tag("html", &[("lang", &language)]);
-        write_html_head(ctx, &doc, &get_html_title(&request_uri))?;
+        let html = doc.tag("html", &[("lang", &language)]);
+        write_html_head(ctx, &html, &get_html_title(&request_uri))?;
 
-        let _body = doc.tag("body", &[]);
+        let body = html.tag("body", &[]);
         let no_such_relation = webframe::check_existing_relation(ctx, &relations, &request_uri)?;
         let handler = get_handler(ctx, &request_uri)?;
         if !no_such_relation.get_value().is_empty() {
-            doc.append_value(no_such_relation.get_value());
+            body.append_value(no_such_relation.get_value());
         } else if let Some(handler) = handler {
             let value = handler(ctx, &mut relations, &request_uri)
                 .context("handler() failed")?
                 .get_value();
-            doc.append_value(value);
+            body.append_value(value);
         } else if request_uri.starts_with(&format!("{}/webhooks/github", prefix)) {
-            doc.append_value(webframe::handle_github_webhook(request, ctx)?.get_value());
+            body.append_value(webframe::handle_github_webhook(request, ctx)?.get_value());
         } else {
-            doc.append_value(handle_main(&request_uri, ctx, &mut relations)?.get_value());
+            body.append_value(handle_main(&request_uri, ctx, &mut relations)?.get_value());
         }
     }
 

--- a/src/wsgi_additional.rs
+++ b/src/wsgi_additional.rs
@@ -102,8 +102,8 @@ pub fn additional_streets_view_result(
                 street.get_osm_id()
             );
             {
-                let _a = cell.tag("a", &[("href", &href), ("target", "_blank")]);
-                cell.text(&street.get_osm_id().to_string());
+                let a = cell.tag("a", &[("href", &href), ("target", "_blank")]);
+                a.text(&street.get_osm_id().to_string());
             }
             let cells = vec![
                 cell,
@@ -115,14 +115,14 @@ pub fn additional_streets_view_result(
         }
 
         {
-            let _p = doc.tag("p", &[]);
-            doc.text(
+            let p = doc.tag("p", &[]);
+            p.text(
                 &tr("OpenStreetMap additionally has the below {0} streets.")
                     .replace("{0}", &count.to_string()),
             );
-            doc.stag("br", &[]);
+            p.stag("br", &[]);
             {
-                let _a = doc.tag(
+                let a = p.tag(
                     "a",
                     &[(
                         "href",
@@ -132,11 +132,11 @@ pub fn additional_streets_view_result(
                         ),
                     )],
                 );
-                doc.text(&tr("Plain text format"));
+                a.text(&tr("Plain text format"));
             }
-            doc.stag("br", &[]);
+            p.stag("br", &[]);
             {
-                let _a = doc.tag(
+                let a = p.tag(
                     "a",
                     &[(
                         "href",
@@ -146,18 +146,18 @@ pub fn additional_streets_view_result(
                         ),
                     )],
                 );
-                doc.text(&tr("Checklist format"));
+                a.text(&tr("Checklist format"));
             }
-            doc.stag("br", &[]);
+            p.stag("br", &[]);
             {
-                let _a = doc.tag(
+                let a = doc.tag(
                     "a",
                     &[(
                         "href",
                         &format!("{}/additional-streets/{}/view-turbo", prefix, relation_name),
                     )],
                 );
-                doc.text(&tr("Overpass turbo query for the below streets"));
+                a.text(&tr("Overpass turbo query for the below streets"));
             }
         }
 
@@ -218,8 +218,8 @@ pub fn additional_streets_view_turbo(
     let streets = relation.get_additional_streets(/*sorted_result=*/ false)?;
     let query = areas::make_turbo_query_for_street_objs(&relation, &streets);
 
-    let _pre = doc.tag("pre", &[]);
-    doc.text(&query);
+    let pre = doc.tag("pre", &[]);
+    pre.text(&query);
     Ok(doc)
 }
 


### PR DESCRIPTION
This allows eliminating variables which are used, but look unused; and
make the relationship between the tag and its text more explicit.

Change-Id: I5182d8a14ae0486de951b4d124f1db1d5e510fb9
