### PR TITLE
webframe: add a stop message matching a start one

### DIFF
--- a/src/bin/rouille.rs
+++ b/src/bin/rouille.rs
@@ -30,7 +30,6 @@ fn main() -> anyhow::Result<()> {
     let ctx = osm_gimmisn::context::Context::new("")?;
     let port = ctx.get_ini().get_tcp_port()?;
     let prefix = ctx.get_ini().get_uri_prefix()?;
-    // TODO no matching stop message.
     println!(
         "Starting the server at <http://127.0.0.1:{}{}/>.",
         port, prefix

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -1196,6 +1196,7 @@ pub fn handle_github_webhook(
             "deploy".into(),
         ])?;
         // Nominally a failure, so the service gets restarted.
+        println!("Stopping the server after deploy.");
         ctx.get_subprocess().exit(1);
     }
 


### PR DESCRIPTION
To make it easier to see when we exit to restart vs real failure.

Change-Id: I182e3b46431568af746bdad02e76b66879e2add0
