### PR TITLE
validator: reduce the amount of untested code in main()

### DIFF
--- a/src/bin/validator.rs
+++ b/src/bin/validator.rs
@@ -10,11 +10,12 @@
 
 //! Provides the 'validator' cmdline tool.
 
-fn main() -> anyhow::Result<()> {
+fn main() {
     let args: Vec<String> = std::env::args().collect();
     let ctx = osm_gimmisn::context::Context::new("").unwrap();
-    match osm_gimmisn::validator::main(&args, &mut std::io::stdout(), &ctx) {
-        Ok(exit_code) => std::process::exit(exit_code),
-        Err(err) => Err(err),
-    }
+    std::process::exit(osm_gimmisn::validator::main(
+        &args,
+        &mut std::io::stdout(),
+        &ctx,
+    ))
 }

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -26,7 +26,7 @@ fn test_relations() {
         let argv = ["".to_string(), path.to_string()];
         let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
         let ctx = context::tests::make_test_context().unwrap();
-        let ret = main(&argv, &mut buf, &ctx).unwrap();
+        let ret = main(&argv, &mut buf, &ctx);
         assert_eq!(ret, 0);
     }
 }
@@ -41,10 +41,10 @@ fn test_relations_missing_osmrelation() {
     ];
     let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
     let ctx = context::tests::make_test_context().unwrap();
-    let ret = main(argv, &mut buf, &ctx).unwrap();
+    let ret = main(argv, &mut buf, &ctx);
     assert_eq!(ret, 1);
-    let expected = b"failed to validate tests/data/relations-missing-osmrelation/relations.yaml: missing key 'gazdagret.osmrelation'\n";
-    assert_eq!(buf.into_inner(), expected);
+    let expected = "missing key 'gazdagret.osmrelation'\nfailed to validate tests/data/relations-missing-osmrelation/relations.yaml\n";
+    assert_eq!(String::from_utf8(buf.into_inner()).unwrap(), expected);
 }
 
 /// Tests the missing-refcounty relations path.
@@ -57,9 +57,9 @@ fn test_relations_missing_refcounty() {
     ];
     let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
     let ctx = context::tests::make_test_context().unwrap();
-    let ret = main(argv, &mut buf, &ctx).unwrap();
+    let ret = main(argv, &mut buf, &ctx);
     assert_eq!(ret, 1);
-    let expected = b"failed to validate tests/data/relations-missing-refcounty/relations.yaml: missing key 'gazdagret.refcounty'\n";
+    let expected = b"missing key 'gazdagret.refcounty'\nfailed to validate tests/data/relations-missing-refcounty/relations.yaml\n";
     assert_eq!(buf.into_inner(), expected);
 }
 
@@ -73,9 +73,9 @@ fn test_relations_missing_refsettlement() {
     ];
     let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
     let ctx = context::tests::make_test_context().unwrap();
-    let ret = main(argv, &mut buf, &ctx).unwrap();
+    let ret = main(argv, &mut buf, &ctx);
     assert_eq!(ret, 1);
-    let expected = b"failed to validate tests/data/relations-missing-refsettlement/relations.yaml: missing key 'gazdagret.refsettlement'\n";
+    let expected = b"missing key 'gazdagret.refsettlement'\nfailed to validate tests/data/relations-missing-refsettlement/relations.yaml\n";
     assert_eq!(buf.into_inner(), expected);
 }
 
@@ -86,7 +86,7 @@ fn test_relation() {
     let argv: &[String] = &["".into(), "tests/data/relation-gazdagret.yaml".into()];
     let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
     let ctx = context::tests::make_test_context().unwrap();
-    let ret = main(argv, &mut buf, &ctx).unwrap();
+    let ret = main(argv, &mut buf, &ctx);
     assert_eq!(ret, 0);
     assert_eq!(buf.into_inner(), b"");
 }
@@ -96,7 +96,7 @@ fn assert_failure_msg(path: &str, expected: &str) {
     let argv: &[String] = &["".to_string(), path.to_string()];
     let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
     let ctx = context::tests::make_test_context().unwrap();
-    let ret = main(argv, &mut buf, &ctx).unwrap();
+    let ret = main(argv, &mut buf, &ctx);
     assert_eq!(ret, 1);
     assert_eq!(String::from_utf8(buf.into_inner()).unwrap(), expected);
 }
