### PR TITLE
make_test_context: default to mocked time.now()

### DIFF
--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -24,6 +24,9 @@ pub fn make_test_context() -> anyhow::Result<Context> {
     let file_system = TestFileSystem::new();
     let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
     ctx.set_file_system(&file_system_arc);
+    let time = TestTime::new(2020, 5, 10);
+    let time_arc: Arc<dyn Time> = Arc::new(time);
+    ctx.set_time(&time_arc);
 
     Ok(ctx)
 }
@@ -194,11 +197,6 @@ impl FileSystem for TestFileSystem {
 
         Ok(contents)
     }
-}
-
-/// Generates unix timestamp for 2020-05-10.
-pub fn make_test_time() -> TestTime {
-    TestTime::new(2020, 5, 10)
 }
 
 /// Time implementation, for test purposes.

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -30,13 +30,11 @@ fn test_overpass_sleep_no_sleep() {
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
     ctx.set_network(&network_arc);
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
 
     overpass_sleep(&ctx);
 
-    let time = time_arc
+    let time = ctx
+        .get_time()
         .as_any()
         .downcast_ref::<context::tests::TestTime>()
         .unwrap();
@@ -62,13 +60,11 @@ fn test_overpass_sleep_need_sleep() {
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
     ctx.set_network(&network_arc);
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
 
     overpass_sleep(&ctx);
 
-    let time = time_arc
+    let time = ctx
+        .get_time()
         .as_any()
         .downcast_ref::<context::tests::TestTime>()
         .unwrap();
@@ -707,9 +703,6 @@ fn test_update_osm_streets_xml_as_csv() {
 #[test]
 fn test_update_stats() {
     let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
     let routes = vec![
         context::tests::URLRoute::new(
             /*url=*/ "https://overpass-api.de/api/status",
@@ -797,9 +790,6 @@ fn test_update_stats() {
 #[test]
 fn test_update_stats_http_error() {
     let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
     let routes = vec![context::tests::URLRoute::new(
         /*url=*/ "https://overpass-api.de/api/status",
         /*data_path=*/ "",
@@ -843,9 +833,6 @@ fn test_update_stats_http_error() {
 #[test]
 fn test_update_stats_no_overpass() {
     let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
     let routes = vec![
         context::tests::URLRoute::new(
             /*url=*/ "https://overpass-api.de/api/status",
@@ -890,7 +877,8 @@ fn test_update_stats_no_overpass() {
 
     update_stats(&ctx, /*overpass=*/ false).unwrap();
 
-    let time = time_arc
+    let time = ctx
+        .get_time()
         .as_any()
         .downcast_ref::<context::tests::TestTime>()
         .unwrap();
@@ -1073,9 +1061,6 @@ fn test_our_main_stats() {
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
     ctx.set_network(&network_arc);
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
     let mut file_system = context::tests::TestFileSystem::new();
     let stats_value = context::tests::TestFileSystem::make_file();
     let today_csv = context::tests::TestFileSystem::make_file();

--- a/src/parse_access_log/tests.rs
+++ b/src/parse_access_log/tests.rs
@@ -23,9 +23,6 @@ use context::FileSystem as _;
 #[test]
 fn test_check_top_edited_relations() {
     let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
     let old_citycount = b"foo\t0\n\
 city1\t0\n\
 city2\t0\n\
@@ -115,9 +112,6 @@ fn test_main() {
     let argv = ["".to_string(), "tests/mock/access_log".to_string()];
     let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
     let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
     let relations_path = ctx.get_abspath("data/relations.yaml");
     // 2020-05-09, so this will be recent
     let expected_args = format!("git blame --line-porcelain {}", relations_path);

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -24,9 +24,6 @@ fn make_test_time_old() -> context::tests::TestTime {
 #[test]
 fn test_handle_progress() {
     let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
     let ref_count = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
@@ -54,9 +51,6 @@ fn test_handle_progress() {
 #[test]
 fn test_handle_capital_progress() {
     let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
     let mut file_system = context::tests::TestFileSystem::new();
     let city_count = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
@@ -129,10 +123,7 @@ fn test_handle_capital_progress_old_time() {
 /// Tests handle_topusers().
 #[test]
 fn test_handle_topusers() {
-    let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
+    let ctx = context::tests::make_test_context().unwrap();
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
     handle_topusers(&ctx, &src_root, &mut j).unwrap();
@@ -159,9 +150,6 @@ fn test_handle_topusers_old_time() {
 #[test]
 fn test_handle_topusers_broken_input() {
     let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
     let today_topusers = b"myuser\n";
     let today_topusers_value = context::tests::TestFileSystem::make_file();
     today_topusers_value
@@ -185,9 +173,6 @@ fn test_handle_topusers_broken_input() {
 #[test]
 fn test_handle_topcities() {
     let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
     let src_root = ctx.get_abspath("workdir/stats");
     let today_citycount = b"budapest_01\t100\n\
 budapest_02\t200\n";
@@ -213,10 +198,7 @@ budapest_02\t200\n";
 /// Tests handle_daily_new().
 #[test]
 fn test_hanle_daily_new() {
-    let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
+    let ctx = context::tests::make_test_context().unwrap();
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
     // From now on, today is 2020-05-10, so this will read 2020-04-26, 2020-04-27, etc
@@ -230,10 +212,7 @@ fn test_hanle_daily_new() {
 /// Tests handle_daily_new(): the case when the day range is empty.
 #[test]
 fn test_handle_daily_new_empty_day_range() {
-    let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
+    let ctx = context::tests::make_test_context().unwrap();
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
     handle_daily_new(&ctx, &src_root, &mut j, /*day_range=*/ -1).unwrap();
@@ -244,10 +223,7 @@ fn test_handle_daily_new_empty_day_range() {
 /// Tests handle_monthly_new().
 #[test]
 fn test_handle_monthly_new() {
-    let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
+    let ctx = context::tests::make_test_context().unwrap();
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
     handle_monthly_new(&ctx, &src_root, &mut j, /*month_range=*/ 12).unwrap();
@@ -262,10 +238,7 @@ fn test_handle_monthly_new() {
 /// Tests handle_monthly_new(): the case when the month range is empty.
 #[test]
 fn test_handle_monthly_new_empty_month_range() {
-    let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
+    let ctx = context::tests::make_test_context().unwrap();
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
     handle_monthly_new(&ctx, &src_root, &mut j, /*month_range=*/ -1).unwrap();
@@ -277,9 +250,6 @@ fn test_handle_monthly_new_empty_month_range() {
 #[test]
 fn test_handle_monthly_new_incomplete_last_month() {
     let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
     // This would be the data for the current state of the last, incomplete month.
@@ -300,10 +270,7 @@ fn test_handle_monthly_new_incomplete_last_month() {
 /// Tests handle_daily_total().
 #[test]
 fn test_handle_daily_total() {
-    let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
+    let ctx = context::tests::make_test_context().unwrap();
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
     handle_daily_total(&ctx, &src_root, &mut j, /*day_range=*/ 13).unwrap();
@@ -315,10 +282,7 @@ fn test_handle_daily_total() {
 /// Tests handle_daily_total(): the case when the day range is empty.
 #[test]
 fn test_handle_daily_total_empty_day_range() {
-    let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
+    let ctx = context::tests::make_test_context().unwrap();
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
     handle_daily_total(&ctx, &src_root, &mut j, /*day_range=*/ -1).unwrap();
@@ -329,10 +293,7 @@ fn test_handle_daily_total_empty_day_range() {
 /// Tests handle_user_total().
 #[test]
 fn test_handle_user_total() {
-    let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
+    let ctx = context::tests::make_test_context().unwrap();
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
     handle_user_total(&ctx, &src_root, &mut j, /*day_range=*/ 13).unwrap();
@@ -344,10 +305,7 @@ fn test_handle_user_total() {
 /// Tests handle_user_total(): the case when the day range is empty.
 #[test]
 fn test_handle_user_total_empty_day_range() {
-    let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
+    let ctx = context::tests::make_test_context().unwrap();
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
     handle_user_total(&ctx, &src_root, &mut j, /*day_range=*/ -1).unwrap();
@@ -358,10 +316,7 @@ fn test_handle_user_total_empty_day_range() {
 /// Tests handle_monthly_total().
 #[test]
 fn test_handle_monthly_total() {
-    let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
+    let ctx = context::tests::make_test_context().unwrap();
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
     handle_monthly_total(&ctx, &src_root, &mut j, /*month_range=*/ 11).unwrap();
@@ -373,10 +328,7 @@ fn test_handle_monthly_total() {
 /// Tests handle_monthly_total(): the case when the day range is empty.
 #[test]
 fn test_handle_monthly_total_empty_day_range() {
-    let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
+    let ctx = context::tests::make_test_context().unwrap();
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
     handle_monthly_total(&ctx, &src_root, &mut j, /*month_range=*/ -1).unwrap();
@@ -387,10 +339,7 @@ fn test_handle_monthly_total_empty_day_range() {
 /// Tests handle_monthly_total(): the case when the day range is of just one element.
 #[test]
 fn test_handle_monthly_total_one_element_day_range() {
-    let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
+    let ctx = context::tests::make_test_context().unwrap();
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
     handle_monthly_total(&ctx, &src_root, &mut j, /*month_range=*/ 0).unwrap();
@@ -403,8 +352,8 @@ fn test_handle_monthly_total_one_element_day_range() {
 /// Tests get_previous_month().
 #[test]
 fn test_get_previous_month() {
-    let time: &dyn context::Time = &context::tests::make_test_time();
-    let today = time.now();
+    let ctx = context::tests::make_test_context().unwrap();
+    let today = ctx.get_time().now();
 
     let actual = chrono::NaiveDateTime::from_timestamp(get_previous_month(today, 2).unwrap(), 0);
 
@@ -416,9 +365,6 @@ fn test_get_previous_month() {
 #[test]
 fn test_get_topcities_test_old_missing() {
     let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
     let mut file_system = context::tests::TestFileSystem::new();
     let src_root = ctx.get_abspath("workdir/stats");
     file_system.set_hide_paths(&vec![format!("{}/2020-04-10.citycount", src_root)]);
@@ -432,9 +378,6 @@ fn test_get_topcities_test_old_missing() {
 #[test]
 fn test_get_topcities_test_new_missing() {
     let mut ctx = context::tests::make_test_context().unwrap();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    ctx.set_time(&time_arc);
     let mut file_system = context::tests::TestFileSystem::new();
     let src_root = ctx.get_abspath("workdir/stats");
     file_system.set_hide_paths(&vec![format!("{}/2020-05-10.citycount", src_root)]);

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -1807,9 +1807,6 @@ fn test_static_text() {
 #[test]
 fn test_handle_stats_cityprogress_well_formed() {
     let mut test_wsgi = TestWsgi::new();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    test_wsgi.ctx.set_time(&time_arc);
     let citycount_value = context::tests::TestFileSystem::make_file();
     citycount_value
         .borrow_mut()
@@ -1833,9 +1830,6 @@ fn test_handle_stats_cityprogress_well_formed() {
 #[test]
 fn test_handle_stats_zipprogress_well_formed() {
     let mut test_wsgi = TestWsgi::new();
-    let time = context::tests::make_test_time();
-    let time_arc: Arc<dyn context::Time> = Arc::new(time);
-    test_wsgi.ctx.set_time(&time_arc);
 
     let zips_value = context::tests::TestFileSystem::make_file();
     zips_value


### PR DESCRIPTION
It's much less code this way and the intention was already to set it
everywhere where matters.

Change-Id: Ib3f44dabbca56f1384db3493179ff213ad1a4640
