### PR TITLE
Make more tests work without a tests/data/yamls.cache file

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -3197,10 +3197,6 @@ way{color:blue; width:4;}
         let mut relations = Relations::new(&ctx).unwrap();
         let relation_name = "gazdagret";
         let mut relation = relations.get_relation(relation_name).unwrap();
-        let expected = String::from_utf8(
-            std::fs::read(&ctx.get_abspath("workdir/gazdagret.percent")).unwrap(),
-        )
-        .unwrap();
 
         let ret = relation.write_missing_housenumbers().unwrap();
 
@@ -3223,7 +3219,7 @@ way{color:blue; width:4;}
         guard.seek(SeekFrom::Start(0)).unwrap();
         let mut actual: Vec<u8> = Vec::new();
         guard.read_to_end(&mut actual).unwrap();
-        assert_eq!(String::from_utf8(actual).unwrap(), expected);
+        assert_eq!(String::from_utf8(actual).unwrap(), "54.55");
     }
 
     /// Tests Relation::write_missing_housenumbers(): the case when percent can't be determined.

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -2752,7 +2752,29 @@ Tűzkő utca	31
     #[test]
     fn test_missing_streets_view_result_txt() {
         let mut test_wsgi = TestWsgi::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "gazdagret": {
+                    "osmrelation": 42,
+                },
+            },
+            "relation-gazdagret.yaml": {
+                "street-filters": ["Only In Ref Nonsense utca"],
+                "refstreets": {
+                    "OSM Name 1": "Ref Name 1",
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+        let files = context::tests::TestFileSystem::make_files(
+            &test_wsgi.ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        let file_system = context::tests::TestFileSystem::from_files(&files);
+        test_wsgi.ctx.set_file_system(&file_system);
+
         let result = test_wsgi.get_txt_for_path("/missing-streets/gazdagret/view-result.txt");
+
         assert_eq!(result, "Only In Ref utca\n");
     }
 
@@ -2760,7 +2782,29 @@ Tűzkő utca	31
     #[test]
     fn test_missing_streets_view_result_chkl() {
         let mut test_wsgi = TestWsgi::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "gazdagret": {
+                    "osmrelation": 42,
+                },
+            },
+            "relation-gazdagret.yaml": {
+                "street-filters": ["Only In Ref Nonsense utca"],
+                "refstreets": {
+                    "OSM Name 1": "Ref Name 1",
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+        let files = context::tests::TestFileSystem::make_files(
+            &test_wsgi.ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        let file_system = context::tests::TestFileSystem::from_files(&files);
+        test_wsgi.ctx.set_file_system(&file_system);
+
         let result = test_wsgi.get_txt_for_path("/missing-streets/gazdagret/view-result.chkl");
+
         assert_eq!(result, "[ ] Only In Ref utca\n");
     }
 
@@ -2802,6 +2846,20 @@ Tűzkő utca	31
     #[test]
     fn test_missing_streets_view_query_well_formed() {
         let mut test_wsgi = TestWsgi::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "gazdagret": {
+                    "osmrelation": 42,
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+        let files = context::tests::TestFileSystem::make_files(
+            &test_wsgi.ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        let file_system = context::tests::TestFileSystem::from_files(&files);
+        test_wsgi.ctx.set_file_system(&file_system);
 
         let root = test_wsgi.get_dom_for_path("/missing-streets/gazdagret/view-query");
 
@@ -2850,6 +2908,31 @@ Tűzkő utca	31
     #[test]
     fn test_missing_streets_view_turbo() {
         let mut test_wsgi = TestWsgi::new();
+        let yamls_cache = serde_json::json!({
+            "relations.yaml": {
+                "gazdagret": {
+                    "osmrelation": 42,
+                },
+            },
+            "relation-gazdagret.yaml": {
+                "filters": {
+                    "OSM Name 2": {
+                        "show-refstreet": false,
+                    },
+                },
+                "refstreets": {
+                    "OSM Name 1": "Ref Name 1",
+                    "OSM Name 2": "Ref Name 2",
+                },
+            },
+        });
+        let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+        let files = context::tests::TestFileSystem::make_files(
+            &test_wsgi.ctx,
+            &[("data/yamls.cache", &yamls_cache_value)],
+        );
+        let file_system = context::tests::TestFileSystem::from_files(&files);
+        test_wsgi.ctx.set_file_system(&file_system);
         let root = test_wsgi.get_dom_for_path("/missing-streets/gazdagret/view-turbo");
 
         let results = TestWsgi::find_all(&root, "body/pre");


### PR DESCRIPTION
- fix wsgi::tests::test_missing_streets_view_query_well_formed
- fix wsgi::tests::test_missing_streets_view_result_chkl
- fix wsgi::tests::test_missing_streets_view_result_txt
- fix wsgi::tests::test_missing_streets_view_turbo

Still 14 tests to fix.

Also get the "long" git version, so e.g. right after tagging v7.3 we get
something like "v7.3-0-g733bdbee", not just "v7.3", leading to broken
github links.

Change-Id: I9bfc829c428d63cd85e9b30fa43427e3df40699e
