### PR TITLE
util: remove not needed error handling in split_house_number_by_separator()

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1060,12 +1060,8 @@ pub fn split_house_number_by_separator(
     for house_number in house_numbers.split(separator) {
         let mut number: i64 = 0;
         if let Some(cap) = NUMBER_WITH_JUNK.captures_iter(house_number).next() {
-            match cap[1].parse::<i64>() {
-                Ok(value) => number = value,
-                Err(_) => {
-                    continue;
-                }
-            }
+            // If parse() fails, then NUMBER_WITH_JUNK is broken.
+            number = cap[1].parse::<i64>().unwrap();
         }
 
         ret_numbers_nofilter.push(number);

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -767,3 +767,14 @@ fn test_get_lexical_sort_key() {
     strings.sort_by_key(|i| get_sort_key(i).unwrap());
     assert_eq!(strings, ["Kórház", "Kőpor"]);
 }
+
+/// Tests split_house_number_by_separator().
+#[test]
+fn test_split_house_number_by_separator() {
+    let normalizer = ranges::Ranges::new(vec![ranges::Range::new(2, 4, "")]);
+
+    let ret = split_house_number_by_separator("2-6", "-", &normalizer);
+
+    assert_eq!(ret.0, vec![2]);
+    assert_eq!(ret.1, vec![2, 6]);
+}


### PR DESCRIPTION
And add a test to ensure the expected behavior.

Change-Id: I97496741890aa54a03239ba6344547b0a545c307
