### PR TITLE
areas: add test for Relation::numbered_streets_to_table()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,6 @@ check-clippy: Cargo.toml $(RS_OBJECTS)
 
 build: $(RS_OBJECTS) Cargo.toml Makefile
 	cargo build ${CARGO_OPTIONS}
-	cargo test ${CARGO_OPTIONS} --lib --no-run
 
 # Without coverage: cargo test --lib -- --test-threads=1
 check-unit: Cargo.toml $(RS_OBJECTS) locale/hu/LC_MESSAGES/osm-gimmisn.mo testdata data/yamls.cache

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -2628,3 +2628,49 @@ fn test_relation_config_is_active() {
     let relation = relations.get_relation(relation_name).unwrap();
     assert_eq!(relation.get_config().is_active(), true);
 }
+
+/// Tests Relation::numbered_streets_to_table(): when a street is not even-odd.
+#[test]
+fn test_relation_numbered_streets_to_table() {
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let yamls_cache = serde_json::json!({
+        "relations.yaml": {
+            "myrelation": {
+                "osmrelation": 42,
+            },
+        },
+        "relation-myrelation.yaml": {
+            "filters": {
+                "mystreet": {
+                    "interpolation": "all",
+                }
+            },
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[("data/yamls.cache", &yamls_cache_value)],
+    );
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    ctx.set_file_system(&file_system);
+    let mut relations = Relations::new(&ctx).unwrap();
+    let relation = relations.get_relation("myrelation").unwrap();
+    let street = util::Street::new("mystreet", "mystreet", false, 0);
+    let house_numbers = vec![
+        util::HouseNumber::new("1", "1", ""),
+        util::HouseNumber::new("2", "2", ""),
+    ];
+    let streets = vec![(street, house_numbers)];
+
+    let (table, _todo_count) = relation.numbered_streets_to_table(&streets);
+
+    assert_eq!(table.len(), 2);
+    // Ignore header.
+    let row = &table[1];
+    assert_eq!(row.len(), 3);
+    assert_eq!(row[0].get_value(), "mystreet");
+    assert_eq!(row[1].get_value(), "2");
+    // No line break here.
+    assert_eq!(row[2].get_value(), "1, 2");
+}


### PR DESCRIPTION
The not-even-odd case is only implicitly tested by
tests/data/relation-budafok.yaml, i.e. nobody asserted that the
behavior is correct.

Also drop 'cargo test ... --no-run', I forgot that it builds without
coverage, so this meant we build the code 3 times, while the intention
was to let 'make' build the tests without building the code more than 2
times.

Change-Id: I6bb9ef022975244cb83aa4cb9d6e5d9ff5c8c95e
