### PR TITLE
TestFileSystem: update mtime on open_write()

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -302,7 +302,9 @@ pub fn get_missing_housenumbers_txt(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
     use std::collections::HashMap;
+    use std::rc::Rc;
     use std::sync::Arc;
 
     /// Tests is_missing_housenumbers_html_cached().
@@ -348,13 +350,16 @@ mod tests {
         let osm_housenumbers_path = relation.get_files().get_osm_housenumbers_path();
 
         let mut file_system = context::tests::TestFileSystem::new();
-        let mut mtimes: HashMap<String, f64> = HashMap::new();
+        let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
         let metadata = std::fs::metadata(cache_path).unwrap();
         let modified = metadata.modified().unwrap();
         let mtime = modified
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap();
-        mtimes.insert(osm_housenumbers_path, mtime.as_secs_f64() + 1_f64);
+        mtimes.insert(
+            osm_housenumbers_path,
+            Rc::new(RefCell::new(mtime.as_secs_f64() + 1_f64)),
+        );
         file_system.set_mtimes(&mtimes);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
         ctx.set_file_system(&file_system_arc);
@@ -375,13 +380,16 @@ mod tests {
         let ref_housenumbers_path = relation.get_files().get_ref_housenumbers_path();
 
         let mut file_system = context::tests::TestFileSystem::new();
-        let mut mtimes: HashMap<String, f64> = HashMap::new();
+        let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
         let metadata = std::fs::metadata(cache_path).unwrap();
         let modified = metadata.modified().unwrap();
         let mtime = modified
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap();
-        mtimes.insert(ref_housenumbers_path, mtime.as_secs_f64() + 1_f64);
+        mtimes.insert(
+            ref_housenumbers_path,
+            Rc::new(RefCell::new(mtime.as_secs_f64() + 1_f64)),
+        );
         file_system.set_mtimes(&mtimes);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
         ctx.set_file_system(&file_system_arc);
@@ -403,13 +411,16 @@ mod tests {
         let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
 
         let mut file_system = context::tests::TestFileSystem::new();
-        let mut mtimes: HashMap<String, f64> = HashMap::new();
+        let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
         let metadata = std::fs::metadata(cache_path).unwrap();
         let modified = metadata.modified().unwrap();
         let mtime = modified
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap();
-        mtimes.insert(relation_path, mtime.as_secs_f64() + 1_f64);
+        mtimes.insert(
+            relation_path,
+            Rc::new(RefCell::new(mtime.as_secs_f64() + 1_f64)),
+        );
         file_system.set_mtimes(&mtimes);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
         ctx.set_file_system(&file_system_arc);

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1529,10 +1529,12 @@ pub fn application(request: &rouille::Request, ctx: &context::Context) -> rouill
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use std::cell::RefCell;
     use std::io::Read;
     use std::io::Seek;
     use std::io::SeekFrom;
     use std::io::Write;
+    use std::rc::Rc;
 
     /// Shared struct for wsgi tests.
     pub struct TestWsgi {
@@ -1824,10 +1826,10 @@ pub mod tests {
         );
         file_system.set_files(&files);
         // Make sure the cache is outdated.
-        let mut mtimes: HashMap<String, f64> = HashMap::new();
+        let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
         mtimes.insert(
             test_wsgi.ctx.get_abspath("workdir/gazdagret.htmlcache.en"),
-            0_f64,
+            Rc::new(RefCell::new(0_f64)),
         );
         file_system.set_mtimes(&mtimes);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);


### PR DESCRIPTION
cron::tests::test_update_additional_streets() needs this before it can
be converted to use TestFileSystem.

Change-Id: Ibfda2131c4bd2674f1bc65fc4ac3f67430c720d3
