### PR TITLE
make_test_context: default to mocked subprocess

### DIFF
--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -30,6 +30,9 @@ pub fn make_test_context() -> anyhow::Result<Context> {
     let network = TestNetwork::new(&[]);
     let network_arc: Arc<dyn Network> = Arc::new(network);
     ctx.set_network(&network_arc);
+    let subprocess = TestSubprocess::new(&HashMap::new());
+    let subprocess_arc: Arc<dyn Subprocess> = Arc::new(subprocess);
+    ctx.set_subprocess(&subprocess_arc);
 
     Ok(ctx)
 }


### PR DESCRIPTION
This way it can't happen that we forget to mock the subprocess in a test
and they start to talk to real subprocesses by accident.

Change-Id: I086b5ceb81a1b9b90ef4f0516fd580d5952a19bb
