### PR TITLE
areas: no need to look for refstreets: in relations.yaml

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -207,8 +207,8 @@ impl RelationConfig {
 
     /// Returns an OSM name -> ref name map.
     pub fn get_refstreets(&self) -> HashMap<String, String> {
-        match RelationConfig::get_property(&self.parent.refstreets, &self.dict.refstreets) {
-            Some(value) => value,
+        match self.dict.refstreets {
+            Some(ref value) => value.clone(),
             None => HashMap::new(),
         }
     }


### PR DESCRIPTION
Which also avoids an untested line of code in the
RelationConfig::get_property::<std::collections::HashMap>()
instantiation.

Change-Id: Ifc947f2351156e45641f85e031d398e2bcc0ab3c