@@ -104,28 +104,36 @@ fn assert_failure_msg(path: &str, expected: &str) {
 /// Tests the relation path: bad source type.
 #[test]
 fn test_relation_source_bad_type() {
-    let expected = "failed to validate tests/data/relation-gazdagret-source-int.yaml: expected value type for 'source' is <class 'str'>\n";
+    let expected = "expected value type for 'source' is <class 'str'>\nfailed to validate tests/data/relation-gazdagret-source-int.yaml\n";
     assert_failure_msg("tests/data/relation-gazdagret-source-int.yaml", expected);
 }
 
 /// Tests the relation path: bad filters type.
 #[test]
 fn test_relation_filters_bad_type() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filters-bad.yaml: filters.Budaörsi út.ranges: invalid type: integer `42`, expected a sequence at line 3 column 13\n";
+    let expected = r#"failed to validate tests/data/relation-gazdagret-filters-bad.yaml
+
+Caused by:
+    filters.Budaörsi út.ranges: invalid type: integer `42`, expected a sequence at line 3 column 13
+"#;
     assert_failure_msg("tests/data/relation-gazdagret-filters-bad.yaml", expected);
 }
 
 /// Tests the relation path: bad toplevel key name.
 #[test]
 fn test_relation_bad_key_name() {
-    let expected = "failed to validate tests/data/relation-gazdagret-bad-key.yaml: unknown field `invalid`, expected one of `additional-housenumbers`, `alias`, `filters`, `housenumber-letters`, `inactive`, `missing-streets`, `osm-street-filters`, `osmrelation`, `refcounty`, `refsettlement`, `refstreets`, `street-filters`, `source` at line 1 column 1\n";
+    let expected = r#"failed to validate tests/data/relation-gazdagret-bad-key.yaml
+
+Caused by:
+    unknown field `invalid`, expected one of `additional-housenumbers`, `alias`, `filters`, `housenumber-letters`, `inactive`, `missing-streets`, `osm-street-filters`, `osmrelation`, `refcounty`, `refsettlement`, `refstreets`, `street-filters`, `source` at line 1 column 1
+"#;
     assert_failure_msg("tests/data/relation-gazdagret-bad-key.yaml", expected);
 }
 
 /// Tests the relation path: bad strfilters value type.
 #[test]
 fn test_relation_strfilters_bad_type() {
-    let expected = "failed to validate tests/data/relation-gazdagret-street-filters-bad.yaml: expected value type for 'street-filters[0]' is str\n";
+    let expected = "expected value type for 'street-filters[0]' is str\nfailed to validate tests/data/relation-gazdagret-street-filters-bad.yaml\n";
     assert_failure_msg(
         "tests/data/relation-gazdagret-street-filters-bad.yaml",
         expected,
@@ -135,7 +143,7 @@ fn test_relation_strfilters_bad_type() {
 /// Tests the relation path: bad refstreets value type.
 #[test]
 fn test_relation_refstreets_bad_value_type() {
-    let expected = "failed to validate tests/data/relation-gazdagret-refstreets-bad-value.yaml: expected value type for 'refstreets.OSM Name 1' is str\n";
+    let expected = "expected value type for 'refstreets.OSM Name 1' is str\nfailed to validate tests/data/relation-gazdagret-refstreets-bad-value.yaml\n";
     assert_failure_msg(
         "tests/data/relation-gazdagret-refstreets-bad-value.yaml",
         expected,
@@ -145,8 +153,9 @@ fn test_relation_refstreets_bad_value_type() {
 /// Tests the relation path: quote in refstreets key or value.
 #[test]
 fn test_relation_refstreets_quote() {
-    let expected = r#"failed to validate tests/data/relation-gazdagret-refstreets-quote.yaml: expected no quotes in 'refstreets.OSM Name 1''
-failed to validate tests/data/relation-gazdagret-refstreets-quote.yaml: expected no quotes in value of 'refstreets.OSM Name 1''
+    let expected = r#"expected no quotes in 'refstreets.OSM Name 1''
+expected no quotes in value of 'refstreets.OSM Name 1''
+failed to validate tests/data/relation-gazdagret-refstreets-quote.yaml
 "#;
     assert_failure_msg(
         "tests/data/relation-gazdagret-refstreets-quote.yaml",
@@ -157,14 +166,18 @@ failed to validate tests/data/relation-gazdagret-refstreets-quote.yaml: expected
 /// Tests the relation path: bad filterssubkey name.
 #[test]
 fn test_relation_filters_bad_subkey() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-bad.yaml: filters.Budaörsi út: unknown field `unexpected`, expected one of `interpolation`, `invalid`, `ranges`, `valid`, `refsettlement`, `show-refstreet` at line 3 column 5\n";
+    let expected = r#"failed to validate tests/data/relation-gazdagret-filter-bad.yaml
+
+Caused by:
+    filters.Budaörsi út: unknown field `unexpected`, expected one of `interpolation`, `invalid`, `ranges`, `valid`, `refsettlement`, `show-refstreet` at line 3 column 5
+"#;
     assert_failure_msg("tests/data/relation-gazdagret-filter-bad.yaml", expected);
 }
 
 /// Tests the relation path: bad filters -> ... -> invalid subkey.
 #[test]
 fn test_relation_filters_invalid_bad2() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-invalid-bad2.yaml: expected format for 'filters.Budaörsi út.invalid[0]' is '42', '42a' or '42/1'\n";
+    let expected = "expected format for 'filters.Budaörsi út.invalid[0]' is '42', '42a' or '42/1'\nfailed to validate tests/data/relation-gazdagret-filter-invalid-bad2.yaml\n";
     assert_failure_msg(
         "tests/data/relation-gazdagret-filter-invalid-bad2.yaml",
         expected,
@@ -174,7 +187,11 @@ fn test_relation_filters_invalid_bad2() {
 /// Tests the relation path: bad type for the filters -> ... -> invalid subkey.
 #[test]
 fn test_relation_filters_invalid_bad_type() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-invalid-bad-type.yaml: filters.Budaörsi út.invalid: invalid type: string \"hello\", expected a sequence at line 3 column 14\n";
+    let expected = r#"failed to validate tests/data/relation-gazdagret-filter-invalid-bad-type.yaml
+
+Caused by:
+    filters.Budaörsi út.invalid: invalid type: string "hello", expected a sequence at line 3 column 14
+"#;
     assert_failure_msg(
         "tests/data/relation-gazdagret-filter-invalid-bad-type.yaml",
         expected,
@@ -184,7 +201,11 @@ fn test_relation_filters_invalid_bad_type() {
 /// Tests the relation path: bad filters -> ... -> ranges subkey.
 #[test]
 fn test_relation_filters_ranges_bad() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-range-bad.yaml: filters.Budaörsi út.ranges[0]: unknown field `unexpected`, expected one of `end`, `refsettlement`, `start` at line 4 column 36\n";
+    let expected = r#"failed to validate tests/data/relation-gazdagret-filter-range-bad.yaml
+
+Caused by:
+    filters.Budaörsi út.ranges[0]: unknown field `unexpected`, expected one of `end`, `refsettlement`, `start` at line 4 column 36
+"#;
     assert_failure_msg(
         "tests/data/relation-gazdagret-filter-range-bad.yaml",
         expected,
@@ -194,8 +215,10 @@ fn test_relation_filters_ranges_bad() {
 /// Tests the relation path: bad filters -> ... -> ranges -> end type.
 #[test]
 fn test_relation_filters_ranges_bad_end() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-range-bad-end.yaml: expected end >= start for 'filters.Budaörsi út.ranges[0]'\n\
-failed to validate tests/data/relation-gazdagret-filter-range-bad-end.yaml: expected start % 2 == end % 2 for 'filters.Budaörsi út.ranges[0]'\n";
+    let expected = r#"expected end >= start for 'filters.Budaörsi út.ranges[0]'
+expected start % 2 == end % 2 for 'filters.Budaörsi út.ranges[0]'
+failed to validate tests/data/relation-gazdagret-filter-range-bad-end.yaml
+"#;
     assert_failure_msg(
         "tests/data/relation-gazdagret-filter-range-bad-end.yaml",
         expected,
@@ -205,7 +228,7 @@ failed to validate tests/data/relation-gazdagret-filter-range-bad-end.yaml: expe
 /// Tests the relation path: bad filters -> ... -> ranges -> if start/end is swapped type.
 #[test]
 fn test_relation_filters_ranges_start_end_swap() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-range-start-end-swap.yaml: expected end >= start for 'filters.Budaörsi út.ranges[0]'\n";
+    let expected = "expected end >= start for 'filters.Budaörsi út.ranges[0]'\nfailed to validate tests/data/relation-gazdagret-filter-range-start-end-swap.yaml\n";
     assert_failure_msg(
         "tests/data/relation-gazdagret-filter-range-start-end-swap.yaml",
         expected,
@@ -216,7 +239,7 @@ fn test_relation_filters_ranges_start_end_swap() {
 /// even/odd or not.
 #[test]
 fn test_relation_filters_ranges_start_end_even_odd() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-range-start-end-even-odd.yaml: expected start % 2 == end % 2 for 'filters.Budaörsi út.ranges[0]'\n";
+    let expected = "expected start % 2 == end % 2 for 'filters.Budaörsi út.ranges[0]'\nfailed to validate tests/data/relation-gazdagret-filter-range-start-end-even-odd.yaml\n";
     assert_failure_msg(
         "tests/data/relation-gazdagret-filter-range-start-end-even-odd.yaml",
         expected,
@@ -226,7 +249,7 @@ fn test_relation_filters_ranges_start_end_even_odd() {
 /// Tests the relation path: bad filters -> ... -> ranges -> start type.
 #[test]
 fn test_relation_filters_ranges_bad_start() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-range-bad-start.yaml: expected start % 2 == end % 2 for 'filters.Budaörsi út.ranges[0]'\n";
+    let expected = "expected start % 2 == end % 2 for 'filters.Budaörsi út.ranges[0]'\nfailed to validate tests/data/relation-gazdagret-filter-range-bad-start.yaml\n";
     assert_failure_msg(
         "tests/data/relation-gazdagret-filter-range-bad-start.yaml",
         expected,
@@ -236,7 +259,11 @@ fn test_relation_filters_ranges_bad_start() {
 /// Tests the relation path: missing filters -> ... -> ranges -> start key.
 #[test]
 fn test_relation_filters_ranges_missing_start() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-range-missing-start.yaml: filters.Budaörsi út.ranges[0]: missing field `start` at line 4 column 9\n";
+    let expected = r#"failed to validate tests/data/relation-gazdagret-filter-range-missing-start.yaml
+
+Caused by:
+    filters.Budaörsi út.ranges[0]: missing field `start` at line 4 column 9
+"#;
     assert_failure_msg(
         "tests/data/relation-gazdagret-filter-range-missing-start.yaml",
         expected,
@@ -246,7 +273,11 @@ fn test_relation_filters_ranges_missing_start() {
 /// Tests the relation path: missing filters -> ... -> ranges -> end key.
 #[test]
 fn test_relation_filters_ranges_missing_end() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-range-missing-end.yaml: filters.Budaörsi út.ranges[0]: missing field `end` at line 4 column 9\n";
+    let expected = r#"failed to validate tests/data/relation-gazdagret-filter-range-missing-end.yaml
+
+Caused by:
+    filters.Budaörsi út.ranges[0]: missing field `end` at line 4 column 9
+"#;
     assert_failure_msg(
         "tests/data/relation-gazdagret-filter-range-missing-end.yaml",
         expected,
@@ -256,7 +287,11 @@ fn test_relation_filters_ranges_missing_end() {
 /// Tests the housenumber-letters key: bad type.
 #[test]
 fn test_relation_housenumber_letters_bad() {
-    let expected = "failed to validate tests/data/relation-gazdagret-housenumber-letters-bad.yaml: housenumber-letters: invalid type: integer `42`, expected a boolean at line 1 column 22\n";
+    let expected = r#"failed to validate tests/data/relation-gazdagret-housenumber-letters-bad.yaml
+
+Caused by:
+    housenumber-letters: invalid type: integer `42`, expected a boolean at line 1 column 22
+"#;
     assert_failure_msg(
         "tests/data/relation-gazdagret-housenumber-letters-bad.yaml",
         expected,
@@ -266,21 +301,25 @@ fn test_relation_housenumber_letters_bad() {
 /// Tests the relation path: bad alias subkey.
 #[test]
 fn test_relation_alias_bad() {
-    let expected = "failed to validate tests/data/relation-budafok-alias-bad.yaml: expected value type for 'alias[0]' is str\n";
+    let expected = "expected value type for 'alias[0]' is str\nfailed to validate tests/data/relation-budafok-alias-bad.yaml\n";
     assert_failure_msg("tests/data/relation-budafok-alias-bad.yaml", expected);
 }
 
 /// Tests the relation path: bad type for the alias subkey.
 #[test]
 fn test_relation_filters_alias_bad_type() {
-    let expected = "failed to validate tests/data/relation-budafok-alias-bad-type.yaml: alias: invalid type: string \"hello\", expected a sequence at line 1 column 8\n";
+    let expected = "failed to validate tests/data/relation-budafok-alias-bad-type.yaml\n\nCaused by:\n    alias: invalid type: string \"hello\", expected a sequence at line 1 column 8\n";
     assert_failure_msg("tests/data/relation-budafok-alias-bad-type.yaml", expected);
 }
 
 /// Tests the relation path: bad filters -> show-refstreet value type.
 #[test]
 fn test_relation_filters_show_refstreet_bad() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-show-refstreet-bad.yaml: filters.Hamzsabégi út.show-refstreet: invalid type: integer `42`, expected a boolean at line 3 column 21\n";
+    let expected = r#"failed to validate tests/data/relation-gazdagret-filter-show-refstreet-bad.yaml
+
+Caused by:
+    filters.Hamzsabégi út.show-refstreet: invalid type: integer `42`, expected a boolean at line 3 column 21
+"#;
     assert_failure_msg(
         "tests/data/relation-gazdagret-filter-show-refstreet-bad.yaml",
         expected,
@@ -290,7 +329,7 @@ fn test_relation_filters_show_refstreet_bad() {
 /// Tests the relation path: bad refstreets map, not 1:1.
 #[test]
 fn test_relation_refstreets_bad_map_type() {
-    let expected = "failed to validate tests/data/relation-gazdagret-refstreets-bad-map.yaml: osm and ref streets are not a 1:1 mapping in 'refstreets.'\n";
+    let expected = "osm and ref streets are not a 1:1 mapping in 'refstreets.'\nfailed to validate tests/data/relation-gazdagret-refstreets-bad-map.yaml\n";
     assert_failure_msg(
         "tests/data/relation-gazdagret-refstreets-bad-map.yaml",
         expected,
@@ -300,7 +339,7 @@ fn test_relation_refstreets_bad_map_type() {
 /// Tests the relation path: bad filters -> ... -> valid subkey.
 #[test]
 fn test_relation_filters_valid_bad2() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-valid-bad2.yaml: expected format for 'filters.Budaörsi út.valid[0]' is '42', '42a' or '42/1'\n";
+    let expected = "expected format for 'filters.Budaörsi út.valid[0]' is '42', '42a' or '42/1'\nfailed to validate tests/data/relation-gazdagret-filter-valid-bad2.yaml\n";
     assert_failure_msg(
         "tests/data/relation-gazdagret-filter-valid-bad2.yaml",
         expected,
@@ -310,7 +349,11 @@ fn test_relation_filters_valid_bad2() {
 /// Tests the relation path: bad type for the filters -> ... -> valid subkey.
 #[test]
 fn test_relation_filters_valid_bad_type() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-valid-bad-type.yaml: filters.Budaörsi út.valid: invalid type: string \"hello\", expected a sequence at line 3 column 12\n";
+    let expected = r#"failed to validate tests/data/relation-gazdagret-filter-valid-bad-type.yaml
+
+Caused by:
+    filters.Budaörsi út.valid: invalid type: string "hello", expected a sequence at line 3 column 12
+"#;
     assert_failure_msg(
         "tests/data/relation-gazdagret-filter-valid-bad-type.yaml",
         expected,
@@ -320,7 +363,7 @@ fn test_relation_filters_valid_bad_type() {
 /// Tests that we do not accept whitespace in the value of the 'start' key.
 #[test]
 fn test_start_whitespace() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-range-bad-start2.yaml: expected value type for 'filters.Budaörsi út.ranges[0].start' is a digit str\n";
+    let expected = "expected value type for 'filters.Budaörsi út.ranges[0].start' is a digit str\nfailed to validate tests/data/relation-gazdagret-filter-range-bad-start2.yaml\n";
     assert_failure_msg(
         "tests/data/relation-gazdagret-filter-range-bad-start2.yaml",
         expected,
@@ -330,7 +373,7 @@ fn test_start_whitespace() {
 /// Tests that we do not accept whitespace in the value of the 'end' key.
 #[test]
 fn test_end_whitespace() {
-    let expected = "failed to validate tests/data/relation-gazdagret-filter-range-bad-end2.yaml: expected value type for 'filters.Budaörsi út.ranges[0].end' is a digit str\n";
+    let expected = "expected value type for 'filters.Budaörsi út.ranges[0].end' is a digit str\nfailed to validate tests/data/relation-gazdagret-filter-range-bad-end2.yaml\n";
     assert_failure_msg(
         "tests/data/relation-gazdagret-filter-range-bad-end2.yaml",
         expected,


### PR DESCRIPTION
Move most of the error handling into validator::main() and turn the
schema errors into a backtrace-like error message.

Change-Id: If2a55a6babf4f32ecffed0a173ade66bd45d5272
