### PR TITLE
areas: String -> &str in limit_to_refcounty()

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1296,9 +1296,9 @@ impl Relations {
     }
 
     /// If refcounty is not None, forget about all relations outside that refcounty.
-    pub fn limit_to_refcounty(&mut self, refcounty: &Option<String>) -> anyhow::Result<()> {
+    pub fn limit_to_refcounty(&mut self, refcounty: &Option<&str>) -> anyhow::Result<()> {
         let refcounty: String = match refcounty {
-            Some(value) => value.clone(),
+            Some(value) => value.to_string(),
             None => {
                 return Ok(());
             }

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -2417,9 +2417,7 @@ fn test_relations() {
             .contains(&"myrelation2".to_string()),
         true
     );
-    relations
-        .limit_to_refcounty(&Some("01".to_string()))
-        .unwrap();
+    relations.limit_to_refcounty(&Some("01")).unwrap();
     assert_eq!(
         relations
             .get_active_names()

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -608,7 +608,7 @@ pub fn our_main(
     let now = chrono::NaiveDateTime::from_timestamp(start, 0);
     let first_day_of_month = now.date().day() == 1;
     relations.activate_all(ctx.get_ini().get_cron_update_inactive() || first_day_of_month);
-    let refcounty = args.value_of("refcounty").map(|value| value.to_string());
+    let refcounty = args.value_of("refcounty");
     relations.limit_to_refcounty(&refcounty)?;
     // Use map(), which handles optional values.
     let refsettlement = args.value_of("refsettlement");


### PR DESCRIPTION
Leftover from Python porting, and this way llvm-cov says cron.rs line
coverage is complete.

Change-Id: I91abe2ee59f85be5783203008c289d1f6939ff5e
