### PR TITLE
Rust: update edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "osm-gimmisn"
 version = "7.2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 accept-language = "2.0.0"


### PR DESCRIPTION
See <https://doc.rust-lang.org/edition-guide/rust-2021/index.html> for
details.

Change-Id: I0e3e3da58a6205d6e2f6c49748409e02484d6087
