### PR TITLE
Return a float percent in write_missing_streets()

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -899,23 +899,24 @@ impl Relation {
     }
 
     /// Calculate and write stat for the street coverage of a relation.
-    pub fn write_missing_streets(&self) -> anyhow::Result<(usize, usize, String, Vec<String>)> {
+    pub fn write_missing_streets(&self) -> anyhow::Result<(usize, usize, f64, Vec<String>)> {
         let (todo_streets, done_streets) = self.get_missing_streets()?;
         let streets = todo_streets.clone();
         let todo_count = todo_streets.len();
         let done_count = done_streets.len();
-        let percent: String;
+        let percent: f64;
         if done_count > 0 || todo_count > 0 {
             let float: f64 = done_count as f64 / (done_count as f64 + todo_count as f64) * 100_f64;
-            percent = format!("{0:.2}", float);
+            percent = float;
         } else {
-            percent = "100.00".into();
+            percent = 100_f64;
         }
 
         // Write the bottom line to a file, so the index page show it fast.
+        let string = format!("{0:.2}", percent);
         self.ctx
             .get_file_system()
-            .write_from_string(&percent, &self.file.get_streets_percent_path())?;
+            .write_from_string(&string, &self.file.get_streets_percent_path())?;
 
         Ok((todo_count, done_count, percent, streets))
     }

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -1846,7 +1846,7 @@ fn test_write_missing_streets() {
 
     assert_eq!(todo_count, 1);
     assert_eq!(done_count, 4);
-    assert_eq!(percent, "80.00");
+    assert_eq!(format!("{0:.2}", percent), "80.00");
     assert_eq!(streets, ["Only In Ref utca"]);
     let mut guard = percent_value.borrow_mut();
     guard.seek(SeekFrom::Start(0)).unwrap();
@@ -1875,7 +1875,7 @@ fn test_write_missing_streets_empty() {
     let mut guard = percent_value.borrow_mut();
     assert_eq!(guard.seek(SeekFrom::Current(0)).unwrap() > 0, true);
     let (_todo_count, _done_count, percent, _streets) = ret;
-    assert_eq!(percent, "100.00");
+    assert_eq!(format!("{0:.2}", percent), "100.00");
 }
 
 /// Tests Relation::build_ref_housenumbers().

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -279,6 +279,7 @@ fn missing_streets_view_result(
             &tr("OpenStreetMap is possibly missing the below {0} streets.")
                 .replace("{0}", &todo_count.to_string()),
         );
+        let percent = format!("{0:.2}", percent);
         p.text(
             &tr(" (existing: {0}, ready: {1}).")
                 .replace("{0}", &done_count.to_string())


### PR DESCRIPTION
Towards taking a float in util::format_percent().

Change-Id: I28adfe68add44e97eba1ff68cc0b00a641653736
