### PR TITLE
cron: sync letter suffix style for txt output with the web

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -397,7 +397,9 @@ impl Relation {
 
     /// Sets the config interface.
     pub fn set_config(&mut self, config: &RelationConfig) {
-        self.config = config.clone()
+        self.config = config.clone();
+        // config.letter_suffix_style possibly changed, empty the osm_housenumbers cache.
+        self.osm_housenumbers.clear();
     }
 
     /// Gets a street name -> ranges map, which allows silencing false positives.

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -233,6 +233,12 @@ fn update_missing_housenumbers(
                 .context("get_missing_housenumbers_html() failed")?;
         }
         i18n::set_language(ctx, &orig_language);
+
+        // To be in sync with wsgi::missing_housenumbers_view_txt().
+        let mut config = relation.get_config().clone();
+        config.set_letter_suffix_style(util::LetterSuffixStyle::Lower);
+        relation.set_config(&config);
+
         cache::get_missing_housenumbers_txt(ctx, &mut relation)
             .context("get_missing_housenumbers_txt() failed")?;
     }


### PR DESCRIPTION
If a relation sets housenumber-letters to true, then we normalize the
1/A style housenumers in the .txt output. The web interface already
normalized to 1a, but cron normalized to 1/A.

Fix this inconsistency.

Change-Id: I01ed121fe33c972c952b724ffc56885913f774d4
