### PR TITLE
typescript: update dependencies (2022-02)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
   "license": "MIT",
   "dependencies": {
-    "@types/node": "17.0.13",
-    "@typescript-eslint/eslint-plugin": "5.10.1",
-    "@typescript-eslint/parser": "5.10.1",
-    "chart.js": "3.7.0",
+    "@types/node": "17.0.21",
+    "@typescript-eslint/eslint-plugin": "5.12.1",
+    "@typescript-eslint/parser": "5.12.1",
+    "chart.js": "3.7.1",
     "chartjs-plugin-datalabels": "2.0.0",
-    "chartjs-plugin-trendline": "1.0.0",
-    "clean-css-cli": "5.5.1",
-    "eslint": "8.7.0",
+    "chartjs-plugin-trendline": "1.0.2",
+    "clean-css-cli": "5.5.2",
+    "eslint": "8.9.0",
     "sorttable": "1.0.2",
     "ts-loader": "9.2.6",
     "typescript": "4.5.5",
-    "webpack": "5.65.0",
-    "webpack-cli": "4.9.1"
+    "webpack": "5.69.1",
+    "webpack-cli": "4.9.2"
   },
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
Finally no need to exclude incompatible chartjs bits

Change-Id: Iccd6e91454f4d865e6e4389e9d64da9aa3dbda35
