### PR TITLE
Fix install doc wrt crontab entry

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -81,7 +81,7 @@ This allows accessing your local instance for development.
 
 ----
 # daily, at 0:05
-5 0 * * * /home/osm-gimmisn/git/osm-gimmisn/target/release/cron --mode all
+5 0 * * * cd /home/osm-gimmisn/git/osm-gimmisn && target/release/cron --mode all
 ----
 
 See `target/release/cron --help` for details on what switches are supported for that tool.


### PR DESCRIPTION
Forgot to update this in commit 4e2f2f19ea4a2a34cf3268973e25d1337ba1aab4
(Don't hardcode the build-time current dir anymore, 2022-05-19).

Change-Id: I7c3baccd6e48fcbe69cf22ace7e01c163faf8450
