### PR TITLE
stats: assume that .topcities CSV files always have 2 cols

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -181,26 +181,10 @@ pub fn get_topcities(ctx: &context::Context, src_root: &str) -> anyhow::Result<V
     let mut csv_read = util::CsvRead::new(&mut read);
     for result in csv_read.records() {
         let row = result?;
-        let mut tokens = row.iter();
-        let city = match tokens.next() {
-            Some(value) => value,
-            None => {
-                continue;
-            }
-        };
-        if city.is_empty() {
-            continue;
-        }
-        let count = match tokens.next() {
-            Some(value) => value,
-            None => {
-                continue;
-            }
-        };
-        if !count.is_empty() {
-            let count: i64 = count.parse()?;
-            old_counts.insert(city.into(), count);
-        }
+        let city = &row[0];
+        let count = &row[1];
+        let count: i64 = count.parse()?;
+        old_counts.insert(city.into(), count);
     }
 
     let new_count_path = format!("{}/{}.citycount", src_root, new_day);
@@ -213,20 +197,9 @@ pub fn get_topcities(ctx: &context::Context, src_root: &str) -> anyhow::Result<V
     let mut csv_read = util::CsvRead::new(&mut read);
     for result in csv_read.records() {
         let row = result?;
-        let mut tokens = row.iter();
-        let city = match tokens.next() {
-            Some(value) => value,
-            None => {
-                continue;
-            }
-        };
-        let count = match tokens.next() {
-            Some(value) => value,
-            None => {
-                continue;
-            }
-        };
-        if !count.is_empty() && old_counts.contains_key(city) {
+        let city = &row[0];
+        let count = &row[1];
+        if old_counts.contains_key(city) {
             let count: i64 = count.parse()?;
             counts.push((city.into(), count - old_counts[city]));
         }

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -190,8 +190,7 @@ fn test_handle_topcities() {
     ctx.set_time(&time_arc);
     let src_root = ctx.get_abspath("workdir/stats");
     let today_citycount = b"budapest_01\t100\n\
-budapest_02\t200\n\
-\t42\n";
+budapest_02\t200\n";
     let today_citycount_value = context::tests::TestFileSystem::make_file();
     today_citycount_value
         .borrow_mut()


### PR DESCRIPTION
Because get_city_key() will return "_Empty" for "", and the second
column is a count, which can't be empty, just "0" worst case.

Change-Id: Ia986d6c8fa344566c39a827b4a8feafd73766c2d
