### PR TITLE
areas: require that osmrelation is defined in relations.yaml

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -144,7 +144,7 @@ impl RelationConfig {
 
     /// Gets the OSM relation object's ID.
     pub fn get_osmrelation(&self) -> u64 {
-        RelationConfig::get_property(&self.parent.osmrelation, &self.dict.osmrelation).unwrap()
+        self.parent.osmrelation.unwrap()
     }
 
     /// Gets the relation's refcounty identifier from reference.


### PR DESCRIPTION
We already do this and it simplifies the code to not look at
relation-<name>.yaml as well.

Change-Id: Id0fe1cffffe777400005d8e634ec8731fe7c67e0
