### PR TITLE
Return a float percent in write_missing_housenumbers()

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1007,7 +1007,7 @@ impl Relation {
     /// Returns a tuple of: todo street count, todo count, done count, percent and table.
     pub fn write_missing_housenumbers(
         &mut self,
-    ) -> anyhow::Result<(usize, usize, usize, String, yattag::HtmlTable)> {
+    ) -> anyhow::Result<(usize, usize, usize, f64, yattag::HtmlTable)> {
         let (ongoing_streets, done_streets) = self
             .get_missing_housenumbers()
             .context("get_missing_housenumbers() failed")?;
@@ -1019,18 +1019,19 @@ impl Relation {
             let number_ranges = util::get_housenumber_ranges(&result.1);
             done_count += number_ranges.len();
         }
-        let percent: String;
+        let percent: f64;
         if done_count > 0 || todo_count > 0 {
             let float: f64 = done_count as f64 / (done_count as f64 + todo_count as f64) * 100_f64;
-            percent = format!("{0:.2}", float);
+            percent = float;
         } else {
-            percent = "100.00".into();
+            percent = 100_f64;
         }
 
         // Write the bottom line to a file, so the index page show it fast.
-        self.ctx
-            .get_file_system()
-            .write_from_string(&percent, &self.file.get_housenumbers_percent_path())?;
+        self.ctx.get_file_system().write_from_string(
+            &format!("{0:.2}", percent),
+            &self.file.get_housenumbers_percent_path(),
+        )?;
 
         Ok((
             ongoing_streets.len(),

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -1695,7 +1695,7 @@ fn test_relation_write_missing_housenumbers() {
     assert_eq!(todo_street_count, 3);
     assert_eq!(todo_count, 5);
     assert_eq!(done_count, 6);
-    assert_eq!(percent, "54.55");
+    assert_eq!(format!("{0:.2}", percent), "54.55");
     let string_table = table_doc_to_string(&table);
     assert_eq!(
         string_table,
@@ -1731,7 +1731,7 @@ fn test_relation_write_missing_housenumbers_empty() {
     let ret = relation.write_missing_housenumbers().unwrap();
 
     let (_todo_street_count, _todo_count, _done_count, percent, _table) = ret;
-    assert_eq!(percent, "100.00");
+    assert_eq!(percent, 100.0);
     assert_eq!(relation.config.get_filters().is_none(), true);
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -114,13 +114,12 @@ pub fn get_missing_housenumbers_html(
                 .replace("{0}", &todo_count.to_string())
                 .replace("{1}", &todo_street_count.to_string()),
         );
+        let percent =
+            util::format_percent(&format!("{0:.2}", percent)).context("format_percent() failed")?;
         p.text(
             &tr(" (existing: {0}, ready: {1}).")
                 .replace("{0}", &done_count.to_string())
-                .replace(
-                    "{1}",
-                    &util::format_percent(&percent).context("format_percent() failed")?,
-                ),
+                .replace("{1}", &percent),
         );
         doc.stag("br");
         {

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -621,19 +621,19 @@ fn handle_stats_cityprogress(
         yattag::Doc::from_text(&tr("Reference count")),
     ]];
     for city in cities {
-        let mut percent: String = "100.00".into();
+        let mut percent = 100_f64;
         if *ref_citycounts.get(city).unwrap() > 0
             && osm_citycounts.get(city).unwrap() < ref_citycounts.get(city).unwrap()
         {
             let osm_count = osm_citycounts[city] as f64;
             let ref_count = ref_citycounts[city] as f64;
-            percent = format!("{0:.2}", osm_count / ref_count * 100_f64);
+            percent = osm_count / ref_count * 100_f64;
         }
+        let percent = util::format_percent(&format!("{0:.2}", percent))
+            .context("util::format_percent() failed:")?;
         table.push(vec![
             yattag::Doc::from_text(city),
-            yattag::Doc::from_text(
-                &util::format_percent(&percent).context("util::format_percent() failed:")?,
-            ),
+            yattag::Doc::from_text(&percent),
             yattag::Doc::from_text(&osm_citycounts.get(city).unwrap().to_string()),
             yattag::Doc::from_text(&ref_citycounts.get(city).unwrap().to_string()),
         ]);
@@ -723,19 +723,19 @@ fn handle_stats_zipprogress(
         yattag::Doc::from_text(&tr("Reference count")),
     ]];
     for zip in zips {
-        let mut percent: String = "100.00".into();
+        let mut percent = 100_f64;
         if *ref_zipcounts.get(zip).unwrap() > 0
             && osm_zipcounts.get(zip).unwrap() < ref_zipcounts.get(zip).unwrap()
         {
             let osm_count = osm_zipcounts[zip] as f64;
             let ref_count = ref_zipcounts[zip] as f64;
-            percent = format!("{0:.2}", osm_count / ref_count * 100_f64);
+            percent = osm_count / ref_count * 100_f64;
         }
+        let percent = util::format_percent(&format!("{0:.2}", percent))
+            .context("util::format_percent() failed:")?;
         table.push(vec![
             yattag::Doc::from_text(zip),
-            yattag::Doc::from_text(
-                &util::format_percent(&percent).context("util::format_percent() failed:")?,
-            ),
+            yattag::Doc::from_text(&percent),
             yattag::Doc::from_text(&osm_zipcounts.get(zip).unwrap().to_string()),
             yattag::Doc::from_text(&ref_zipcounts.get(zip).unwrap().to_string()),
         ]);


### PR DESCRIPTION
Towards taking a float in util::format_percent().

Change-Id: Ibcf0df672346ccf71da5ae03da6ef44ad4508dce
