### PR TITLE
missing_housenumbers: reduce the amount of untested code in main()

### DIFF
--- a/src/bin/missing_housenumbers.rs
+++ b/src/bin/missing_housenumbers.rs
@@ -10,10 +10,12 @@
 
 //! Provides the 'missing_housenumbers' cmdline tool.
 
-fn main() -> anyhow::Result<()> {
+fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let ctx = osm_gimmisn::context::Context::new("")?;
-    osm_gimmisn::missing_housenumbers::main(&args, &mut std::io::stdout(), &ctx)?;
-
-    Ok(())
+    let ctx = osm_gimmisn::context::Context::new("").unwrap();
+    std::process::exit(osm_gimmisn::missing_housenumbers::main(
+        &args,
+        &mut std::io::stdout(),
+        &ctx,
+    ))
 }

--- a/src/missing_housenumbers.rs
+++ b/src/missing_housenumbers.rs
@@ -15,8 +15,12 @@ use crate::context;
 use crate::util;
 use std::io::Write;
 
-/// Commandline interface.
-pub fn main(argv: &[String], stream: &mut dyn Write, ctx: &context::Context) -> anyhow::Result<()> {
+/// Inner main() that is allowed to fail.
+pub fn our_main(
+    argv: &[String],
+    stream: &mut dyn Write,
+    ctx: &context::Context,
+) -> anyhow::Result<()> {
     let relation_name = argv[1].clone();
 
     let mut relations = areas::Relations::new(ctx)?;
@@ -35,8 +39,18 @@ pub fn main(argv: &[String], stream: &mut dyn Write, ctx: &context::Context) -> 
         stream.write_all(format!("{:?}\n", range_strings).as_bytes())?;
     }
 
-    // TODO return i32 here
-    Ok(())
+    ctx.get_unit().make_error()
+}
+
+/// Similar to plain main(), but with an interface that allows testing.
+pub fn main(argv: &[String], stream: &mut dyn Write, ctx: &context::Context) -> i32 {
+    match our_main(argv, stream, ctx) {
+        Ok(_) => 0,
+        Err(err) => {
+            stream.write_all(format!("{:?}\n", err).as_bytes()).unwrap();
+            1
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/missing_housenumbers/tests.rs
+++ b/src/missing_housenumbers/tests.rs
@@ -14,6 +14,7 @@ use super::*;
 use std::io::Read;
 use std::io::Seek;
 use std::io::SeekFrom;
+use std::sync::Arc;
 
 /// Tests main().
 #[test]
@@ -22,8 +23,9 @@ fn test_main() {
     let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
     let mut ctx = context::tests::make_test_context().unwrap();
 
-    main(&argv, &mut buf, &mut ctx).unwrap();
+    let ret = main(&argv, &mut buf, &mut ctx);
 
+    assert_eq!(ret, 0);
     buf.seek(SeekFrom::Start(0)).unwrap();
     let mut actual: Vec<u8> = Vec::new();
     buf.read_to_end(&mut actual).unwrap();
@@ -31,4 +33,19 @@ fn test_main() {
         actual,
         b"Kalotaszeg utca\t3\n[\"25\", \"27-37\", \"31*\"]\n"
     );
+}
+
+/// Tests main(), the failing case.
+#[test]
+fn test_main_error() {
+    let argv = vec!["".to_string(), "gh195".to_string()];
+    let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let unit = context::tests::TestUnit::new();
+    let unit_arc: Arc<dyn context::Unit> = Arc::new(unit);
+    ctx.set_unit(&unit_arc);
+
+    let ret = main(&argv, &mut buf, &mut ctx);
+
+    assert_eq!(ret, 1);
 }


### PR DESCRIPTION
This is similar to commit 9887114c9bc5e21eec69754e9adfdf754c3ccf38
(validator: reduce the amount of untested code in main(), 2022-03-19).

Change-Id: Iead65fadb631e5494375d9b756bbbf0d1afa51ab
