### PR TITLE
cache: improve test_get_additional_housenumbers_html()

### DIFF
--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -163,7 +163,32 @@ fn test_is_missing_housenumbers_html_cached_relation_new() {
 /// Tests get_additional_housenumbers_html(): the case when we find the result in cache
 #[test]
 fn test_get_additional_housenumbers_html() {
-    let ctx = context::tests::make_test_context().unwrap();
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let relation_count = context::tests::TestFileSystem::make_file();
+    let relation_htmlcache = context::tests::TestFileSystem::make_file();
+    let mut file_system = context::tests::TestFileSystem::new();
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[
+            (
+                "workdir/gazdagret-additional-housenumbers.count",
+                &relation_count,
+            ),
+            (
+                "workdir/gazdagret.additional-htmlcache.en",
+                &relation_htmlcache,
+            ),
+        ],
+    );
+    let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
+    mtimes.insert(
+        ctx.get_abspath("workdir/gazdagret.additional-htmlcache.en"),
+        Rc::new(RefCell::new(0_f64)),
+    );
+    file_system.set_files(&files);
+    file_system.set_mtimes(&mtimes);
+    let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
+    ctx.set_file_system(&file_system_arc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let mut relation = relations.get_relation("gazdagret").unwrap();
     let first = get_additional_housenumbers_html(&ctx, &mut relation).unwrap();


### PR DESCRIPTION
Towards not creating files while running the tests.

Change-Id: I8d1fd805cda999ea585000381b46759d9a3e1fa0
