### PR TITLE
parse_access_log: reduce the amount of untested code in main()

### DIFF
--- a/src/bin/parse_access_log.rs
+++ b/src/bin/parse_access_log.rs
@@ -10,10 +10,12 @@
 
 //! Provides the 'parse_access_log' cmdline tool.
 
-fn main() -> anyhow::Result<()> {
+fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let ctx = osm_gimmisn::context::Context::new("")?;
-    osm_gimmisn::parse_access_log::main(&args, &mut std::io::stdout(), &ctx)?;
-
-    Ok(())
+    let ctx = osm_gimmisn::context::Context::new("").unwrap();
+    std::process::exit(osm_gimmisn::parse_access_log::main(
+        &args,
+        &mut std::io::stdout(),
+        &ctx,
+    ))
 }

--- a/src/parse_access_log/tests.rs
+++ b/src/parse_access_log/tests.rs
@@ -155,8 +155,10 @@ author-time 1588975200\n\
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
-    main(&argv, &mut buf, &ctx).unwrap();
 
+    let ret = main(&argv, &mut buf, &ctx);
+
+    assert_eq!(ret, 0);
     buf.seek(SeekFrom::Start(0)).unwrap();
     let mut actual: Vec<u8> = Vec::new();
     buf.read_to_end(&mut actual).unwrap();
@@ -187,4 +189,16 @@ author-time 1588975200\n\
     // Also, if this would be not ignored, it would push 'inactiverelation' out of the active
     // relation list.
     assert_eq!(actual.contains("gyomaendrod"), false);
+}
+
+/// Tests main(), the failing case: missing required parameter.
+#[test]
+fn test_main_error() {
+    let argv = vec!["".to_string()];
+    let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
+    let mut ctx = context::tests::make_test_context().unwrap();
+
+    let ret = main(&argv, &mut buf, &mut ctx);
+
+    assert_eq!(ret, 1);
 }


### PR DESCRIPTION
This is similar to commit 9887114c9bc5e21eec69754e9adfdf754c3ccf38
(validator: reduce the amount of untested code in main(), 2022-03-19).

Change-Id: I27dbe0de34b8535bb54d2f1125fb889438440c4c
