### PR TITLE
Make more tests work without a tests/data/yamls.cache file

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -45,8 +45,13 @@ make
 To run a single test:
 
 ----
-cargo test --lib -- --test-threads=1 --exact wsgi_json::tests::test_missing_streets_update_result_json
+cargo test --lib -- --test-threads=1 --exact --nocapture wsgi_json::tests::test_missing_streets_update_result_json
 ----
+
+Tests follow the
+https://stackoverflow.blog/2022/01/03/favor-real-dependencies-for-unit-testing/[Favor real
+dependencies for unit testing] pattern, i.e. apart from filesystem, network or time (see
+`src/context.rs` for the exact list), no mocking is used.
 
 == Rust performance profiling
 


### PR DESCRIPTION
- fix wsgi::tests::test_compress
- fix wsgi::tests::test_handle_invalid_refstreets_well_formed
- fix wsgi::tests::test_handle_streets_update_result_error_well_formed
- fix wsgi::tests::test_handle_streets_update_result_missing_streets_well_formed

Still 43 tests to fix.

Change-Id: Idaefa15e727665253beef3c06fc0d55e4773563d
