### PR TITLE
areas: test get_osm_housenumbers() with not-well-formed CSV

### DIFF
--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -642,6 +642,30 @@ fn test_relation_get_osm_streets_csv_error() {
     assert_eq!(ret.is_empty(), true);
 }
 
+/// Tests Relation::get_osm_housenumbers(): when it fails due to not-well-formed CSV.
+#[test]
+fn test_relation_get_osm_housenumers_csv_error() {
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let streets_value = context::tests::TestFileSystem::make_file();
+    // This is garbage, 1st row has 2 cols, 2nd row has 1 col.
+    streets_value
+        .borrow_mut()
+        .write_all(b"@id\t@name\n42\n")
+        .unwrap();
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[("workdir/street-housenumbers-myrelation.csv", &streets_value)],
+    );
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    ctx.set_file_system(&file_system);
+    let mut relations = Relations::new(&ctx).unwrap();
+    let mut relation = relations.get_relation("myrelation").unwrap();
+
+    let ret = relation.get_osm_housenumbers("").unwrap();
+
+    assert_eq!(ret.is_empty(), true);
+}
+
 /// Tests Relation.get_osm_streets(): the case when the street name is coming from a house
 /// number (node).
 #[test]


### PR DESCRIPTION
cargo llvm-cov points out there is no test for this.

Change-Id: I5de9d601b186273b79f834fada7eb1846e911b67
