### PR TITLE
Update simplelog.rs to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 accept-language = "2.0.0"
 anyhow = "1.0.57"
 chrono = "0.4.19"
-clap = "3.1.12"
+clap = "3.1.13"
 configparser = "3.0.0"
 csv = "1.1.6"
 gettext = "0.4.0"
@@ -23,9 +23,10 @@ rust_icu_ustring = { version = "2.0.3", optional = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 serde_yaml = "0.8.23"
-simplelog = "0.11.2"
+simplelog = "0.12.0"
 unidecode = "0.3.0"
 url = "2.2.2"
+time = { version = "0.3.9", features = ["formatting", "macros"] }
 
 [dev-dependencies]
 flate2 = "1.0.23"

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -53,6 +53,12 @@ https://stackoverflow.blog/2022/01/03/favor-real-dependencies-for-unit-testing/[
 dependencies for unit testing] pattern, i.e. apart from filesystem, network or time (see
 `src/context.rs` for the exact list), no mocking is used.
 
+Debugging `workdir/stats/stats.json` generation:
+
+----
+cargo run --bin cron -- --mode stats --no-overpass
+----
+
 == Rust performance profiling
 
 The symbols profile enables debug symbols while keeping optimizations on:

--- a/src/bin/cron.rs
+++ b/src/bin/cron.rs
@@ -13,8 +13,11 @@
 /// Sets up logging.
 fn setup_logging(ctx: &osm_gimmisn::context::Context) {
     let config = simplelog::ConfigBuilder::new()
-        .set_time_format("%Y-%m-%d %H:%M:%S".into())
-        .set_time_to_local(true)
+        .set_time_format_custom(simplelog::format_description!(
+            "[year]-[month]-[day] [hour]:[minute]:[second]"
+        ))
+        .set_time_offset_to_local()
+        .unwrap()
         .build();
     let logpath = ctx.get_abspath("workdir/cron.log");
     let file = std::fs::File::create(logpath).expect("failed to create cron.log");


### PR DESCRIPTION
Which switched from chrono.rs to time.rs, so the way to specify a custom
time format has changed, adapt the cron command to that.

Change-Id: If41e2aa1787c4ecc95f8cc095e9e087e9be27ef6
