### PR TITLE
wsgi: avoid std::path::Path

### DIFF
--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1369,8 +1369,9 @@ fn our_application_txt(
     let mut headers: webframe::Headers = Vec::new();
     let prefix = ctx.get_ini().get_uri_prefix()?;
     let mut chkl = false;
-    if let Some(value) = std::path::Path::new(request_uri).extension() {
-        chkl = value == "chkl";
+    let tokens: Vec<_> = request_uri.split('.').collect();
+    if tokens.len() >= 2 {
+        chkl = tokens.last().cloned().unwrap() == "chkl";
     }
     let data: Vec<u8>;
     if request_uri.starts_with(&format!("{}/missing-streets/", prefix)) {
@@ -1459,8 +1460,9 @@ fn our_application(
     let request_uri = webframe::get_request_uri(request, ctx, &mut relations)
         .context("get_request_uri() failed")?;
     let mut ext: String = "".into();
-    if let Some(value) = std::path::Path::new(&request_uri).extension() {
-        ext = value.to_str().unwrap().into();
+    let tokens: Vec<_> = request_uri.split('.').collect();
+    if tokens.len() >= 2 {
+        ext = tokens.last().cloned().unwrap().to_string();
     }
 
     if ext == "txt" || ext == "chkl" {


### PR DESCRIPTION
See commit 49cd62a0d4ee54fa7386586d0e130086dd4e47da (cron: use
context::FileSystem in update_missing_streets(), 2022-03-15) for
motivation.

This particular usage is not that problematic, but it's very easy to
call problematic functions on the created Path object, so don't risk it.

Change-Id: I59c88118cb4cee830cc238cec6b407c640a6d473
