### PR TITLE
make_test_context: default to mocked network

### DIFF
--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -27,6 +27,9 @@ pub fn make_test_context() -> anyhow::Result<Context> {
     let time = TestTime::new(2020, 5, 10);
     let time_arc: Arc<dyn Time> = Arc::new(time);
     ctx.set_time(&time_arc);
+    let network = TestNetwork::new(&[]);
+    let network_arc: Arc<dyn Network> = Arc::new(network);
+    ctx.set_network(&network_arc);
 
     Ok(ctx)
 }


### PR DESCRIPTION
This way it can't happen that we forget to mock the network in a test
and they start to talk to real overpass servers by accident.

Change-Id: I9044a98b1b200ae9bdc644c434d0c4f44d5a0295
