### PR TITLE
cache: add more tests for get_missing_housenumbers_txt()

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -169,15 +169,6 @@ impl RelationFiles {
         ctx.get_file_system().open_read(&path)
     }
 
-    /// Opens the house number plain text cache file of a relation for reading.
-    pub fn get_housenumbers_txtcache_read_stream(
-        &self,
-        ctx: &context::Context,
-    ) -> anyhow::Result<Rc<RefCell<dyn Read>>> {
-        let path = self.get_housenumbers_txtcache_path();
-        ctx.get_file_system().open_read(&path)
-    }
-
     /// Opens the housenumbers additional count file of a relation for reading.
     pub fn get_housenumbers_additional_count_read_stream(
         &self,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -267,11 +267,9 @@ pub fn get_missing_housenumbers_txt(
     let output: String;
     if is_missing_housenumbers_txt_cached(ctx, relation)? {
         let files = relation.get_files();
-        let stream = files.get_housenumbers_txtcache_read_stream(ctx)?;
-        let mut guard = stream.borrow_mut();
-        let mut buffer = Vec::new();
-        guard.read_to_end(&mut buffer)?;
-        output = String::from_utf8(buffer)?;
+        output = ctx
+            .get_file_system()
+            .read_to_string(&files.get_housenumbers_txtcache_path())?;
         return Ok(output);
     }
 


### PR DESCRIPTION
The interpolation=all case was not tested explicitly.

Change-Id: I34a35d18001952622f7a9c3a1184697360faa64e
