### PR TITLE
util: avoid std::path::Path

### DIFF
--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -148,12 +148,15 @@ fn test_build_street_reference_cache_cached() {
 #[test]
 fn test_build_reference_cache() {
     let refpath = "tests/refdir/hazszamok_20190511.tsv";
-    let cachepath = format!("{}-01-v1.cache", refpath);
-    if std::path::Path::new(&cachepath).exists() {
-        std::fs::remove_file(&cachepath).unwrap();
-    }
-    let ctx = context::tests::make_test_context().unwrap();
+    let cache_path = format!("{}-01-v1.cache", refpath);
+    let cache = context::tests::TestFileSystem::make_file();
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let files = context::tests::TestFileSystem::make_files(&ctx, &[(&cache_path, &cache)]);
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    ctx.set_file_system(&file_system);
+
     let memory_cache = build_reference_cache(&ctx, refpath, "01").unwrap();
+
     let mut streets: HashMap<String, Vec<HouseNumberWithComment>> = HashMap::new();
     streets.insert(
         "Ref Name 1".to_string(),


### PR DESCRIPTION
See commit 49cd62a0d4ee54fa7386586d0e130086dd4e47da (cron: use
context::FileSystem in update_missing_streets(), 2022-03-15) for
motivation.

Change-Id: Ic2a8840b114ff20a49901b378cd6c5c14c6a6b9d
