### PR TITLE
validator: improve error message in validate_refstreets()

### DIFF
--- a/src/validator.rs
+++ b/src/validator.rs
@@ -184,10 +184,9 @@ fn validate_refstreets(
     reverse.sort_unstable();
     reverse.dedup();
     if refstreets.keys().len() != reverse.len() {
-        // TODO use parent here, not context
         errors.push(format!(
             "osm and ref streets are not a 1:1 mapping in '{}'",
-            context
+            parent
         ));
     }
 

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -329,7 +329,7 @@ Caused by:
 /// Tests the relation path: bad refstreets map, not 1:1.
 #[test]
 fn test_relation_refstreets_bad_map_type() {
-    let expected = "osm and ref streets are not a 1:1 mapping in 'refstreets.'\nfailed to validate tests/data/relation-gazdagret-refstreets-bad-map.yaml\n";
+    let expected = "osm and ref streets are not a 1:1 mapping in 'refstreets'\nfailed to validate tests/data/relation-gazdagret-refstreets-bad-map.yaml\n";
     assert_failure_msg(
         "tests/data/relation-gazdagret-refstreets-bad-map.yaml",
         expected,


### PR DESCRIPTION
The name of the key is e.g. "refstreets", not "refstreets.".

Change-Id: Ief7fe96141cc0ec8ae7f560c436d6b75507eff2a
