### PR TITLE
areas: test get_invalid_filter_keys()

### DIFF
--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -2700,3 +2700,37 @@ fn test_relation_config_set_active() {
     config.set_active(false);
     assert_eq!(config.is_active(), false);
 }
+
+/// Tests get_invalid_filter_keys().
+#[test]
+fn test_get_invalid_filter_keys() {
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let yamls_cache = serde_json::json!({
+        "relations.yaml": {
+            "gazdagret": {
+                "osmrelation": 42,
+            },
+        },
+        "relation-gazdagret.yaml": {
+            "filters": {
+                "mystreet": {
+                    "interpolation": "all",
+                }
+            },
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[("data/yamls.cache", &yamls_cache_value)],
+    );
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    ctx.set_file_system(&file_system);
+    let mut relations = Relations::new(&ctx).unwrap();
+    let relation = relations.get_relation("gazdagret").unwrap();
+
+    let ret = relation.get_invalid_filter_keys().unwrap();
+
+    let expected: Vec<String> = vec!["mystreet".to_string()];
+    assert_eq!(ret, expected);
+}


### PR DESCRIPTION
This was only tested implicitly via tests/data/yamls.cache previously.

Change-Id: I5f450b229b86a2d4ab70732b0c0c45ca8bd00564
