### PR TITLE
cache_yamls: report which file contains the problem

### DIFF
--- a/src/cache_yamls.rs
+++ b/src/cache_yamls.rs
@@ -36,7 +36,8 @@ pub fn main(argv: &[String], ctx: &context::Context) -> anyhow::Result<()> {
             .context("yaml outside datadir")?
             .to_string();
         let data = std::fs::read_to_string(&yaml_path)?;
-        let cache_value = serde_yaml::from_str::<serde_json::Value>(&data)?;
+        let cache_value = serde_yaml::from_str::<serde_json::Value>(&data)
+            .context(format!("serde_yaml::from_str() failed for {}", yaml_path))?;
         cache.insert(cache_key, cache_value);
     }
 


### PR DESCRIPTION
This is helpful if cache_yamls aborts the build before the validator
could report the name of the problematic file.

Change-Id: I28c7801b9f6514114002a436e89589ee9c6f8e89
