### PR TITLE
Make more tests work without a tests/data/yamls.cache file

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1520,15 +1520,35 @@ mod tests {
     /// Tests normalize().
     #[test]
     fn test_normalize() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "myrelation": {
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::make_file();
+        {
+            let mut guard = yamls_cache_value.borrow_mut();
+            let write = guard.deref_mut();
+            serde_json::to_writer(write, &yamls_cache).unwrap();
+        }
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let mut relations = Relations::new(&ctx).unwrap();
-        let relation = relations.get_relation("gazdagret").unwrap();
+        let relation = relations.get_relation("myrelation").unwrap();
         let normalizers = relation.get_street_ranges().unwrap();
-        let street_is_even_odd = relation.config.get_street_is_even_odd("Budaörsi út");
+        let street_is_even_odd = relation.config.get_street_is_even_odd("mystreet");
         let house_numbers = normalize(
             &relation,
             "139",
-            "Budaörsi út",
+            "mystreet",
             street_is_even_odd,
             &normalizers,
         )
@@ -1673,7 +1693,28 @@ mod tests {
     /// Tests normalize: the case when ';' is a separator.
     #[test]
     fn test_normalize_separator_semicolon() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "gazdagret": {
+                    "osmrelation": 2713748,
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::make_file();
+        {
+            let mut guard = yamls_cache_value.borrow_mut();
+            let write = guard.deref_mut();
+            serde_json::to_writer(write, &yamls_cache).unwrap();
+        }
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let mut relations = Relations::new(&ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
         let normalizers = relation.get_street_ranges().unwrap();
@@ -1693,15 +1734,35 @@ mod tests {
     /// Tests normalize: the 2-6 case means implicit 4.
     #[test]
     fn test_normalize_separator_interval() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "myrelation": {
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::make_file();
+        {
+            let mut guard = yamls_cache_value.borrow_mut();
+            let write = guard.deref_mut();
+            serde_json::to_writer(write, &yamls_cache).unwrap();
+        }
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let mut relations = Relations::new(&ctx).unwrap();
-        let relation = relations.get_relation("gazdagret").unwrap();
+        let relation = relations.get_relation("myrelation").unwrap();
         let normalizers = relation.get_street_ranges().unwrap();
-        let street_is_even_odd = relation.get_config().get_street_is_even_odd("Budaörsi út");
+        let street_is_even_odd = relation.get_config().get_street_is_even_odd("mystreet");
         let house_numbers = normalize(
             &relation,
             "2-6",
-            "Budaörs út",
+            "mystreet",
             street_is_even_odd,
             &normalizers,
         )
@@ -1713,7 +1774,28 @@ mod tests {
     /// Tests normalize: the 5-8 case: means just 5 and 8 as the parity doesn't match.
     #[test]
     fn test_normalize_separator_interval_parity() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "gazdagret": {
+                    "osmrelation": 2713748,
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::make_file();
+        {
+            let mut guard = yamls_cache_value.borrow_mut();
+            let write = guard.deref_mut();
+            serde_json::to_writer(write, &yamls_cache).unwrap();
+        }
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let mut relations = Relations::new(&ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
         let normalizers = relation.get_street_ranges().unwrap();
@@ -1733,7 +1815,35 @@ mod tests {
     /// Tests normalize: the 2-5 case: means implicit 3 and 4 (interpolation=all).
     #[test]
     fn test_normalize_separator_interval_interp_all() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "gazdagret": {
+                    "osmrelation": 2713748,
+                },
+            },
+            "relation-gazdagret.yaml": {
+                "filters": {
+                    "Hamzsabégi út": {
+                        "interpolation": "all",
+                    },
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::make_file();
+        {
+            let mut guard = yamls_cache_value.borrow_mut();
+            let write = guard.deref_mut();
+            serde_json::to_writer(write, &yamls_cache).unwrap();
+        }
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let mut relations = Relations::new(&ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
         let normalizers = relation.get_street_ranges().unwrap();
@@ -1753,7 +1863,40 @@ mod tests {
     /// Tests normalize: the case where x-y is partially filtered out.
     #[test]
     fn test_normalize_separator_interval_filter() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "gazdagret": {
+                    "osmrelation": 2713748,
+                },
+            },
+            "relation-gazdagret.yaml": {
+                "filters": {
+                    "Budaörsi út": {
+                        "ranges": [
+                            {
+                                "start": "137",
+                                "end": "165",
+                            }
+                        ],
+                    },
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::make_file();
+        {
+            let mut guard = yamls_cache_value.borrow_mut();
+            let write = guard.deref_mut();
+            serde_json::to_writer(write, &yamls_cache).unwrap();
+        }
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let mut relations = Relations::new(&ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
         let normalizers = relation.get_street_ranges().unwrap();
@@ -1775,15 +1918,35 @@ mod tests {
     /// Tests normalize: the case where x-y is nonsense: y is too large.
     #[test]
     fn test_normalize_separator_interval_block() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "myrelation": {
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::make_file();
+        {
+            let mut guard = yamls_cache_value.borrow_mut();
+            let write = guard.deref_mut();
+            serde_json::to_writer(write, &yamls_cache).unwrap();
+        }
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let mut relations = Relations::new(&ctx).unwrap();
-        let relation = relations.get_relation("gazdagret").unwrap();
+        let relation = relations.get_relation("myrelation").unwrap();
         let normalizers = relation.get_street_ranges().unwrap();
-        let street_is_even_odd = relation.config.get_street_is_even_odd("Budaörsi út");
+        let street_is_even_odd = relation.config.get_street_is_even_odd("mystreet");
         let house_numbers = normalize(
             &relation,
             "2-2000",
-            "Budaörs út",
+            "mystreet",
             street_is_even_odd,
             &normalizers,
         )
@@ -1797,15 +1960,35 @@ mod tests {
     /// Tests normalize: the case where x-y is nonsense: y-x is too large.
     #[test]
     fn test_normalize_separator_interval_block2() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "myrelation": {
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::make_file();
+        {
+            let mut guard = yamls_cache_value.borrow_mut();
+            let write = guard.deref_mut();
+            serde_json::to_writer(write, &yamls_cache).unwrap();
+        }
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let mut relations = Relations::new(&ctx).unwrap();
-        let relation = relations.get_relation("gazdagret").unwrap();
+        let relation = relations.get_relation("myrelation").unwrap();
         let normalizers = relation.get_street_ranges().unwrap();
-        let street_is_even_odd = relation.config.get_street_is_even_odd("Budaörsi út");
+        let street_is_even_odd = relation.config.get_street_is_even_odd("mystreet");
         let house_numbers = normalize(
             &relation,
             "2-56",
-            "Budaörs út",
+            "mystreet",
             street_is_even_odd,
             &normalizers,
         )
@@ -1818,7 +2001,28 @@ mod tests {
     /// Tests normalize: the case where x-y is nonsense: x is 0.
     #[test]
     fn test_normalize_separator_interval_block3() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "gazdagret": {
+                    "osmrelation": 2713748,
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::make_file();
+        {
+            let mut guard = yamls_cache_value.borrow_mut();
+            let write = guard.deref_mut();
+            serde_json::to_writer(write, &yamls_cache).unwrap();
+        }
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let mut relations = Relations::new(&ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
         let normalizers = relation.get_street_ranges().unwrap();
@@ -1839,7 +2043,28 @@ mod tests {
     /// Tests normalize: the case where x-y is only partially useful: x is OK, but y is a suffix.
     #[test]
     fn test_normalize_separator_interval_block4() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "gazdagret": {
+                    "osmrelation": 2713748,
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::make_file();
+        {
+            let mut guard = yamls_cache_value.borrow_mut();
+            let write = guard.deref_mut();
+            serde_json::to_writer(write, &yamls_cache).unwrap();
+        }
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let mut relations = Relations::new(&ctx).unwrap();
         let relation = relations.get_relation("gazdagret").unwrap();
         let normalizers = relation.get_street_ranges().unwrap();
@@ -2915,13 +3140,34 @@ way{color:blue; width:4;}
     /// Tests Relation::build_ref_housenumbers(): the case when the street is not in the reference.
     #[test]
     fn test_relation_build_ref_housenumbers_missing() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "myrelation": {
+                    "refsettlement": "42",
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::make_file();
+        {
+            let mut guard = yamls_cache_value.borrow_mut();
+            let write = guard.deref_mut();
+            serde_json::to_writer(write, &yamls_cache).unwrap();
+        }
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let mut relations = Relations::new(&ctx).unwrap();
         let refdir = ctx.get_abspath("refdir");
         let refpath = format!("{}/hazszamok_20190511.tsv", refdir);
         let memory_cache = util::build_reference_cache(&refpath, "01").unwrap();
-        let relation_name = "gazdagret";
-        let street = "No such utca";
+        let relation_name = "myrelation";
+        let street = "mystreet";
         let relation = relations.get_relation(relation_name).unwrap();
 
         let ret = relation.build_ref_housenumbers(&memory_cache, street, "");
@@ -3250,7 +3496,28 @@ way{color:blue; width:4;}
     /// Tests refcounty_get_name().
     #[test]
     fn test_refcounty_get_name() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+            },
+            "refcounty-names.yaml": {
+                "01": "Budapest",
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::make_file();
+        {
+            let mut guard = yamls_cache_value.borrow_mut();
+            let write = guard.deref_mut();
+            serde_json::to_writer(write, &yamls_cache).unwrap();
+        }
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let relations = Relations::new(&ctx).unwrap();
         assert_eq!(relations.refcounty_get_name("01"), "Budapest");
         assert_eq!(relations.refcounty_get_name("99"), "");
@@ -3259,7 +3526,34 @@ way{color:blue; width:4;}
     /// Tests refcounty_get_refsettlement_ids().
     #[test]
     fn test_refcounty_get_refsettlement_ids() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+            },
+            "refcounty-names.yaml": {
+                "01": "mycity",
+            },
+            "refsettlement-names.yaml": {
+                "01": {
+                    "011": "myrelation1",
+                    "012": "myrelation1",
+                }
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::make_file();
+        {
+            let mut guard = yamls_cache_value.borrow_mut();
+            let write = guard.deref_mut();
+            serde_json::to_writer(write, &yamls_cache).unwrap();
+        }
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let relations = Relations::new(&ctx).unwrap();
         assert_eq!(
             relations.refcounty_get_refsettlement_ids("01"),
@@ -3274,9 +3568,38 @@ way{color:blue; width:4;}
     /// Tests refsettlement_get_name().
     #[test]
     fn test_refsettlement_get_name() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+            },
+            "refcounty-names.yaml": {
+                "01": "mycity",
+            },
+            "refsettlement-names.yaml": {
+                "01": {
+                    "011": "mysettlement",
+                }
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::make_file();
+        {
+            let mut guard = yamls_cache_value.borrow_mut();
+            let write = guard.deref_mut();
+            serde_json::to_writer(write, &yamls_cache).unwrap();
+        }
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let relations = Relations::new(&ctx).unwrap();
-        assert_eq!(relations.refsettlement_get_name("01", "011"), "Újbuda");
+        assert_eq!(
+            relations.refsettlement_get_name("01", "011"),
+            "mysettlement"
+        );
         assert_eq!(relations.refsettlement_get_name("99", ""), "");
         assert_eq!(relations.refsettlement_get_name("01", "99"), "");
     }


### PR DESCRIPTION
This way each test can have a custom, minimal relation config.

Change-Id: I5d4ed09cc382c0e739bab4a893bffd8baca33c64
