### PR TITLE
validator: fix this odd value type

### DIFF
--- a/src/validator.rs
+++ b/src/validator.rs
@@ -247,11 +247,10 @@ fn validate_relation(
             street_filters,
         )?;
     }
-    // TODO fix these odd value types.
     if let Some(ref source) = relation.source {
         if source.parse::<i64>().is_ok() {
             errors.push(format!(
-                "expected value type for '{}source' is <class 'str'>",
+                "expected value type for '{}source' is str",
                 context
             ));
         }

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -104,7 +104,7 @@ fn assert_failure_msg(path: &str, expected: &str) {
 /// Tests the relation path: bad source type.
 #[test]
 fn test_relation_source_bad_type() {
-    let expected = "expected value type for 'source' is <class 'str'>\nfailed to validate tests/data/relation-gazdagret-source-int.yaml\n";
+    let expected = "expected value type for 'source' is str\nfailed to validate tests/data/relation-gazdagret-source-int.yaml\n";
     assert_failure_msg("tests/data/relation-gazdagret-source-int.yaml", expected);
 }
 


### PR DESCRIPTION
<class 'str'> is a leftover from Python.

Change-Id: If4392d661c96a6fe7510e696f6035e0bcd19346e
