### PR TITLE
cron: restore lost file-based logging

### DIFF
--- a/src/bin/cron.rs
+++ b/src/bin/cron.rs
@@ -11,13 +11,13 @@
 //! Provides the 'cron' cmdline tool.
 
 /// Sets up logging.
-pub fn setup_logging(ctx: &osm_gimmisn::context::Context) -> anyhow::Result<()> {
+fn setup_logging(ctx: &osm_gimmisn::context::Context) {
     let config = simplelog::ConfigBuilder::new()
         .set_time_format("%Y-%m-%d %H:%M:%S".into())
         .set_time_to_local(true)
         .build();
     let logpath = ctx.get_abspath("workdir/cron.log");
-    let file = std::fs::File::create(logpath)?;
+    let file = std::fs::File::create(logpath).expect("failed to create cron.log");
     simplelog::CombinedLogger::init(vec![
         simplelog::TermLogger::new(
             simplelog::LevelFilter::Info,
@@ -26,13 +26,13 @@ pub fn setup_logging(ctx: &osm_gimmisn::context::Context) -> anyhow::Result<()> 
             simplelog::ColorChoice::Never,
         ),
         simplelog::WriteLogger::new(simplelog::LevelFilter::Info, config, file),
-    ])?;
-
-    Ok(())
+    ])
+    .expect("failed to init the combined logger");
 }
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     let ctx = osm_gimmisn::context::Context::new("").unwrap();
+    setup_logging(&ctx);
     std::process::exit(osm_gimmisn::cron::main(&args, &mut std::io::stdout(), &ctx))
 }

--- a/src/bin/rouille.rs
+++ b/src/bin/rouille.rs
@@ -26,6 +26,8 @@ fn app(request: &rouille::Request) -> rouille::Response {
 /// ProxyPreserveHost On
 /// ProxyPass / http://127.0.0.1:8000/
 /// ProxyPassReverse / http://127.0.0.1:8000/
+/// # Default would be 60
+/// ProxyTimeout 120
 fn main() -> anyhow::Result<()> {
     let ctx = osm_gimmisn::context::Context::new("")?;
     let port = ctx.get_ini().get_tcp_port()?;


### PR DESCRIPTION
Also bump the timeout in the proxy to the double of the current value,
so /missing-housenumbers/.../update-result.json doesn't fail with a HTTP
502 error when the overpass query takes more than 60 seconds when
rouille is behind an SSL proxy.

Change-Id: I20f244702700b3aba825d6c47dd2ca1e835703e5
