### PR TITLE
cron: use context::FileSystem in update_missing_streets()

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -222,12 +222,18 @@ fn update_missing_housenumbers(
 }
 
 /// Update the relation's street coverage stats.
-fn update_missing_streets(relations: &mut areas::Relations, update: bool) -> anyhow::Result<()> {
+fn update_missing_streets(
+    ctx: &context::Context,
+    relations: &mut areas::Relations,
+    update: bool,
+) -> anyhow::Result<()> {
     log::info!("update_missing_streets: start");
     for relation_name in relations.get_active_names()? {
         let relation = relations.get_relation(&relation_name)?;
         if !update
-            && std::path::Path::new(&relation.get_files().get_streets_percent_path()).exists()
+            && ctx
+                .get_file_system()
+                .path_exists(&relation.get_files().get_streets_percent_path())
         {
             continue;
         }
@@ -509,7 +515,7 @@ fn our_main(
         update_osm_housenumbers(ctx, relations, update)?;
         update_ref_streets(ctx, relations, update)?;
         update_ref_housenumbers(ctx, relations, update)?;
-        update_missing_streets(relations, update)?;
+        update_missing_streets(ctx, relations, update)?;
         update_missing_housenumbers(ctx, relations, update)?;
         update_additional_streets(relations, update)?;
     }

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -345,14 +345,14 @@ fn test_update_missing_streets() {
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let expected: String = "50.00".into();
 
-    update_missing_streets(&mut relations, /*update=*/ true).unwrap();
+    update_missing_streets(&ctx, &mut relations, /*update=*/ true).unwrap();
 
-    let expected_mtime = file_system_arc.getmtime(&path1).unwrap();
+    let expected_mtime = ctx.get_file_system().getmtime(&path1).unwrap();
     assert_eq!(expected_mtime > 0_f64, true);
 
-    update_missing_streets(&mut relations, /*update=*/ false).unwrap();
+    update_missing_streets(&ctx, &mut relations, /*update=*/ false).unwrap();
 
-    let actual_mtime = file_system_arc.getmtime(&path1).unwrap();
+    let actual_mtime = ctx.get_file_system().getmtime(&path1).unwrap();
     assert_eq!(actual_mtime, expected_mtime);
     let actual = context::tests::TestFileSystem::get_content(&count_file1);
     assert_eq!(actual, expected);


### PR DESCRIPTION
That std::path::Path::new() doesn't look right, this way the test passes
or not based on if the integer-rounded modification time manages to be
inside the same second vs not.

One such failing case was https://github.com/vmiklos/osm-gimmisn/actions/runs/1986438662/attempts/1

Change-Id: I8b215a2d603c2947863f95a358ad17b285e134e7
