### PR TITLE
util: remove not needed error handling in split_house_number()

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -388,13 +388,15 @@ impl<'a> CsvRead<'a> {
 /// Splits house_number into a numerical and a remainder part.
 pub fn split_house_number(house_number: &str) -> (i32, String) {
     let mut number = 0;
-    let mut remainder: String = "".into();
-    if let Some(cap) = NUMBER_WITH_REMAINDER.captures_iter(house_number).next() {
-        if let Ok(value) = cap[1].parse::<i32>() {
-            number = value;
-        }
-        remainder = cap[2].to_string();
+    // There will be always a capture, but it may be an empty string.
+    let cap = NUMBER_WITH_REMAINDER
+        .captures_iter(house_number)
+        .next()
+        .unwrap();
+    if let Ok(value) = cap[1].parse::<i32>() {
+        number = value;
     }
+    let remainder = cap[2].to_string();
     (number, remainder)
 }
 

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -294,6 +294,7 @@ fn test_split_house_number_number_alpha() {
 #[test]
 fn test_split_house_number_only_alpha() {
     assert_eq!(split_house_number("a"), (0, "a".to_string()));
+    assert_eq!(split_house_number(""), (0, "".to_string()));
 }
 
 /// Tests parse_filters(): the incomplete case.


### PR DESCRIPTION
This regex always matches, add a test to make sure an empty string input
is handled correctly.

Change-Id: Icc3c8f9490d3a3bf4a5eec6087e306a8529a2171
