### PR TITLE
cron: improve test_update_ref_housenumbers_xml_as_csv()

### DIFF
--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -1234,6 +1234,8 @@ fn test_update_ref_housenumbers_xml_as_csv() {
     let mut file_system = context::tests::TestFileSystem::new();
     let osm_streets_value = context::tests::TestFileSystem::make_file();
     let ref_housenumbers_value = context::tests::TestFileSystem::make_file();
+    let ref_housenumbers_cache = context::tests::TestFileSystem::make_file();
+    let ref_housenumbers2_cache = context::tests::TestFileSystem::make_file();
     osm_streets_value
         .borrow_mut()
         .write_all(b"@id\n42\n")
@@ -1251,6 +1253,14 @@ fn test_update_ref_housenumbers_xml_as_csv() {
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
         &[
+            (
+                "refdir/hazszamok_20190511.tsv-01-v1.cache",
+                &ref_housenumbers_cache,
+            ),
+            (
+                "refdir/hazszamok_kieg_20190808.tsv-01-v1.cache",
+                &ref_housenumbers2_cache,
+            ),
             ("data/yamls.cache", &yamls_cache_value),
             ("workdir/streets-gazdagret.csv", &osm_streets_value),
             (


### PR DESCRIPTION
Towards not creating files while running the tests.

Change-Id: I4f6eb356f56386aa12e31656051ed489d1f8a7b9
