### PR TITLE
context: no need to inherit any trait in Unit

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -189,7 +189,7 @@ impl Subprocess for StdSubprocess {
 }
 
 /// Unit testing interface.
-pub trait Unit: Send + Sync {
+pub trait Unit {
     /// Injects a fake error.
     fn make_error(&self) -> String;
 }


### PR DESCRIPTION
This is a leftover from Python where this had to be thread-safe.

Change-Id: Ic1fd88edf30f635ce2386895227b5e13a5b51d0f
