### PR TITLE
cache_yamls: reduce the amount of untested code in main()

### DIFF
--- a/src/bin/cache_yamls.rs
+++ b/src/bin/cache_yamls.rs
@@ -10,10 +10,12 @@
 
 //! Provides the 'cache_yamls' cmdline tool.
 
-fn main() -> anyhow::Result<()> {
+fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let ctx = osm_gimmisn::context::Context::new("")?;
-    osm_gimmisn::cache_yamls::main(&args, &ctx)?;
-
-    Ok(())
+    let ctx = osm_gimmisn::context::Context::new("").unwrap();
+    std::process::exit(osm_gimmisn::cache_yamls::main(
+        &args,
+        &mut std::io::stdout(),
+        &ctx,
+    ))
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -219,15 +219,15 @@ impl Subprocess for StdSubprocess {
 /// Unit testing interface.
 pub trait Unit {
     /// Injects a fake error.
-    fn make_error(&self) -> String;
+    fn make_error(&self) -> anyhow::Result<()>;
 }
 
 /// Unit implementation, which intentionally does nothing.
 struct StdUnit {}
 
 impl Unit for StdUnit {
-    fn make_error(&self) -> String {
-        String::from("")
+    fn make_error(&self) -> anyhow::Result<()> {
+        Ok(())
     }
 }
 

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -314,8 +314,8 @@ impl TestUnit {
 }
 
 impl Unit for TestUnit {
-    fn make_error(&self) -> String {
-        return "TestError".into();
+    fn make_error(&self) -> anyhow::Result<()> {
+        Err(anyhow::anyhow!("TestError"))
     }
 }
 

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -546,12 +546,8 @@ fn our_main(
             break;
         }
     }
-    let err = ctx.get_unit().make_error();
-    if !err.is_empty() {
-        return Err(anyhow::anyhow!(err));
-    }
 
-    Ok(())
+    ctx.get_unit().make_error()
 }
 
 /// Commandline interface to this module.

--- a/src/webframe/tests.rs
+++ b/src/webframe/tests.rs
@@ -170,7 +170,7 @@ fn test_handle_error() {
     let unit = context::tests::TestUnit::new();
     let err = unit.make_error();
 
-    let response = handle_error(&request, &err);
+    let response = handle_error(&request, &format!("{:?}", err));
     let mut data = Vec::new();
     let (mut reader, _size) = response.data.into_reader_and_size();
     reader.read_to_end(&mut data).unwrap();

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -21,7 +21,6 @@ use crate::webframe;
 use crate::wsgi_additional;
 use crate::wsgi_json;
 use crate::yattag;
-use anyhow::anyhow;
 use anyhow::Context;
 use lazy_static::lazy_static;
 use std::collections::HashMap;
@@ -1521,10 +1520,7 @@ fn our_application(
         }
     }
 
-    let err = ctx.get_unit().make_error();
-    if !err.is_empty() {
-        return Err(anyhow!(err));
-    }
+    ctx.get_unit().make_error()?;
     Ok(webframe::make_response(
         200_u16,
         vec![("Content-type".into(), "text/html; charset=utf-8".into())],


### PR DESCRIPTION
This is similar to commit 9887114c9bc5e21eec69754e9adfdf754c3ccf38
(validator: reduce the amount of untested code in main(), 2022-03-19).

Also impove make_error() to return a Result, which needs less code.

Change-Id: I360d4dccf8f11495a13a7c26c525e27b676ddb04
