### PR TITLE
Add tests for areas::RelationConfig::set_active() and wsgi::handle_main_relation()

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1232,12 +1232,6 @@ impl Relations {
         Ok(self.relations[name].clone())
     }
 
-    /// Sets a relation for testing.
-    #[cfg(test)]
-    pub fn set_relation(&mut self, name: &str, relation: &Relation) {
-        self.relations.insert(name.into(), relation.clone());
-    }
-
     /// Gets a sorted list of relation names.
     pub fn get_names(&self) -> Vec<String> {
         let mut ret: Vec<String> = self.dict.iter().map(|(key, _value)| key.into()).collect();

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -2674,3 +2674,29 @@ fn test_relation_numbered_streets_to_table() {
     // No line break here.
     assert_eq!(row[2].get_value(), "1, 2");
 }
+
+/// Tests RelationConfig::set_active().
+#[test]
+fn test_relation_config_set_active() {
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let yamls_cache = serde_json::json!({
+        "relations.yaml": {
+            "myrelation": {
+                "osmrelation": 42,
+            },
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[("data/yamls.cache", &yamls_cache_value)],
+    );
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    ctx.set_file_system(&file_system);
+    let mut relations = Relations::new(&ctx).unwrap();
+    let relation = relations.get_relation("myrelation").unwrap();
+    let mut config = relation.get_config().clone();
+    assert_eq!(config.is_active(), true);
+    config.set_active(false);
+    assert_eq!(config.is_active(), false);
+}

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -492,15 +492,6 @@ fn test_update_osm_housenumbers_http_error() {
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
     ctx.set_network(&network_arc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
-    for relation_name in relations.get_active_names().unwrap() {
-        if relation_name != "gazdagret" {
-            let mut relation = relations.get_relation(&relation_name).unwrap();
-            let mut config = relation.get_config().clone();
-            config.set_active(false);
-            relation.set_config(&config);
-            relations.set_relation(&relation_name, &relation);
-        }
-    }
     let path = ctx.get_abspath("workdir/street-housenumbers-gazdagret.csv");
     let expected = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
     update_osm_housenumbers(&ctx, &mut relations, /*update=*/ true).unwrap();
@@ -530,15 +521,6 @@ fn test_update_osm_housenumbers_xml_as_csv() {
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
     ctx.set_network(&network_arc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
-    for relation_name in relations.get_active_names().unwrap() {
-        if relation_name != "gazdagret" {
-            let mut relation = relations.get_relation(&relation_name).unwrap();
-            let mut config = relation.get_config().clone();
-            config.set_active(false);
-            relation.set_config(&config);
-            relations.set_relation(&relation_name, &relation);
-        }
-    }
     let path = ctx.get_abspath("workdir/street-housenumbers-gazdagret.csv");
     let expected = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
     update_osm_housenumbers(&ctx, &mut relations, /*update=*/ true).unwrap();
@@ -625,15 +607,6 @@ fn test_update_osm_streets_http_error() {
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
     ctx.set_network(&network_arc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
-    for relation_name in relations.get_active_names().unwrap() {
-        if relation_name != "gazdagret" {
-            let mut relation = relations.get_relation(&relation_name).unwrap();
-            let mut config = relation.get_config().clone();
-            config.set_active(false);
-            relation.set_config(&config);
-            relations.set_relation(&relation_name, &relation);
-        }
-    }
     let path = ctx.get_abspath("workdir/streets-gazdagret.csv");
     let expected = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
 
@@ -665,15 +638,6 @@ fn test_update_osm_streets_xml_as_csv() {
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
     ctx.set_network(&network_arc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
-    for relation_name in relations.get_active_names().unwrap() {
-        if relation_name != "gazdagret" {
-            let mut relation = relations.get_relation(&relation_name).unwrap();
-            let mut config = relation.get_config().clone();
-            config.set_active(false);
-            relation.set_config(&config);
-            relations.set_relation(&relation_name, &relation);
-        }
-    }
     let path = ctx.get_abspath("workdir/streets-gazdagret.csv");
     let expected = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
 
@@ -1225,14 +1189,5 @@ fn test_update_ref_housenumbers_xml_as_csv() {
     let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
     ctx.set_file_system(&file_system_arc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
-    for relation_name in relations.get_active_names().unwrap() {
-        if relation_name != "gazdagret" {
-            let mut relation = relations.get_relation(&relation_name).unwrap();
-            let mut config = relation.get_config().clone();
-            config.set_active(false);
-            relation.set_config(&config);
-            relations.set_relation(&relation_name, &relation);
-        }
-    }
     update_ref_housenumbers(&ctx, &mut relations, /*update=*/ true).unwrap();
 }

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -1949,3 +1949,38 @@ fn test_handle_main_relation() {
     // same for additional streets.
     assert_eq!(ret[4].get_value(), "");
 }
+
+/// Tests handle_main_relation() for the missing-streets=only case.
+#[test]
+fn test_handle_main_relation_streets_only() {
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let yamls_cache = serde_json::json!({
+        "relations.yaml": {
+            "myrelation": {
+                "osmrelation": 42,
+            },
+        },
+        "relation-myrelation.yaml": {
+            "missing-streets": "only",
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[("data/yamls.cache", &yamls_cache_value)],
+    );
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    ctx.set_file_system(&file_system);
+    let mut relations = areas::Relations::new(&ctx).unwrap();
+    let filter_for = Box::new(filter_for_everything);
+
+    let ret = handle_main_relation(&ctx, &mut relations, &filter_for, "myrelation").unwrap();
+
+    // area, missing housenumbers, additional housenumbers, missing streets, additional streets,
+    // relation link
+    assert_eq!(ret.len(), 6);
+    // missing-streets=only, so 'missing housenumbers' should be empty.
+    assert_eq!(ret[1].get_value(), "");
+    // same for additional housenumbers.
+    assert_eq!(ret[2].get_value(), "");
+}

--- a/tests/data/relation-ujbuda.yaml
+++ b/tests/data/relation-ujbuda.yaml
@@ -1,3 +1,0 @@
-missing-streets: only
-filters: {}
-source: survey

--- a/tests/data/relations.yaml
+++ b/tests/data/relations.yaml
@@ -2,8 +2,3 @@ gazdagret:
     osmrelation: 2713748
     refcounty: "01"
     refsettlement: "011"
-# this relation has 'missing-streets: only' set
-ujbuda:
-    osmrelation: 221998
-    refcounty: "01"
-    refsettlement: "011"


### PR DESCRIPTION
It's less code to have explicit tests for these two functions, and then
the whole "ujbuda" relation can go from the test data.

Which means that the remaining tests always get a single relation, so no
need to disable anything.

Change-Id: Ib601f0486617edb6a15dca54f9ce3af54b1cc3f4
