### PR TITLE
util::format_percent: take a f64

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,5 +1,9 @@
 = Version descriptions
 
+== master
+
+- Ported to chartjs v3, the javascript bundle size is now about 20% smaller
+
 == 7.3
 
 - Ported to Rust, the missing-housenumbers analysis is now about 5 times faster

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -114,8 +114,7 @@ pub fn get_missing_housenumbers_html(
                 .replace("{0}", &todo_count.to_string())
                 .replace("{1}", &todo_street_count.to_string()),
         );
-        let percent =
-            util::format_percent(&format!("{0:.2}", percent)).context("format_percent() failed")?;
+        let percent = util::format_percent(percent).context("format_percent() failed")?;
         p.text(
             &tr(" (existing: {0}, ready: {1}).")
                 .replace("{0}", &done_count.to_string())

--- a/src/util.rs
+++ b/src/util.rs
@@ -1165,10 +1165,7 @@ pub fn get_valid_settlements(ctx: &context::Context) -> anyhow::Result<HashSet<S
 }
 
 /// Formats a percentage, taking locale into account.
-pub fn format_percent(english: &str) -> anyhow::Result<String> {
-    let parsed: f64 = english
-        .parse()
-        .context(format!("failed to parse '{}'", english))?;
+pub fn format_percent(parsed: f64) -> anyhow::Result<String> {
     let formatted = format!("{0:.2}%", parsed);
     let language: &str = &i18n::get_language();
     let decimal_point = match language {

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -629,8 +629,7 @@ fn handle_stats_cityprogress(
             let ref_count = ref_citycounts[city] as f64;
             percent = osm_count / ref_count * 100_f64;
         }
-        let percent = util::format_percent(&format!("{0:.2}", percent))
-            .context("util::format_percent() failed:")?;
+        let percent = util::format_percent(percent).context("util::format_percent() failed:")?;
         table.push(vec![
             yattag::Doc::from_text(city),
             yattag::Doc::from_text(&percent),
@@ -731,8 +730,7 @@ fn handle_stats_zipprogress(
             let ref_count = ref_zipcounts[zip] as f64;
             percent = osm_count / ref_count * 100_f64;
         }
-        let percent = util::format_percent(&format!("{0:.2}", percent))
-            .context("util::format_percent() failed:")?;
+        let percent = util::format_percent(percent).context("util::format_percent() failed:")?;
         table.push(vec![
             yattag::Doc::from_text(zip),
             yattag::Doc::from_text(&percent),

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -279,11 +279,10 @@ fn missing_streets_view_result(
             &tr("OpenStreetMap is possibly missing the below {0} streets.")
                 .replace("{0}", &todo_count.to_string()),
         );
-        let percent = format!("{0:.2}", percent);
         p.text(
             &tr(" (existing: {0}, ready: {1}).")
                 .replace("{0}", &done_count.to_string())
-                .replace("{1}", &util::format_percent(&percent)?),
+                .replace("{1}", &util::format_percent(percent)?),
         );
         p.stag("br", &[]);
         {
@@ -785,8 +784,8 @@ fn handle_main_housenr_percent(
                 ("title", &format!("{} {}", tr("updated"), date)),
             ],
         );
-        let percent_string = util::format_percent(&format!("{0:.2}", percent))
-            .context("util::format_percent() failed")?;
+        let percent_string =
+            util::format_percent(percent).context("util::format_percent() failed")?;
         a.text(&percent_string);
         return Ok((doc, percent));
     }
@@ -830,8 +829,8 @@ fn handle_main_street_percent(
                 ("title", &format!("{} {}", tr("updated"), date)),
             ],
         );
-        let percent_string = util::format_percent(&format!("{0:.2}", percent))
-            .context("util::format_percent() failed")?;
+        let percent_string =
+            util::format_percent(percent).context("util::format_percent() failed")?;
         a.text(&percent_string);
         return Ok((doc, percent));
     }


### PR DESCRIPTION
All callers have a f64, so this avoids a f64 -> string -> f64 -> string
conversion, just keeping the final f64 -> string one.

Change-Id: Idb910d482233178f6aa6b3925884e97cec935053
