### PR TITLE
validator: fix exit code

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -8,6 +8,7 @@
 - Resolves: gh#1746 fix disappeared localized strings
 - Resolves: gh#1815 validator now rejects trailing whitespace when converting numbers to strings
 - Resolves: gh#1839 stats: report per-zip coverage of housenumbers
+- Resolves: gh#1950 fix the validator's exit code to actually fail on validation errors during CI
 
 == 7.2
 

--- a/src/bin/validator.rs
+++ b/src/bin/validator.rs
@@ -12,7 +12,8 @@
 
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
-    osm_gimmisn::validator::main(&args, &mut std::io::stdout())?;
-
-    Ok(())
+    match osm_gimmisn::validator::main(&args, &mut std::io::stdout()) {
+        Ok(exit_code) => std::process::exit(exit_code),
+        Err(err) => Err(err),
+    }
 }


### PR DESCRIPTION
The bug was in the last step, which is mocked in tests, annoying.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/1950>.

Change-Id: I8b25da9fbdcae274fc40d0a726ab66294ba2dc51
