### PR TITLE
wsgi_additional: test sorting in additional_streets_view_txt()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ check-unit: Cargo.toml $(RS_OBJECTS) locale/hu/LC_MESSAGES/osm-gimmisn.mo data/y
 	cargo tarpaulin --lib -v --skip-clean --fail-under 100 --target-dir ${PWD}/target-cov ${CARGO_OPTIONS}
 
 check-unit-llvm: Cargo.toml $(RS_OBJECTS) locale/hu/LC_MESSAGES/osm-gimmisn.mo data/yamls.cache
-	cargo llvm-cov --lib -q --ignore-filename-regex system.rs --html --fail-under-lines 100
+	cargo llvm-cov --lib -q --ignore-filename-regex system.rs --html --fail-under-lines 100 ${CARGO_OPTIONS} -- --test-threads=1
 
 src/browser/config.ts: wsgi.ini Makefile
 	printf 'const uriPrefix = "%s";\nexport { uriPrefix };\n' $(shell grep prefix wsgi.ini |sed 's/uri_prefix = //') > $@

--- a/src/wsgi_additional/tests.rs
+++ b/src/wsgi_additional/tests.rs
@@ -35,7 +35,6 @@ fn test_streets_view_result_txt() {
             "refstreets": {
                 "OSM Name 1": "Ref Name 1",
             },
-            "osm-street-filters": ["Second Only In OSM utca"],
         },
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
@@ -48,7 +47,7 @@ fn test_streets_view_result_txt() {
 
     let result = test_wsgi.get_txt_for_path("/additional-streets/gazdagret/view-result.txt");
 
-    assert_eq!(result, "Only In OSM utca\n");
+    assert_eq!(result, "Only In OSM utca\nSecond Only In OSM utca\n");
 }
 
 /// Tests additional streets: the chkl output.


### PR DESCRIPTION
And run tests on only one thread when measuring coverage, that seems to
avoid unexpected uncovered lines (happened at least once out of 10
cases).

Change-Id: I7188036f2ab7ff159da2b3757d3827230fd67d93
