### PR TITLE
stats: avoid std::fs::File::open()

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -136,8 +136,10 @@ fn handle_topusers(
     let mut ret: Vec<(String, String)> = Vec::new();
     let topusers_path = format!("{}/{}.topusers", src_root, today);
     if ctx.get_file_system().path_exists(&topusers_path) {
-        let stream = std::io::BufReader::new(std::fs::File::open(topusers_path)?);
-        for line in stream.lines() {
+        let stream = ctx.get_file_system().open_read(&topusers_path)?;
+        let mut guard = stream.borrow_mut();
+        let read = std::io::BufReader::new(guard.deref_mut());
+        for line in read.lines() {
             let line = line?.trim().to_string();
             let mut tokens = line.split(' ');
             let count = tokens.next().unwrap();


### PR DESCRIPTION
To be able to mock this from tests.

Change-Id: I2f3496899f2397ceb9124719838ea06a92426d89
