### PR TITLE
cron: use a proper CSV parser in update_stats_topusers()

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -402,12 +402,21 @@ fn update_stats_topusers(ctx: &context::Context, today: &str) -> anyhow::Result<
     {
         let stream = ctx.get_file_system().open_read(&csv_path)?;
         let mut guard = stream.borrow_mut();
-        let reader = std::io::BufReader::new(guard.deref_mut());
-        for line in reader.lines() {
-            let line = line?.to_string();
-            let cells: Vec<String> = line.split('\t').map(|i| i.into()).collect();
+        let mut read = std::io::BufReader::new(guard.deref_mut());
+        let mut csv_read = util::CsvRead::new(&mut read);
+        let mut columns: HashMap<String, usize> = HashMap::new();
+        let mut first = true;
+        for result in csv_read.records() {
+            let row = result?;
+            if first {
+                first = false;
+                for (index, label) in row.iter().enumerate() {
+                    columns.insert(label.into(), index);
+                }
+                continue;
+            }
             // Only care about the last column.
-            let user = cells[cells.len() - 1].clone();
+            let user = row[columns["@user"]].to_string();
             let entry = users.entry(user).or_insert(0);
             (*entry) += 1;
         }


### PR DESCRIPTION
To be able to refer to columns by name, so this doesn't break if
data/street-housenumbers-hungary.txt reorders columns.

Additionally we used to count "@user" as a user in the first line, don't
do that.

Change-Id: I9c1108b0b8f978c23f9abe18786bdf24569ec3aa
