### PR TITLE
parse_access_log: avoid std::path::Path

### DIFF
--- a/src/parse_access_log.rs
+++ b/src/parse_access_log.rs
@@ -27,7 +27,10 @@ fn is_complete_relation(
     relation_name: &str,
 ) -> anyhow::Result<bool> {
     let relation = relations.get_relation(relation_name)?;
-    if !std::path::Path::new(&relation.get_files().get_housenumbers_percent_path()).exists() {
+    if !ctx
+        .get_file_system()
+        .path_exists(&relation.get_files().get_housenumbers_percent_path())
+    {
         return Ok(false);
     }
 


### PR DESCRIPTION
See commit 49cd62a0d4ee54fa7386586d0e130086dd4e47da (cron: use
context::FileSystem in update_missing_streets(), 2022-03-15) for
motivation.

Change-Id: Ie600b6c31eecc13b07b7e3ae3f7efce57cc9e17b
