### PR TITLE
context: give up on configurable path for workdir

### DIFF
--- a/data/wsgi.ini.template
+++ b/data/wsgi.ini.template
@@ -1,5 +1,4 @@
 [wsgi]
-workdir = workdir
 reference_housenumbers = refdir/hazszamok_20220410.tsv refdir/hazszamok_kieg_20220410.tsv
 reference_street = refdir/utcak_20220410.tsv
 reference_citycounts = refdir/varosok_count_20220410.tsv

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -359,7 +359,7 @@ impl Relation {
         yaml_cache: &HashMap<String, serde_json::Value>,
     ) -> anyhow::Result<Self> {
         let mut my_config = RelationDict::default();
-        let file = area_files::RelationFiles::new(&ctx.get_ini().get_workdir()?, name);
+        let file = area_files::RelationFiles::new(&ctx.get_ini().get_workdir(), name);
         let relation_path = format!("relation-{}.yaml", name);
         // Intentionally don't require this cache to be present, it's fine to omit it for simple
         // relations.

--- a/src/context.rs
+++ b/src/context.rs
@@ -255,12 +255,8 @@ impl Ini {
     }
 
     /// Gets the directory which is writable.
-    pub fn get_workdir(&self) -> anyhow::Result<String> {
-        let workdir = self
-            .config
-            .get("wsgi", "workdir")
-            .context("no wsgi.workdir in config")?;
-        Ok(format!("{}/{}", self.root, workdir))
+    pub fn get_workdir(&self) -> String {
+        format!("{}/workdir", self.root)
     }
 
     /// Gets the abs paths of ref housenumbers.

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -377,8 +377,8 @@ fn test_ini_get_tcp_port() {
 fn test_ini_get_with_fallback() {
     let ctx = make_test_context().unwrap();
     assert_eq!(
-        ctx.get_ini().get_with_fallback("workdir", "myfallback"),
-        "workdir"
+        ctx.get_ini().get_with_fallback("uri_prefix", "myfallback"),
+        "/osm"
     );
     assert_eq!(
         ctx.get_ini().get_with_fallback("mykey", "myfallback"),

--- a/src/parse_access_log.rs
+++ b/src/parse_access_log.rs
@@ -102,7 +102,7 @@ fn get_frequent_relations(
     // Dump relations and their visit count to workdir for further inspection.
     let csv_stream = ctx.get_file_system().open_write(&format!(
         "{}/frequent-relations.csv",
-        ctx.get_ini().get_workdir()?
+        ctx.get_ini().get_workdir()
     ))?;
     let mut guard = csv_stream.borrow_mut();
     for item in count_list.iter() {
@@ -175,7 +175,7 @@ fn check_top_edited_relations(
     ctx: &context::Context,
     frequent_relations: &mut HashSet<String>,
 ) -> anyhow::Result<()> {
-    let workdir = ctx.get_ini().get_workdir()?;
+    let workdir = ctx.get_ini().get_workdir();
     // List of 'city name' <-> '# of new house numbers' pairs.
     let topcities = stats::get_topcities(ctx, &format!("{}/stats", workdir))?;
     let topcities: Vec<_> = topcities

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -477,7 +477,7 @@ pub fn handle_static(
     if request_uri.ends_with(".css") {
         let content_type = "text/css; charset=utf-8";
         let (content, extra_headers) =
-            get_content_with_meta(ctx, &format!("{}/{}", ctx.get_ini().get_workdir()?, path))
+            get_content_with_meta(ctx, &format!("{}/{}", ctx.get_ini().get_workdir(), path))
                 .context("get_content_with_meta() failed")?;
         return Ok((content, content_type.into(), extra_headers));
     }
@@ -485,7 +485,7 @@ pub fn handle_static(
         let content_type = "application/json; charset=utf-8";
         let (content, extra_headers) = get_content_with_meta(
             ctx,
-            &format!("{}/stats/{}", ctx.get_ini().get_workdir()?, path),
+            &format!("{}/stats/{}", ctx.get_ini().get_workdir(), path),
         )?;
         return Ok((content, content_type.into(), extra_headers));
     }
@@ -592,7 +592,7 @@ fn handle_stats_cityprogress(
     let naive = chrono::NaiveDateTime::from_timestamp(timestamp, 0);
     let today = naive.format("%Y-%m-%d").to_string();
     let mut osm_citycounts: HashMap<String, u64> = HashMap::new();
-    let path = format!("{}/stats/{}.citycount", ctx.get_ini().get_workdir()?, today);
+    let path = format!("{}/stats/{}.citycount", ctx.get_ini().get_workdir(), today);
     let csv_stream: Rc<RefCell<dyn Read>> = ctx.get_file_system().open_read(&path)?;
     let mut guard = csv_stream.borrow_mut();
     let mut read = guard.deref_mut();
@@ -693,7 +693,7 @@ fn handle_stats_zipprogress(
     let naive = chrono::NaiveDateTime::from_timestamp(timestamp, 0);
     let today = naive.format("%Y-%m-%d").to_string();
     let mut osm_zipcounts: HashMap<String, u64> = HashMap::new();
-    let path = format!("{}/stats/{}.zipcount", ctx.get_ini().get_workdir()?, today);
+    let path = format!("{}/stats/{}.zipcount", ctx.get_ini().get_workdir(), today);
     let csv_stream: Rc<RefCell<dyn Read>> = ctx.get_file_system().open_read(&path)?;
     let mut guard = csv_stream.borrow_mut();
     let mut read = guard.deref_mut();

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1332,7 +1332,7 @@ fn write_html_head(ctx: &context::Context, doc: &yattag::Tag, title: &str) -> an
         ],
     );
 
-    let css_path = format!("{}/{}", ctx.get_ini().get_workdir()?, "osm.min.css");
+    let css_path = format!("{}/{}", ctx.get_ini().get_workdir(), "osm.min.css");
     if ctx.get_file_system().path_exists(&css_path) {
         let stream = ctx.get_file_system().open_read(&css_path)?;
         let mut buf: Vec<u8> = Vec::new();

--- a/tests/wsgi.ini
+++ b/tests/wsgi.ini
@@ -1,5 +1,4 @@
 [wsgi]
-workdir = workdir
 reference_housenumbers = refdir/hazszamok_20190511.tsv refdir/hazszamok_kieg_20190808.tsv
 reference_street = refdir/utcak_20190514.tsv
 reference_citycounts = refdir/varosok_count_20190717.tsv


### PR DESCRIPTION
workdir is already hardcoded at many places to be workdir/, don't
require a wsgi.ini entry for this when we don't fully handle it anyway.

Change-Id: Ieaefbeb77e51d7d2669292a7842bbe260d3134ad
