### PR TITLE
areas: test get_alias(), the fallback case

### DIFF
--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -2879,3 +2879,30 @@ fn test_relation_new_error() {
 
     assert_eq!(ret.is_err(), true);
 }
+
+/// Tests RelationConfig::get_alias(), the case when the parent provides the data.
+#[test]
+fn test_relation_config_get_alias_parent() {
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let yamls_cache = serde_json::json!({
+        "relations.yaml": {
+            "myrelation": {
+                "osmrelation": 42,
+                "alias": ["myoldrelation"],
+            },
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[("data/yamls.cache", &yamls_cache_value)],
+    );
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    ctx.set_file_system(&file_system);
+    let mut relations = Relations::new(&ctx).unwrap();
+    let relation = relations.get_relation("myrelation").unwrap();
+
+    let ret = relation.get_config().get_alias();
+
+    assert_eq!(ret, vec!["myoldrelation".to_string()]);
+}


### PR DESCRIPTION
cargo llvm-cov points out there is no test for this.

Change-Id: Ie5bd17686c9332761a2fe1946d118355518fe97b
