### PR TITLE
data: budapest_12: remove no longer needed Tearózsa utca street mapping

### DIFF
--- a/data/relation-budapest_12.yaml
+++ b/data/relation-budapest_12.yaml
@@ -482,7 +482,5 @@ refstreets:
   'Hunyad-orom lépcső': 'Hunyadorom lépcső'  # utcajegyzék: Hunyad Orom lépcső
   # hibás írásmód
   'Szent Család park': 'Szent család park'
-  # Felmérendő melyik a helyes
-  'Tearózsa út': 'Tearózsa utca'  # utcajegyzék Tearózsa utca
 source: survey
 inactive: false


### PR DESCRIPTION
This is no longer needed since
<https://www.openstreetmap.org/changeset/119346980> (3 days ago).

Change-Id: I2ade6d76c605f99272543477689a6d62f1568f38
