### PR TITLE
cron: improve test_main_error()

### DIFF
--- a/src/cache_yamls.rs
+++ b/src/cache_yamls.rs
@@ -71,6 +71,7 @@ pub fn main(argv: &[String], ctx: &context::Context) -> anyhow::Result<()> {
         serde_json::to_writer(write, &relation_ids)?;
     }
 
+    // TODO return i32 here
     Ok(())
 }
 

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -19,7 +19,13 @@ use std::ops::DerefMut;
 
 /// Creates a Context instance for text purposes.
 pub fn make_test_context() -> anyhow::Result<Context> {
-    Ok(Context::new("tests")?)
+    let mut ctx = Context::new("tests")?;
+
+    let file_system = TestFileSystem::new();
+    let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
+    ctx.set_file_system(&file_system_arc);
+
+    Ok(ctx)
 }
 
 /// File system implementation, for test purposes.

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -622,6 +622,7 @@ pub fn main(
         seconds
     );
 
+    // TODO return i32 here
     Ok(())
 }
 

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -1138,6 +1138,22 @@ fn test_main_error() {
     let unit = context::tests::TestUnit::new();
     let unit_arc: Arc<dyn context::Unit> = Arc::new(unit);
     ctx.set_unit(&unit_arc);
+    let ref_count = context::tests::TestFileSystem::make_file();
+    let stats_json = context::tests::TestFileSystem::make_file();
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[
+            ("workdir/stats/ref.count", &ref_count),
+            ("workdir/stats/stats.json", &stats_json),
+        ],
+    );
+    let mut file_system = context::tests::TestFileSystem::new();
+    file_system.set_files(&files);
+    file_system
+        .write_from_string("300", &ctx.get_abspath("workdir/stats/ref.count"))
+        .unwrap();
+    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+    ctx.set_file_system(&file_system_arc);
     let argv = vec![
         "".to_string(),
         "--mode".to_string(),
@@ -1148,6 +1164,8 @@ fn test_main_error() {
 
     // main() catches the error returned by our_main().
     main(&argv, &mut buf, &mut ctx).unwrap();
+
+    // TODO assert the contents of buf here
 }
 
 /// Tests update_stats_count().

--- a/src/missing_housenumbers.rs
+++ b/src/missing_housenumbers.rs
@@ -35,6 +35,7 @@ pub fn main(argv: &[String], stream: &mut dyn Write, ctx: &context::Context) -> 
         stream.write_all(format!("{:?}\n", range_strings).as_bytes())?;
     }
 
+    // TODO return i32 here
     Ok(())
 }
 

--- a/src/parse_access_log.rs
+++ b/src/parse_access_log.rs
@@ -244,6 +244,7 @@ pub fn main(argv: &[String], stdout: &mut dyn Write, ctx: &context::Context) -> 
         .as_bytes(),
     )?;
 
+    // TODO return i32 here
     Ok(())
 }
 


### PR DESCRIPTION
Now all tests go via TestFileSystem::open_write(), so at least such
writes now fail the test.

Towards not creating files while running the tests.

Change-Id: I62693a68e674ab8bf01608899656dc05b6a6aa20
