### PR TITLE
Code coverage: switch to 'cargo llvm-cov'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ CARGO_OPTIONS += --color always
 ifndef V
 	QUIET_MSGFMT = @echo '   ' MSGMFT $@;
 	QUIET_ESLINT = @echo '   ' ESLINT $@;
+	QUIET_WEBPACK = @echo '   ' WEBPACK $@;
 	QUIET_VALIDATOR = @echo '   ' VALIDATOR $@;
 endif
 
@@ -108,9 +109,6 @@ build: $(RS_OBJECTS) Cargo.toml Makefile
 
 # Without coverage: cargo test --lib
 check-unit: Cargo.toml $(RS_OBJECTS) locale/hu/LC_MESSAGES/osm-gimmisn.mo data/yamls.cache
-	cargo tarpaulin --lib -v --skip-clean --fail-under 100 --target-dir ${PWD}/target-cov ${CARGO_OPTIONS}
-
-check-unit-llvm: Cargo.toml $(RS_OBJECTS) locale/hu/LC_MESSAGES/osm-gimmisn.mo data/yamls.cache
 	cargo llvm-cov --lib -q --ignore-filename-regex system.rs --html --fail-under-lines 100 ${CARGO_OPTIONS} -- --test-threads=1
 
 src/browser/config.ts: wsgi.ini Makefile
@@ -124,7 +122,7 @@ endif
 
 builddir/bundle.js: $(TS_OBJECTS) package-lock.json Makefile
 	mkdir -p builddir
-	npx webpack ${WEBPACK_OPTIONS} --config webpack.config.js
+	$(QUIET_WEBPACK)npx webpack ${WEBPACK_OPTIONS} --config webpack.config.js
 	touch $@
 
 package-lock.json: package.json

--- a/src/context/system.rs
+++ b/src/context/system.rs
@@ -19,7 +19,6 @@ use isahc::RequestExt as _;
 pub struct StdFileSystem {}
 
 // Real file-system is intentionally mocked.
-#[cfg(not(tarpaulin_include))]
 impl FileSystem for StdFileSystem {
     fn path_exists(&self, path: &str) -> bool {
         Path::new(path).exists()
@@ -72,7 +71,6 @@ impl FileSystem for StdFileSystem {
 pub struct StdNetwork {}
 
 // Real network is intentionally mocked.
-#[cfg(not(tarpaulin_include))]
 impl Network for StdNetwork {
     fn urlopen(&self, url: &str, data: &str) -> anyhow::Result<String> {
         if !data.is_empty() {
@@ -99,7 +97,6 @@ impl Network for StdNetwork {
 pub struct StdTime {}
 
 // Real time is intentionally mocked.
-#[cfg(not(tarpaulin_include))]
 impl Time for StdTime {
     fn now(&self) -> i64 {
         let now = chrono::Local::now();
@@ -119,7 +116,6 @@ impl Time for StdTime {
 pub struct StdSubprocess {}
 
 // Real processes are intentionally mocked.
-#[cfg(not(tarpaulin_include))]
 impl Subprocess for StdSubprocess {
     fn run(&self, args: Vec<String>) -> anyhow::Result<String> {
         let (first, rest) = args

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -15,11 +15,12 @@ if [ -n "${GITHUB_WORKFLOW}" ]; then
 
     sudo apt-get install gettext
 
-    # Build from source: cargo install --version 0.18.5 cargo-tarpaulin
+    # Build from source: cargo install --version 0.4.4 cargo-llvm-cov
     # Binary install:
     wget https://github.com/ryankurte/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-gnu.tgz
     tar -xvf cargo-binstall-x86_64-unknown-linux-gnu.tgz
-    ./cargo-binstall --no-confirm --version 0.18.5 cargo-tarpaulin
+    ./cargo-binstall --no-confirm --version 0.4.4 cargo-llvm-cov
+    rustup component add llvm-tools-preview --toolchain stable-x86_64-unknown-linux-gnu
 fi
 make -j$(getconf _NPROCESSORS_ONLN) check RSDEBUG=1
 


### PR DESCRIPTION
Main benefit is that llvm-based coverage is much more mature, and
already found many untested code where tarpaulin claimed completely line
coverage already.

Also make the webpack build output more silent by default.

Change-Id: I0d9f701bfc8985ab4209653a406803c1748eef3b
