### PR TITLE
Don't hardcode the build-time current dir anymore

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -218,7 +218,9 @@ pub struct Context {
 impl Context {
     /// Creates a new Context.
     pub fn new(prefix: &str) -> anyhow::Result<Self> {
-        let root = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), prefix);
+        let current_dir = std::env::current_dir()?;
+        let current_dir_str = current_dir.to_str().context("current_dir() failed")?;
+        let root = format!("{}/{}", current_dir_str, prefix);
         let network = Arc::new(StdNetwork {});
         let time = Arc::new(StdTime {});
         let subprocess = Arc::new(StdSubprocess {});

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -20,10 +20,11 @@ thread_local! {
 /// Sets the language of the current thread.
 pub fn set_language(ctx: &context::Context, language: &str) {
     // Not using ctx.get_abspath() here, tests/ doesn't have its own dummy translations.
-    let root_dir = env!("CARGO_MANIFEST_DIR");
+    let current_dir = std::env::current_dir().expect("current_dir() failed");
+    let current_dir_str = current_dir.to_str().expect("PathBuf::to_str() failed");
     let path = format!(
         "{}/locale/{}/LC_MESSAGES/osm-gimmisn.mo",
-        root_dir, language
+        current_dir_str, language
     );
 
     if ctx.get_file_system().path_exists(&path) {


### PR DESCRIPTION
One more leftover from the Python porting, this was useful in the free
pythonanywhere hosting only.

Change-Id: Ib68916b32587269716ac9bafdbdcc88b46a642f2
