### PR TITLE
Replace std::fs::read() with read_to_string() where possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ check-clippy: Cargo.toml $(RS_OBJECTS)
 
 build: $(RS_OBJECTS) Cargo.toml Makefile
 	cargo build ${CARGO_OPTIONS}
+	cargo test ${CARGO_OPTIONS} --lib --no-run
 
 # Without coverage: cargo test --lib -- --test-threads=1
 check-unit: Cargo.toml $(RS_OBJECTS) locale/hu/LC_MESSAGES/osm-gimmisn.mo testdata data/yamls.cache

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -445,9 +445,9 @@ fn update_stats_refcount(ctx: &context::Context, state_dir: &str) -> anyhow::Res
 fn update_stats(ctx: &context::Context, overpass: bool) -> anyhow::Result<()> {
     // Fetch house numbers for the whole country.
     log::info!("update_stats: start, updating whole-country csv");
-    let query = String::from_utf8(std::fs::read(
-        &ctx.get_abspath("data/street-housenumbers-hungary.txt"),
-    )?)?;
+    let query = ctx
+        .get_file_system()
+        .read_to_string(&ctx.get_abspath("data/street-housenumbers-hungary.txt"))?;
     let statedir = ctx.get_abspath("workdir/stats");
     std::fs::create_dir_all(&statedir)?;
     let now = chrono::NaiveDateTime::from_timestamp(ctx.get_time().now(), 0);

--- a/src/parse_access_log.rs
+++ b/src/parse_access_log.rs
@@ -22,6 +22,7 @@ use crate::stats;
 
 /// Does this relation have 100% house number coverage?
 fn is_complete_relation(
+    ctx: &context::Context,
     relations: &mut areas::Relations,
     relation_name: &str,
 ) -> anyhow::Result<bool> {
@@ -30,9 +31,9 @@ fn is_complete_relation(
         return Ok(false);
     }
 
-    let percent = String::from_utf8(std::fs::read(
-        &relation.get_files().get_housenumbers_percent_path(),
-    )?)?;
+    let percent = ctx
+        .get_file_system()
+        .read_to_string(&relation.get_files().get_housenumbers_percent_path())?;
     Ok(percent == "100.00")
 }
 
@@ -210,7 +211,7 @@ pub fn main(argv: &[String], stdout: &mut dyn Write, ctx: &context::Context) -> 
         let relation = relations.get_relation(&relation_name)?;
         let actual = relation.get_config().is_active();
         let expected = frequent_relations.contains(&relation_name)
-            && !is_complete_relation(&mut relations, &relation_name)?;
+            && !is_complete_relation(ctx, &mut relations, &relation_name)?;
         if actual != expected {
             if actual {
                 if !is_relation_recently_added(ctx, &relation_create_dates, &relation_name) {

--- a/src/parse_access_log/tests.rs
+++ b/src/parse_access_log/tests.rs
@@ -79,7 +79,7 @@ fn test_is_complete_relation() {
     let ctx = context::tests::make_test_context().unwrap();
     let mut relations = areas::Relations::new(&ctx).unwrap();
     assert_eq!(
-        is_complete_relation(&mut relations, "gazdagret").unwrap(),
+        is_complete_relation(&ctx, &mut relations, "gazdagret").unwrap(),
         false
     );
 }


### PR DESCRIPTION
This is possible in case the return value is used with
String::from_utf8() anyway.

std::fs::read() is problematic as it reads the filesystem directly, so
not possible to mock the data in tests.

Change-Id: Ibbcce0889fc5773c4e3e4dd8bf937bd56e52fc54
