### PR TITLE
cron: use a proper CSV parser in update_stats_count()

### DIFF
--- a/tests/network/overpass-stats.csv
+++ b/tests/network/overpass-stats.csv
@@ -1,4 +1,3 @@
-@id	addr:postcode
-addr:city	addr:street	addr:housenumber	@user
+addr:postcode	addr:city	addr:street	addr:housenumber	@user
 7677	Orfű	Dollár utca	1	vasony
 7677	Orfű	Dollár utca	2	vasony


### PR DESCRIPTION
To be able to refer to columns by name, so this doesn't break if
data/street-housenumbers-hungary.txt reorders columns.

Change-Id: I02727203a83db37b4ec14e91f425cad4ff12c276
