### PR TITLE
Remove unused use declaration

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -21,7 +21,6 @@ use anyhow::Context;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::convert::TryFrom;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::io::BufRead;


### PR DESCRIPTION
I'm not exactly sure why rustc didn't flag this on Linux, only on
Windows.

Change-Id: I39a5a08334146565cf6501af955722288072cb0d
