### PR TITLE
Clean up util::get_content()

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -2223,7 +2223,7 @@ mod tests {
         let relation = relations.get_relation(relation_name).unwrap();
         let result_from_overpass =
             "@id\tname\n1\tTűzkő utca\n2\tTörökugrató utca\n3\tOSM Name 1\n4\tHamzsabégi út\n";
-        let expected = util::get_content("tests/workdir/streets-gazdagret.csv").unwrap();
+        let expected = std::fs::read("tests/workdir/streets-gazdagret.csv").unwrap();
         relation
             .get_files()
             .write_osm_streets(&ctx, result_from_overpass)
@@ -2274,7 +2274,7 @@ addr:conscriptionnumber\taddr:flats\taddr:floor\taddr:door\taddr:unit\tname\t@ty
 1\tOnly In OSM utca\t1\t\t\t\t\t\t\t\t\tnode\n\
 1\tSecond Only In OSM utca\t1\t\t\t\t\t\t\t\t\tnode\n";
         let expected = String::from_utf8(
-            util::get_content("tests/workdir/street-housenumbers-gazdagret.csv").unwrap(),
+            std::fs::read("tests/workdir/street-housenumbers-gazdagret.csv").unwrap(),
         )
         .unwrap();
         let relation = relations.get_relation(relation_name).unwrap();
@@ -3198,7 +3198,7 @@ way{color:blue; width:4;}
         let relation_name = "gazdagret";
         let mut relation = relations.get_relation(relation_name).unwrap();
         let expected = String::from_utf8(
-            util::get_content(&ctx.get_abspath("workdir/gazdagret.percent")).unwrap(),
+            std::fs::read(&ctx.get_abspath("workdir/gazdagret.percent")).unwrap(),
         )
         .unwrap();
 
@@ -3349,7 +3349,7 @@ way{color:blue; width:4;}
         let relation_name = "gazdagret";
         let relation = relations.get_relation(relation_name).unwrap();
         let expected = String::from_utf8(
-            util::get_content(&ctx.get_abspath("workdir/gazdagret-streets.percent")).unwrap(),
+            std::fs::read(&ctx.get_abspath("workdir/gazdagret-streets.percent")).unwrap(),
         )
         .unwrap();
 
@@ -3569,10 +3569,8 @@ way{color:blue; width:4;}
         let mut relations = Relations::new(&ctx).unwrap();
         let relation_name = "gazdagret";
         let expected = String::from_utf8(
-            util::get_content(
-                &ctx.get_abspath("workdir/street-housenumbers-reference-gazdagret.lst"),
-            )
-            .unwrap(),
+            std::fs::read(&ctx.get_abspath("workdir/street-housenumbers-reference-gazdagret.lst"))
+                .unwrap(),
         )
         .unwrap();
         let relation = relations.get_relation(relation_name).unwrap();
@@ -3699,7 +3697,7 @@ way{color:blue; width:4;}
         let relation_name = "gazdagret";
         let relation = relations.get_relation(relation_name).unwrap();
         let expected = String::from_utf8(
-            util::get_content(&ctx.get_abspath("workdir/streets-reference-gazdagret.lst")).unwrap(),
+            std::fs::read(&ctx.get_abspath("workdir/streets-reference-gazdagret.lst")).unwrap(),
         )
         .unwrap();
 

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -445,7 +445,7 @@ fn update_stats_refcount(ctx: &context::Context, state_dir: &str) -> anyhow::Res
 fn update_stats(ctx: &context::Context, overpass: bool) -> anyhow::Result<()> {
     // Fetch house numbers for the whole country.
     log::info!("update_stats: start, updating whole-country csv");
-    let query = String::from_utf8(util::get_content(
+    let query = String::from_utf8(std::fs::read(
         &ctx.get_abspath("data/street-housenumbers-hungary.txt"),
     )?)?;
     let statedir = ctx.get_abspath("workdir/stats");
@@ -1076,7 +1076,7 @@ mod tests {
         update_osm_housenumbers(&ctx, &mut relations, /*update=*/ false).unwrap();
 
         assert_eq!(ctx.get_file_system().getmtime(&path).unwrap(), mtime);
-        let actual = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
+        let actual = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
         assert_eq!(actual, expected);
     }
 
@@ -1110,11 +1110,11 @@ mod tests {
             }
         }
         let path = ctx.get_abspath("workdir/street-housenumbers-gazdagret.csv");
-        let expected = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
+        let expected = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
         update_osm_housenumbers(&ctx, &mut relations, /*update=*/ true).unwrap();
         // Make sure that in case we keep getting errors we give up at some stage and
         // leave the last state unchanged.
-        let actual = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
+        let actual = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
         assert_eq!(actual, expected);
     }
 
@@ -1148,9 +1148,9 @@ mod tests {
             }
         }
         let path = ctx.get_abspath("workdir/street-housenumbers-gazdagret.csv");
-        let expected = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
+        let expected = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
         update_osm_housenumbers(&ctx, &mut relations, /*update=*/ true).unwrap();
-        let actual = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
+        let actual = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
         assert_eq!(actual, expected);
     }
 
