### PR TITLE
context: introduce write_from_string()

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -160,17 +160,6 @@ impl RelationFiles {
             .context("open_write() failed")
     }
 
-    /// Opens the house number percent file of a relation for writing.
-    pub fn get_housenumbers_percent_write_stream(
-        &self,
-        ctx: &context::Context,
-    ) -> anyhow::Result<Rc<RefCell<dyn Write>>> {
-        let path = self.get_housenumbers_percent_path();
-        ctx.get_file_system()
-            .open_write(&path)
-            .with_context(|| format!("failed to open {} for writing", path))
-    }
-
     /// Opens the house number HTML cache file of a relation for reading.
     pub fn get_housenumbers_htmlcache_read_stream(
         &self,
@@ -178,15 +167,6 @@ impl RelationFiles {
     ) -> anyhow::Result<Rc<RefCell<dyn Read>>> {
         let path = self.get_housenumbers_htmlcache_path();
         ctx.get_file_system().open_read(&path)
-    }
-
-    /// Opens the house number HTML cache file of a relation for writing.
-    pub fn get_housenumbers_htmlcache_write_stream(
-        &self,
-        ctx: &context::Context,
-    ) -> anyhow::Result<Rc<RefCell<dyn Write>>> {
-        let path = self.get_housenumbers_htmlcache_path();
-        ctx.get_file_system().open_write(&path)
     }
 
     /// Opens the house number plain text cache file of a relation for reading.
@@ -198,24 +178,6 @@ impl RelationFiles {
         ctx.get_file_system().open_read(&path)
     }
 
-    /// Opens the house number plain text cache file of a relation for writing.
-    pub fn get_housenumbers_txtcache_write_stream(
-        &self,
-        ctx: &context::Context,
-    ) -> anyhow::Result<Rc<RefCell<dyn Write>>> {
-        let path = self.get_housenumbers_txtcache_path();
-        ctx.get_file_system().open_write(&path)
-    }
-
-    /// Opens the street percent file of a relation for writing.
-    pub fn get_streets_percent_write_stream(
-        &self,
-        ctx: &context::Context,
-    ) -> anyhow::Result<Rc<RefCell<dyn Write>>> {
-        let path = self.get_streets_percent_path();
-        ctx.get_file_system().open_write(&path)
-    }
-
     /// Opens the street additional count file of a relation for reading.
     pub fn get_streets_additional_count_read_stream(
         &self,
@@ -225,15 +187,6 @@ impl RelationFiles {
         ctx.get_file_system().open_read(&path)
     }
 
-    /// Opens the street additional count file of a relation for writing.
-    pub fn get_streets_additional_count_write_stream(
-        &self,
-        ctx: &context::Context,
-    ) -> anyhow::Result<Rc<RefCell<dyn Write>>> {
-        let path = self.get_streets_additional_count_path();
-        ctx.get_file_system().open_write(&path)
-    }
-
     /// Opens the housenumbers additional count file of a relation for reading.
     pub fn get_housenumbers_additional_count_read_stream(
         &self,
@@ -241,15 +194,6 @@ impl RelationFiles {
     ) -> anyhow::Result<Rc<RefCell<dyn Read>>> {
         let path = self.get_housenumbers_additional_count_path();
         ctx.get_file_system().open_read(&path)
-    }
-
-    /// Opens the housenumbers additional count file of a relation for writing.
-    pub fn get_housenumbers_additional_count_write_stream(
-        &self,
-        ctx: &context::Context,
-    ) -> anyhow::Result<Rc<RefCell<dyn Write>>> {
-        let path = self.get_housenumbers_additional_count_path();
-        ctx.get_file_system().open_write(&path)
     }
 
     /// Opens the OSM street list of a relation for writing.
@@ -305,14 +249,5 @@ impl RelationFiles {
     ) -> anyhow::Result<Rc<RefCell<dyn Read>>> {
         let path = self.get_additional_housenumbers_htmlcache_path();
         ctx.get_file_system().open_read(&path)
-    }
-
-    /// Opens the additional house number HTML cache file of a relation for writing.
-    pub fn get_additional_housenumbers_htmlcache_write_stream(
-        &self,
-        ctx: &context::Context,
-    ) -> anyhow::Result<Rc<RefCell<dyn Write>>> {
-        let path = self.get_additional_housenumbers_htmlcache_path();
-        ctx.get_file_system().open_write(&path)
     }
 }

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -913,9 +913,9 @@ impl Relation {
         }
 
         // Write the bottom line to a file, so the index page show it fast.
-        let write = self.file.get_streets_percent_write_stream(&self.ctx)?;
-        let mut guard = write.borrow_mut();
-        guard.write_all(percent.as_bytes())?;
+        self.ctx
+            .get_file_system()
+            .write_from_string(&percent, &self.file.get_streets_percent_path())?;
 
         Ok((todo_count, done_count, percent, streets))
     }
@@ -926,9 +926,10 @@ impl Relation {
 
         // Write the count to a file, so the index page show it fast.
         let file = &self.file;
-        let write = file.get_streets_additional_count_write_stream(&self.ctx)?;
-        let mut guard = write.borrow_mut();
-        guard.write_all(additional_streets.len().to_string().as_bytes())?;
+        self.ctx.get_file_system().write_from_string(
+            &additional_streets.len().to_string(),
+            &file.get_streets_additional_count_path(),
+        )?;
 
         Ok(additional_streets)
     }
@@ -1027,12 +1028,9 @@ impl Relation {
         }
 
         // Write the bottom line to a file, so the index page show it fast.
-        let write = self
-            .file
-            .get_housenumbers_percent_write_stream(&self.ctx)
-            .context("get_housenumbers_percent_write_stream() failed")?;
-        let mut guard = write.borrow_mut();
-        guard.write_all(percent.as_bytes())?;
+        self.ctx
+            .get_file_system()
+            .write_from_string(&percent, &self.file.get_housenumbers_percent_path())?;
 
         Ok((
             ongoing_streets.len(),
@@ -1095,9 +1093,10 @@ impl Relation {
 
         // Write the street count to a file, so the index page show it fast.
         let file = &self.file;
-        let write = file.get_housenumbers_additional_count_write_stream(&self.ctx)?;
-        let mut guard = write.borrow_mut();
-        guard.write_all(todo_count.to_string().as_bytes())?;
+        self.ctx.get_file_system().write_from_string(
+            &todo_count.to_string(),
+            &file.get_housenumbers_additional_count_path(),
+        )?;
 
         Ok((ongoing_streets.len(), todo_count, table))
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -186,11 +186,8 @@ pub fn get_missing_housenumbers_html(
     );
 
     let files = relation.get_files();
-    let stream = files
-        .get_housenumbers_htmlcache_write_stream(ctx)
-        .context("get_housenumbers_htmlcache_write_stream() failed")?;
-    let mut guard = stream.borrow_mut();
-    guard.write_all(doc.get_value().as_bytes())?;
+    ctx.get_file_system()
+        .write_from_string(&doc.get_value(), &files.get_housenumbers_htmlcache_path())?;
 
     Ok(doc)
 }
@@ -239,9 +236,10 @@ pub fn get_additional_housenumbers_html(
     );
 
     let files = relation.get_files();
-    let stream = files.get_additional_housenumbers_htmlcache_write_stream(ctx)?;
-    let mut guard = stream.borrow_mut();
-    guard.write_all(doc.get_value().as_bytes())?;
+    ctx.get_file_system().write_from_string(
+        &doc.get_value(),
+        &files.get_additional_housenumbers_htmlcache_path(),
+    )?;
 
     Ok(doc)
 }
@@ -307,9 +305,8 @@ pub fn get_missing_housenumbers_txt(
     output = table.join("\n");
 
     let files = relation.get_files();
-    let stream = files.get_housenumbers_txtcache_write_stream(ctx)?;
-    let mut guard = stream.borrow_mut();
-    guard.write_all(output.as_bytes())?;
+    ctx.get_file_system()
+        .write_from_string(&output, &files.get_housenumbers_txtcache_path())?;
     Ok(output)
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -45,6 +45,13 @@ pub trait FileSystem {
         guard.read_to_end(&mut bytes).unwrap();
         Ok(String::from_utf8(bytes)?)
     }
+
+    /// Write the entire string to a file.
+    fn write_from_string(&self, string: &str, path: &str) -> anyhow::Result<()> {
+        let stream = self.open_write(path)?;
+        let mut guard = stream.borrow_mut();
+        Ok(guard.write_all(string.as_bytes())?)
+    }
 }
 
 /// File system implementation, backed by the Rust stdlib.


### PR DESCRIPTION
Merges the various copy&pasted get_foo_write_stream() functions into a
single one.

Change-Id: Ie871bd06cac08c182eaec92aa588fa6a7339f298
