### PR TITLE
Make more tests work without a tests/data/yamls.cache file

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -491,7 +491,8 @@ pub mod tests {
                 return Ok(*value.borrow());
             }
 
-            let metadata = std::fs::metadata(path)?;
+            let metadata =
+                std::fs::metadata(path).context(format!("metadata() failed for '{}'", path))?;
             let modified = metadata.modified()?;
             let mtime = modified.duration_since(std::time::SystemTime::UNIX_EPOCH)?;
             Ok(mtime.as_secs_f64())


### PR DESCRIPTION
- fix webframe::tests::test_handle_static
- fix webframe::tests::test_handle_static_ico
- fix webframe::tests::test_handle_static_svg

Still 61 tests to fix.

Change-Id: I3cbbd88e5509a10e78bd4e03a61a2cf05bfa50db
