### PR TITLE
Make more tests work without a tests/data/yamls.cache file

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -45,7 +45,7 @@ make
 To run a single test:
 
 ----
-cargo test --lib -- --test-threads=1 wsgi_json::tests::test_missing_streets_update_result_json
+cargo test --lib -- --test-threads=1 --exact wsgi_json::tests::test_missing_streets_update_result_json
 ----
 
 == Rust performance profiling


### PR DESCRIPTION
- fix cron::tests::test_update_osm_streets
- fix cron::tests::test_update_ref_housenumbers
- fix cron::tests::test_update_ref_streets
- fix parse_access_log::tests::test_main

Still 71 tests to fix.

Change-Id: I0b843feb701cba5bbdc52d54b95b1a431831e0dc
