### PR TITLE
cargo: update dependencies (2022-02)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 accept-language = "2.0.0"
-anyhow = "1.0.53"
+anyhow = "1.0.55"
 chrono = "0.4.19"
-clap = "3.1.0"
+clap = "3.1.2"
 configparser = "3.0.0"
 csv = "1.1.6"
 gettext = "0.4.0"
@@ -22,7 +22,7 @@ rouille = "3.5.0"
 rust_icu_ucol = { version = "2.0.0", optional = true }
 rust_icu_ustring = { version = "2.0.0", optional = true }
 serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1.0.78"
+serde_json = "1.0.79"
 serde_yaml = "0.8.23"
 simplelog = "0.11.2"
 unidecode = "0.3.0"


### PR DESCRIPTION
- anyhow to 1.0.55
- clap to 3.1.2
- serde_json to 1.0.79

Change-Id: I16935447a33d73ae4b19018bbdde4cb7fb79d523
