### PR TITLE
Remove no longer needed utime dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ url = "2.2.2"
 flate2 = "1.0.22"
 sxd-document = "0.3.2"
 sxd-xpath = "0.4.2"
-utime = "0.3.1"
 
 [features]
 icu = ["rust_icu_ucol", "rust_icu_ustring"]


### PR DESCRIPTION
It was only needed till tests were wrting the filesystem.

Change-Id: I7beaf553d9b4d50ca39014e1b38a589c3053c6d3
