### PR TITLE
CI: try to lock down the clippy version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.57.0
+          components: rustfmt, clippy
       - name: Rust Cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
The default one may be newer than what we can handle.

Change-Id: Ied7a0cf7bc62f9ee6a1b4aefc21fe057633eaa90
