### PR TITLE
areas: avoid std::fs::read_to_string()

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -511,7 +511,7 @@ impl Relation {
 
     /// Produces a query which lists streets in relation.
     pub fn get_osm_streets_query(&self) -> anyhow::Result<String> {
-        let contents = std::fs::read_to_string(format!(
+        let contents = self.ctx.get_file_system().read_to_string(&format!(
             "{}/{}",
             self.ctx.get_abspath("data"),
             "streets-template.txt"
@@ -1104,7 +1104,7 @@ impl Relation {
 
     /// Produces a query which lists house numbers in relation.
     pub fn get_osm_housenumbers_query(&self) -> anyhow::Result<String> {
-        let contents = std::fs::read_to_string(format!(
+        let contents = self.ctx.get_file_system().read_to_string(&format!(
             "{}/{}",
             self.ctx.get_abspath("data"),
             "street-housenumbers-template.txt"

--- a/src/bin/validator.rs
+++ b/src/bin/validator.rs
@@ -12,7 +12,8 @@
 
 fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
-    match osm_gimmisn::validator::main(&args, &mut std::io::stdout()) {
+    let ctx = osm_gimmisn::context::Context::new("").unwrap();
+    match osm_gimmisn::validator::main(&args, &mut std::io::stdout(), &ctx) {
         Ok(exit_code) => std::process::exit(exit_code),
         Err(err) => Err(err),
     }

--- a/src/cache_yamls.rs
+++ b/src/cache_yamls.rs
@@ -36,7 +36,7 @@ pub fn main(argv: &[String], ctx: &context::Context) -> anyhow::Result<()> {
             .strip_prefix(&format!("{}/", datadir))
             .context("yaml outside datadir")?
             .to_string();
-        let data = std::fs::read_to_string(&yaml_path)?;
+        let data = ctx.get_file_system().read_to_string(&yaml_path)?;
         let cache_value = serde_yaml::from_str::<serde_json::Value>(&data)
             .context(format!("serde_yaml::from_str() failed for {}", yaml_path))?;
         cache.insert(cache_key, cache_value);

--- a/src/context.rs
+++ b/src/context.rs
@@ -36,6 +36,15 @@ pub trait FileSystem {
 
     /// Opens a file for writing in binary mode.
     fn open_write(&self, path: &str) -> anyhow::Result<Rc<RefCell<dyn Write>>>;
+
+    /// Read the entire contents of a file into a string.
+    fn read_to_string(&self, path: &str) -> anyhow::Result<String> {
+        let stream = self.open_read(path)?;
+        let mut guard = stream.borrow_mut();
+        let mut bytes: Vec<u8> = Vec::new();
+        guard.read_to_end(&mut bytes).unwrap();
+        Ok(String::from_utf8(bytes)?)
+    }
 }
 
 /// File system implementation, backed by the Rust stdlib.

--- a/src/overpass_query.rs
+++ b/src/overpass_query.rs
@@ -119,7 +119,10 @@ mod tests {
         let network = context::tests::TestNetwork::new(&routes);
         let network_arc: Arc<dyn context::Network> = Arc::new(network);
         ctx.set_network(&network_arc);
-        let query = std::fs::read_to_string("tests/network/overpass-happy.expected-data").unwrap();
+        let query = ctx
+            .get_file_system()
+            .read_to_string("tests/network/overpass-happy.expected-data")
+            .unwrap();
 
         let buf = overpass_query(&ctx, query).unwrap();
 


### PR DESCRIPTION
Which reads the filesystem directly, so not possible to mock the data in
tests.

And the same in:

- cache_yamls
- overpass_query
- validator

Change-Id: I6d7611bc34e2b371711fee4b0a0282e206951a98
