### PR TITLE
cargo: update dependencies (2022-01)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,26 +5,26 @@ edition = "2021"
 
 [dependencies]
 accept-language = "2.0.0"
-anyhow = "1.0.50"
+anyhow = "1.0.53"
 chrono = "0.4.19"
-clap = "2.33.3"
+clap = "3.0.13"
 configparser = "3.0.0"
 csv = "1.1.6"
 gettext = "0.4.0"
 git-version = "0.3.5"
 html-escape = "0.2.9"
 isahc = "1.6.0"
-itertools = "0.10.1"
+itertools = "0.10.3"
 lazy_static = "1.4.0"
 log = "0.4.14"
 regex = "1.5.4"
-rouille = "3.4.0"
-rust_icu_ucol = { version = "1.0.3", optional = true }
-rust_icu_ustring = { version = "1.0.3", optional = true }
-serde = { version = "1.0.129", features = ["derive"] }
-serde_json = "1.0.72"
-serde_yaml = "0.8.21"
-simplelog = "0.11.0"
+rouille = "3.5.0"
+rust_icu_ucol = { version = "2.0.0", optional = true }
+rust_icu_ustring = { version = "2.0.0", optional = true }
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.78"
+serde_yaml = "0.8.23"
+simplelog = "0.11.2"
 unidecode = "0.3.0"
 url = "2.2.2"
 

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -556,29 +556,29 @@ pub fn main(
 ) -> anyhow::Result<()> {
     let mut relations = areas::Relations::new(ctx)?;
 
-    let refcounty = clap::Arg::with_name("refcounty")
+    let refcounty = clap::Arg::new("refcounty")
         .long("refcounty")
         .takes_value(true)
         .help("limit the list of relations to a given refcounty");
-    let refsettlement = clap::Arg::with_name("refsettlement")
+    let refsettlement = clap::Arg::new("refsettlement")
         .long("refsettlement")
         .takes_value(true)
         .help("limit the list of relations to a given refsettlement");
     // Default: true.
-    let no_update = clap::Arg::with_name("no-update")
+    let no_update = clap::Arg::new("no-update")
         .long("no-update")
         .help("don't update existing state of relations");
-    let mode = clap::Arg::with_name("mode")
+    let mode = clap::Arg::new("mode")
         .long("mode")
         .takes_value(true)
         .default_value("relations")
         .help("only perform the given sub-task or all of them [all, stats or relations]");
-    let no_overpass = clap::Arg::with_name("no-overpass") // default: true
+    let no_overpass = clap::Arg::new("no-overpass") // default: true
         .long("no-overpass")
         .help("when updating stats, don't perform any overpass update");
     let args = [refcounty, refsettlement, no_update, mode, no_overpass];
     let app = clap::App::new("osm-gimmisn");
-    let args = app.args(&args).get_matches_from_safe(argv)?;
+    let args = app.args(&args).try_get_matches_from(argv)?;
 
     let start = ctx.get_time().now();
     // Query inactive relations once a month.


### PR DESCRIPTION
- anyhow to 1.0.53
- clap to 3.0.13
- itertools to 0.10.3
- rouille to 3.5.0
- rust_icu_ucol to 2.0.0
- rust_icu_ustring to 2.0.0
- serde to 1.0.136
- serde_json to 1.0.78
- serde_yaml to 0.8.23
- simplelog to 0.11.2

Change-Id: I4f54b88140ac3a18849c60b494c84b35ae868120
