### PR TITLE
data: budapest_14 renamed street, fix subarea boundary

### DIFF
--- a/data/relation-budapest_14.yaml
+++ b/data/relation-budapest_14.yaml
@@ -9,6 +9,8 @@ street-filters:
   - Vajdahunyadvár  # https://www.openstreetmap.org/node/4685641019
   # csak a XIII. kerületben van része
   - Róbert Károly körút  
+  # Belőle lett a Variházi Oszkár utca
+  - Újvidék köz
 osm-street-filters:
   # létezik, de nem utcaként
   - Adria park

--- a/data/relation-herminamezo.yaml
+++ b/data/relation-herminamezo.yaml
@@ -3,7 +3,7 @@ filters:
   Ajtósi Dürer sor:
     ranges:
       - {start: '37', end: '99'}
-      - {start: '4', end: '10'}
+      - {start: '2', end: '10'}
   Amerikai út:
     ranges:
       - {start: '27', end: '99'}

--- a/data/relation-istvanmezo.yaml
+++ b/data/relation-istvanmezo.yaml
@@ -3,7 +3,6 @@ filters:
   Ajtósi Dürer sor:
     ranges:
       - {start: '1', end: '35'}
-      - {start: '2', end: '2'}
   Besnyői utca:
     ranges:
       - {start: '1', end: '5'}


### PR DESCRIPTION
- Egy II. világháború előtt átnevezett, már csak táblán látható utcanév
- Ajtósi Dürer sor 2 az már Herminamező.