### PR TITLE
areas: test Relation::get_street_ranges() error handling

### DIFF
--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -834,6 +834,39 @@ fn test_relation_get_street_ranges() {
     assert_eq!(street_blacklist, ["mystreet2".to_string()]);
 }
 
+/// Tests Relation::get_street_ranges() error handling.
+#[test]
+fn test_relation_get_street_ranges_error() {
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let yamls_cache = serde_json::json!({
+        "relation-myrelation.yaml": {
+            "filters": {
+                "mystreet": {
+                    "ranges": [
+                        {
+                            "start": "foo",
+                            "end": "3",
+                        },
+                    ],
+                },
+            },
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[("data/yamls.cache", &yamls_cache_value)],
+    );
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    ctx.set_file_system(&file_system);
+    let mut relations = Relations::new(&ctx).unwrap();
+    let relation = relations.get_relation("myrelation").unwrap();
+
+    let ret = relation.get_street_ranges();
+
+    assert_eq!(ret.is_err(), true);
+}
+
 /// Tests Relation::get_street_ranges(): when the filter file is empty.
 #[test]
 fn test_relation_get_street_ranges_empty() {


### PR DESCRIPTION
cargo llvm-cov points out there is no test for this.

Change-Id: Id7b45cda2295e06c86fb7f39d6b946c444c8267d