@@ -1243,13 +1243,13 @@ mod tests {
             }
         }
         let path = ctx.get_abspath("workdir/streets-gazdagret.csv");
-        let expected = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
+        let expected = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
 
         update_osm_streets(&ctx, &mut relations, /*update=*/ true).unwrap();
 
         // Make sure that in case we keep getting errors we give up at some stage and
         // leave the last state unchanged.
-        let actual = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
+        let actual = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
         assert_eq!(actual, expected);
     }
 
@@ -1283,11 +1283,11 @@ mod tests {
             }
         }
         let path = ctx.get_abspath("workdir/streets-gazdagret.csv");
-        let expected = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
+        let expected = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
 
         update_osm_streets(&ctx, &mut relations, /*update=*/ true).unwrap();
 
-        let actual = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
+        let actual = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
         assert_eq!(actual, expected);
     }
 
@@ -1349,11 +1349,10 @@ mod tests {
 
         update_stats(&ctx, /*overpass=*/ true).unwrap();
 
-        let actual = String::from_utf8(util::get_content(&path).unwrap()).unwrap();
+        let actual = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
         assert_eq!(
             actual,
-            String::from_utf8(util::get_content("tests/network/overpass-stats.csv").unwrap())
-                .unwrap()
+            String::from_utf8(std::fs::read("tests/network/overpass-stats.csv").unwrap()).unwrap()
         );
 
         // Make sure that the old CSV is removed.

--- a/src/parse_access_log.rs
+++ b/src/parse_access_log.rs
@@ -19,7 +19,6 @@ use std::io::Write;
 use crate::areas;
 use crate::context;
 use crate::stats;
-use crate::util;
 
 /// Does this relation have 100% house number coverage?
 fn is_complete_relation(
@@ -31,7 +30,7 @@ fn is_complete_relation(
         return Ok(false);
     }
 
-    let percent = String::from_utf8(util::get_content(
+    let percent = String::from_utf8(std::fs::read(
         &relation.get_files().get_housenumbers_percent_path(),
     )?)?;
     Ok(percent == "100.00")

--- a/src/util.rs
+++ b/src/util.rs
@@ -1025,12 +1025,6 @@ pub fn get_in_both<T: Clone + Diff>(first: &[T], second: &[T]) -> Vec<T> {
         .collect()
 }
 
-/// Gets the content of a file in workdir.
-pub fn get_content(path: &str) -> anyhow::Result<Vec<u8>> {
-    // TODO just use std::fs::read() directly, this was 12 lines originally.
-    Ok(std::fs::read(path)?)
-}
-
 /// Determines the normalizer for a given street.
 pub fn get_normalizer(
     street_name: &str,
@@ -1794,18 +1788,6 @@ A street\t9",
         ]);
         let actual: Vec<_> = ascending.iter().map(|i| i.get_number()).collect();
         assert_eq!(actual, ["a", "b", "c"]);
-    }
-
-    /// Tests get_content().
-    #[test]
-    fn test_get_content() {
-        let ctx = context::tests::make_test_context().unwrap();
-        let workdir = ctx.get_abspath("workdir");
-        let actual =
-            String::from_utf8(get_content(&format!("{}/gazdagret.percent", workdir)).unwrap())
-                .unwrap();
-        let expected = "54.55";
-        assert_eq!(actual, expected);
     }
 
     /// Tests Street.

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -1203,7 +1203,7 @@ pub fn make_response(status_code: u16, headers: Headers, data: Vec<u8>) -> rouil
 
 /// Gets the content of a file in workdir with metadata.
 fn get_content_with_meta(path: &str) -> anyhow::Result<(Vec<u8>, Headers)> {
-    let buf = util::get_content(path)?;
+    let buf = std::fs::read(path)?;
 
     let metadata = std::fs::metadata(path)?;
     let modified = metadata.modified()?;

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1400,7 +1400,7 @@ fn our_application_txt(
             ));
             data = output.as_bytes().to_vec();
         } else if request_uri.ends_with("robots.txt") {
-            data = util::get_content(&ctx.get_abspath("data/robots.txt"))?;
+            data = std::fs::read(&ctx.get_abspath("data/robots.txt"))?;
         } else {
             // assume txt
             let output = missing_housenumbers_view_txt(ctx, relations, request_uri)?;


### PR DESCRIPTION
It was a no longer necessary wrapper and this makes more tests work
without a tests/data/yamls.cache file.

Still 70 tests to fix.

Change-Id: I92e11aaaec09f5f3e9ed0962d670c997088a12ee
