### PR TITLE
areas: test that get_street_refsettlement() picks the correct filter

### DIFF
--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -898,6 +898,10 @@ fn test_relation_get_ref_street_from_osm_street_refsettlement_override() {
                     // this would be 011 by default, but here it's overwritten at a street
                     // level
                     "refsettlement": "012",
+                },
+                "mystreet2": {
+                    // make sure the above 012 is picked up, not this one
+                    "refsettlement": "013",
                 }
             },
         },


### PR DESCRIPTION
Previously there was just a single filter, so just picking the last
filter was also accepted.

Change-Id: I4e38b7cfba02d99c0439d33779f098a79644143c
