### PR TITLE
systemd: set a working directory explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,10 +150,8 @@ check-filters: $(patsubst %.yaml,%.validyaml,$(YAML_SAFE_OBJECTS))
 %.validyaml : %.yaml build
 	$(QUIET_VALIDATOR)target/${TARGET_PATH}/validator $< && touch $@
 
-# Make sure that the current directory is *not* the repo root but something else to catch
-# non-absolute paths.
 run: all
-	cd $(HOME) && $(PWD)/target/${TARGET_PATH}/rouille
+	target/${TARGET_PATH}/rouille
 
 deploy:
 ifeq (,$(wildcard ./deploy.sh))

--- a/osm-gimmisn.service
+++ b/osm-gimmisn.service
@@ -7,6 +7,7 @@ ExecStart=/home/osm-gimmisn/git/osm-gimmisn/target/release/rouille
 Restart=on-failure
 RestartSec=1s
 User=osm-gimmisn
+WorkingDirectory=/home/osm-gimmisn/git/osm-gimmisn
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is meant to allow not hardcoding the path to refdir/workdir at
build-time in the future.

Change-Id: Ie3f6103cefe2372b38423b33f77920002215fb4e
