### PR TITLE
Make more tests work without a tests/data/yamls.cache file

### DIFF
--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1997,9 +1997,24 @@ pub mod tests {
         let hide_path = relation.get_files().get_osm_streets_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "gazdagret": {
+                    "osmrelation": 42,
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+        let files = context::tests::TestFileSystem::make_files(
+            &test_wsgi.ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
         test_wsgi.ctx.set_file_system(&file_system_arc);
+
         let root = test_wsgi.get_dom_for_path("/missing-housenumbers/gazdagret/view-result");
+
         let results = TestWsgi::find_all(&root, "body/div[@id='no-osm-streets']");
         assert_eq!(results.len(), 1);
     }
@@ -2044,9 +2059,24 @@ pub mod tests {
         let hide_path = relation.get_files().get_ref_housenumbers_path();
         let mut file_system = context::tests::TestFileSystem::new();
         file_system.set_hide_paths(&[hide_path]);
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "gazdagret": {
+                    "osmrelation": 42,
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+        let files = context::tests::TestFileSystem::make_files(
+            &test_wsgi.ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        file_system.set_files(&files);
         let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
         test_wsgi.ctx.set_file_system(&file_system_arc);
+
         let root = test_wsgi.get_dom_for_path("/missing-housenumbers/gazdagret/view-result");
+
         let results = TestWsgi::find_all(&root, "body/div[@id='no-ref-housenumbers']");
         assert_eq!(results.len(), 1);
     }
@@ -2258,7 +2288,23 @@ Tűzkő utca	31
     #[test]
     fn test_missing_housenumbers_view_query_well_formed() {
         let mut test_wsgi = TestWsgi::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "gazdagret": {
+                    "osmrelation": 42,
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+        let files = context::tests::TestFileSystem::make_files(
+            &test_wsgi.ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        let file_system = context::tests::TestFileSystem::from_files(&files);
+        test_wsgi.ctx.set_file_system(&file_system);
+
         let root = test_wsgi.get_dom_for_path("/missing-housenumbers/gazdagret/view-query");
+
         let results = TestWsgi::find_all(&root, "body/pre");
         assert_eq!(results.len(), 1);
     }
@@ -2267,17 +2313,42 @@ Tűzkő utca	31
     #[test]
     fn test_missing_housenumbers_update_result_link() {
         let mut test_wsgi = TestWsgi::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "gazdagret": {
+                    "osmrelation": 42,
+                    "refcounty": "01",
+                    "refsettlement": "011",
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+        let ref_housenumbers_cache = context::tests::TestFileSystem::make_file();
+        let ref_housenumbers2_cache = context::tests::TestFileSystem::make_file();
         let housenumbers_value = context::tests::TestFileSystem::make_file();
         let files = context::tests::TestFileSystem::make_files(
             &test_wsgi.ctx,
-            &[(
-                "workdir/street-housenumbers-reference-gazdagret.lst",
-                &housenumbers_value,
-            )],
+            &[
+                ("data/yamls.cache", &yamls_cache_value),
+                (
+                    "refdir/hazszamok_20190511.tsv-01-v1.cache",
+                    &ref_housenumbers_cache,
+                ),
+                (
+                    "refdir/hazszamok_kieg_20190808.tsv-01-v1.cache",
+                    &ref_housenumbers2_cache,
+                ),
+                (
+                    "workdir/street-housenumbers-reference-gazdagret.lst",
+                    &housenumbers_value,
+                ),
+            ],
         );
         let file_system = context::tests::TestFileSystem::from_files(&files);
         test_wsgi.ctx.set_file_system(&file_system);
+
         let root = test_wsgi.get_dom_for_path("/missing-housenumbers/gazdagret/update-result");
+
         let mut guard = housenumbers_value.borrow_mut();
         assert_eq!(guard.seek(SeekFrom::Current(0)).unwrap() > 0, true);
         let prefix = test_wsgi.ctx.get_ini().get_uri_prefix().unwrap();


### PR DESCRIPTION
- fix wsgi::tests::test_missing_housenumbers_no_osm_streets
- fix wsgi::tests::test_missing_housenumbers_no_ref_housenumbers_well_formed
- fix wsgi::tests::test_missing_housenumbers_update_result_link
- fix wsgi::tests::test_missing_housenumbers_view_query_well_formed

Still 26 tests to fix.

Change-Id: I326b20114a71f64a4f854819127b2742e1545a3d
