### PR TITLE
validator: report location of the errors where possible

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -27,20 +27,22 @@ use std::rc::Rc;
 
 /// The filters -> <street> -> ranges key from data/relation-<name>.yaml.
 #[derive(Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RelationRangesDict {
-    end: String,
+    pub end: String,
     refsettlement: Option<String>,
-    start: String,
+    pub start: String,
 }
 
 /// The filters key from data/relation-<name>.yaml.
 #[derive(Clone, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
 pub struct RelationFiltersDict {
-    interpolation: Option<String>,
-    invalid: Option<Vec<String>>,
-    ranges: Option<Vec<RelationRangesDict>>,
-    valid: Option<Vec<String>>,
+    pub interpolation: Option<String>,
+    pub invalid: Option<Vec<String>>,
+    pub ranges: Option<Vec<RelationRangesDict>>,
+    pub valid: Option<Vec<String>>,
     refsettlement: Option<String>,
     show_refstreet: Option<bool>,
 }
@@ -48,19 +50,21 @@ pub struct RelationFiltersDict {
 /// A relation from data/relation-<name>.yaml.
 #[derive(Clone, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
 pub struct RelationDict {
     additional_housenumbers: Option<bool>,
-    alias: Option<Vec<String>>,
-    filters: Option<HashMap<String, RelationFiltersDict>>,
+    pub alias: Option<Vec<String>>,
+    pub filters: Option<HashMap<String, RelationFiltersDict>>,
     housenumber_letters: Option<bool>,
     inactive: Option<bool>,
     missing_streets: Option<String>,
     osm_street_filters: Option<Vec<String>>,
-    osmrelation: Option<u64>,
-    refcounty: Option<String>,
-    refsettlement: Option<String>,
-    refstreets: Option<HashMap<String, String>>,
-    street_filters: Option<Vec<String>>,
+    pub osmrelation: Option<u64>,
+    pub refcounty: Option<String>,
+    pub refsettlement: Option<String>,
+    pub refstreets: Option<HashMap<String, String>>,
+    pub street_filters: Option<Vec<String>>,
+    pub source: Option<String>,
 }
 
 impl Default for RelationDict {
@@ -77,6 +81,7 @@ impl Default for RelationDict {
         let refsettlement = None;
         let refstreets = None;
         let street_filters = None;
+        let source = None;
         RelationDict {
             additional_housenumbers,
             alias,
@@ -90,6 +95,7 @@ impl Default for RelationDict {
             refsettlement,
             refstreets,
             street_filters,
+            source,
         }
     }
 }
@@ -1152,7 +1158,7 @@ impl Relation {
 }
 
 /// List of relations from data/relations.yaml.
-type RelationsDict = HashMap<String, RelationDict>;
+pub type RelationsDict = HashMap<String, RelationDict>;
 
 /// A relations object is a container of named relation objects.
 #[derive(Clone)]

--- a/tests/data/relation-gazdagret-filter-interpolation-bad.yaml
+++ b/tests/data/relation-gazdagret-filter-interpolation-bad.yaml
@@ -1,3 +1,0 @@
-filters:
-  'Hamzsabégi út':
-    interpolation: 42

--- a/tests/data/relation-gazdagret-filter-invalid-bad.yaml
+++ b/tests/data/relation-gazdagret-filter-invalid-bad.yaml
@@ -1,3 +1,0 @@
-filters:
-  'Budaörsi út':
-    invalid: [1]

--- a/tests/data/relation-gazdagret-filter-range-bad-type.yaml
+++ b/tests/data/relation-gazdagret-filter-range-bad-type.yaml
@@ -1,4 +1,0 @@
-filters:
-  'Budaörsi út':
-    ranges:
-      - {start: '137', end: '165', refsettlement: 42}

--- a/tests/data/relation-gazdagret-filter-refsettlement-bad.yaml
+++ b/tests/data/relation-gazdagret-filter-refsettlement-bad.yaml
@@ -1,3 +1,0 @@
-filters:
-  'Hamzsabégi út':
-    refsettlement: 42

--- a/tests/data/relation-gazdagret-filter-valid-bad.yaml
+++ b/tests/data/relation-gazdagret-filter-valid-bad.yaml
@@ -1,3 +1,0 @@
-filters:
-  'Budaörsi út':
-    valid: [1]

--- a/tests/data/relations-missing-refcounty/relations.yaml
+++ b/tests/data/relations-missing-refcounty/relations.yaml
@@ -1,0 +1,4 @@
+gazdagret:
+    osmrelation: 42
+    # refcounty is intentionally missing
+    refsettlement: "011"

--- a/tests/data/relations-missing-refsettlement/relations.yaml
+++ b/tests/data/relations-missing-refsettlement/relations.yaml
@@ -1,0 +1,4 @@
+gazdagret:
+    osmrelation: 42
+    refcounty: "01"
+    # refsettlement is intentionally missing


### PR DESCRIPTION
Parsing via typed json gives this out of the box, and it's also less
code. Some errors are still unchanged, where the type system can't
express some condition and a manual check is kept.

Dropped tests:

- test_relation_filters_valid_bad: this just enforced that all numbers
  in the "valid" array are strings -- but there is no problem to have
  them as numbers, really.
- test_relation_filters_refsettlement_bad: same, enforced that numbers
  have to be strings
- test_relation_filters_ranges_bad_type: same
- test_relation_filters_invalid_bad: same
- test_relation_filters_interpolation_bad: same

Added tests:

- test_relations_missing_refcounty: previously only the osmrelation key
  was checked
- test_relations_missing_refsettlement: same

Change-Id: Ibba415c99dd21e08809727319235657063d3425b
