### PR TITLE
cron: improve test_update_osm_housenumbers()

### DIFF
--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -436,9 +436,16 @@ fn test_update_osm_housenumbers() {
         },
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let osm_housenumbers_value = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
-        &[("data/yamls.cache", &yamls_cache_value)],
+        &[
+            ("data/yamls.cache", &yamls_cache_value),
+            (
+                "workdir/street-housenumbers-gazdagret.csv",
+                &osm_housenumbers_value,
+            ),
+        ],
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);


### PR DESCRIPTION
Towards not creating files while running the tests.

Change-Id: I4744faf9a4d7be66d15e3490ea3ceae23e76d7df
