### PR TITLE
flate2: dep -> dev-dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ chrono = "0.4.19"
 clap = "2.33.3"
 configparser = "3.0.0"
 csv = "1.1.6"
-flate2 = "1.0.22"
 gettext = "0.4.0"
 git-version = "0.3.5"
 html-escape = "0.2.9"
@@ -26,10 +25,13 @@ serde = { version = "1.0.129", features = ["derive"] }
 serde_json = "1.0.72"
 serde_yaml = "0.8.21"
 simplelog = "0.11.0"
-sxd-document = "0.3.2"
-sxd-xpath = "0.4.2"
 unidecode = "0.3.0"
 url = "2.2.2"
+
+[dev-dependencies]
+flate2 = "1.0.22"
+sxd-document = "0.3.2"
+sxd-xpath = "0.4.2"
 utime = "0.3.1"
 
 [features]


### PR DESCRIPTION
Same for sxd-* and utime.

246 -> 236 dependencies when building the non-test code.

Change-Id: I9bffb859089a0c6653c472a23a865ee8b9e2cf29
