### PR TITLE
Fix tests that make changes to the test data during 'make check'

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -324,10 +324,30 @@ mod tests {
     /// Tests is_missing_housenumbers_html_cached().
     #[test]
     fn test_is_missing_housenumbers_html_cached() {
-        let ctx = context::tests::make_test_context().unwrap();
+        let mut ctx = context::tests::make_test_context().unwrap();
+        let mut file_system = context::tests::TestFileSystem::new();
+        let percent_value = context::tests::TestFileSystem::make_file();
+        let html_cache_value = context::tests::TestFileSystem::make_file();
+        let files = context::tests::TestFileSystem::make_files(
+            &ctx,
+            &[
+                ("workdir/gazdagret.percent", &percent_value),
+                ("workdir/gazdagret.htmlcache.en", &html_cache_value),
+            ],
+        );
+        file_system.set_files(&files);
+        let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
+        mtimes.insert(
+            ctx.get_abspath("workdir/gazdagret.htmlcache.en"),
+            Rc::new(RefCell::new(0_f64)),
+        );
+        file_system.set_mtimes(&mtimes);
+        let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+        ctx.set_file_system(&file_system_arc);
         let mut relations = areas::Relations::new(&ctx).unwrap();
         let mut relation = relations.get_relation("gazdagret").unwrap();
         get_missing_housenumbers_html(&ctx, &mut relation).unwrap();
+
         assert_eq!(
             is_missing_housenumbers_html_cached(&ctx, &mut relation).unwrap(),
             true

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1888,11 +1888,13 @@ pub mod tests {
             },
         });
         let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+        let percent_value = context::tests::TestFileSystem::make_file();
         let html_cache_value = context::tests::TestFileSystem::make_file();
         let files = context::tests::TestFileSystem::make_files(
             &test_wsgi.ctx,
             &[
                 ("data/yamls.cache", &yamls_cache_value),
+                ("workdir/gazdagret.percent", &percent_value),
                 ("workdir/gazdagret.htmlcache.en", &html_cache_value),
             ],
         );


### PR DESCRIPTION
- fix cache::tests::test_is_missing_housenumbers_html_cached: don't write relation percent file
- fix wsgi::tests::test_missing_housenumbers_well_formed: don't write relation percent file

With this, 'git diff' is now again empty after 'make check'.

Change-Id: I12c758ef7c7214a273386c6ca12e92d903a8b20e
