### PR TITLE
stats: test broken input for handle_topusers()

### DIFF
--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -141,13 +141,39 @@ fn test_handle_topusers() {
     assert_eq!(topusers[0], serde_json::json!(["user1", "68885"]));
 }
 
-/// Tests handle_topusers(): the case when the .count file doesn't exist for a date.
+/// Tests handle_topusers(): the case when the .topusers file doesn't exist for a date.
 #[test]
 fn test_handle_topusers_old_time() {
     let mut ctx = context::tests::make_test_context().unwrap();
     let time = make_test_time_old();
     let time_arc: Arc<dyn context::Time> = Arc::new(time);
     ctx.set_time(&time_arc);
+    let src_root = ctx.get_abspath("workdir/stats");
+    let mut j = serde_json::json!({});
+    handle_topusers(&ctx, &src_root, &mut j).unwrap();
+    let topusers = &j.as_object().unwrap()["topusers"].as_array().unwrap();
+    assert_eq!(topusers.len(), 0);
+}
+
+/// Tests handle_topusers(): the case when the .topusers file is broken.
+#[test]
+fn test_handle_topusers_broken_input() {
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let time = context::tests::make_test_time();
+    let time_arc: Arc<dyn context::Time> = Arc::new(time);
+    ctx.set_time(&time_arc);
+    let today_topusers = b"myuser\n";
+    let today_topusers_value = context::tests::TestFileSystem::make_file();
+    today_topusers_value
+        .borrow_mut()
+        .write_all(today_topusers)
+        .unwrap();
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[("workdir/stats/2020-05-10.topusers", &today_topusers_value)],
+    );
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    ctx.set_file_system(&file_system);
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
     handle_topusers(&ctx, &src_root, &mut j).unwrap();


### PR DESCRIPTION
The code skips broken rows, but there was no test for this.

Change-Id: I82d749b96661eb4e959826c796c8b66cf7ab3d4f
