### PR TITLE
areas: only convert to lowercase letter style at the end of txt/chkl output

### DIFF
--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -2520,40 +2520,6 @@ fn test_relation_config_should_check_missing_streets_default() {
     assert_eq!(ret, "yes");
 }
 
-/// Tests RelationConfig::get_letter_suffix_style().
-#[test]
-fn test_relation_config_get_letter_suffix_style() {
-    let relation_name = "myrelation";
-    let mut ctx = context::tests::make_test_context().unwrap();
-    let yamls_cache = serde_json::json!({
-        "relations.yaml": {
-            relation_name: {
-                "refsettlement": "42",
-            },
-        },
-    });
-    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
-    let files = context::tests::TestFileSystem::make_files(
-        &ctx,
-        &[("data/yamls.cache", &yamls_cache_value)],
-    );
-    let file_system = context::tests::TestFileSystem::from_files(&files);
-    ctx.set_file_system(&file_system);
-    let mut relations = Relations::new(&ctx).unwrap();
-    let mut relation = relations.get_relation(relation_name).unwrap();
-    assert_eq!(
-        relation.config.get_letter_suffix_style(),
-        util::LetterSuffixStyle::Upper
-    );
-    let mut config = relation.config.clone();
-    config.set_letter_suffix_style(util::LetterSuffixStyle::Lower);
-    relation.set_config(&config);
-    assert_eq!(
-        relation.config.get_letter_suffix_style(),
-        util::LetterSuffixStyle::Lower
-    );
-}
-
 /// Tests refcounty_get_name().
 #[test]
 fn test_refcounty_get_name() {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -277,8 +277,10 @@ pub fn get_missing_housenumbers_txt(
     let mut table: Vec<String> = Vec::new();
     for result in ongoing_streets {
         let range_list = util::get_housenumber_ranges(&result.1);
-        let mut range_strings: Vec<String> =
-            range_list.iter().map(|i| i.get_number()).cloned().collect();
+        let mut range_strings: Vec<String> = range_list
+            .iter()
+            .map(|i| i.get_lowercase_number())
+            .collect();
         // Street name, only_in_reference items.
         let row: String = if !relation
             .get_config()

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -234,11 +234,6 @@ fn update_missing_housenumbers(
         }
         i18n::set_language(ctx, &orig_language);
 
-        // To be in sync with wsgi::missing_housenumbers_view_txt().
-        let mut config = relation.get_config().clone();
-        config.set_letter_suffix_style(util::LetterSuffixStyle::Lower);
-        relation.set_config(&config);
-
         cache::get_missing_housenumbers_txt(ctx, &mut relation)
             .context("get_missing_housenumbers_txt() failed")?;
     }

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -550,37 +550,41 @@ fn test_house_number_letter_suffix() {
 #[test]
 fn test_house_number_normalize_letter_suffix() {
     assert_eq!(
-        HouseNumber::normalize_letter_suffix("42a", "", LetterSuffixStyle::Upper).unwrap(),
+        HouseNumber::normalize_letter_suffix("42a", "").unwrap(),
         "42/A"
     );
     assert_eq!(
-        HouseNumber::normalize_letter_suffix("42 a", "", LetterSuffixStyle::Upper).unwrap(),
+        HouseNumber::normalize_letter_suffix("42 a", "").unwrap(),
         "42/A"
     );
     assert_eq!(
-        HouseNumber::normalize_letter_suffix("42/a", "", LetterSuffixStyle::Upper).unwrap(),
+        HouseNumber::normalize_letter_suffix("42/a", "").unwrap(),
         "42/A"
     );
     assert_eq!(
-        HouseNumber::normalize_letter_suffix("42/A", "", LetterSuffixStyle::Upper).unwrap(),
+        HouseNumber::normalize_letter_suffix("42/A", "").unwrap(),
         "42/A"
     );
     assert_eq!(
-        HouseNumber::normalize_letter_suffix("42/A*", "*", LetterSuffixStyle::Upper).unwrap(),
+        HouseNumber::normalize_letter_suffix("42/A*", "*").unwrap(),
         "42/A*"
     );
     assert_eq!(
-        HouseNumber::normalize_letter_suffix("42 A", "", LetterSuffixStyle::Upper).unwrap(),
+        HouseNumber::normalize_letter_suffix("42 A", "").unwrap(),
         "42/A"
     );
-    assert_eq!(
-        HouseNumber::normalize_letter_suffix("x", "", LetterSuffixStyle::Upper).is_err(),
-        true
-    );
-    assert_eq!(
-        HouseNumber::normalize_letter_suffix("42/A", "", LetterSuffixStyle::Lower).unwrap(),
-        "42a"
-    );
+    assert_eq!(HouseNumber::normalize_letter_suffix("x", "").is_err(), true);
+}
+
+/// Tests HouseNumberRange::get_lowercase_number().
+#[test]
+fn test_house_number_range_get_lowercase_number() {
+    let range = HouseNumberRange::new("42/A", "");
+    assert_eq!(range.get_lowercase_number(), "42a");
+    let range = HouseNumberRange::new("43b", "");
+    assert_eq!(range.get_lowercase_number(), "43b");
+    let range = HouseNumberRange::new("44/C*", "");
+    assert_eq!(range.get_lowercase_number(), "44c*");
 }
 
 /// Tests get_housenumber_ranges().
@@ -820,16 +824,6 @@ fn test_get_valid_settlements_error() {
     let mut expected: HashSet<String> = HashSet::new();
     expected.insert("mycity1".to_string());
     assert_eq!(ret, expected);
-}
-
-/// Tests that LetterSuffixStyle implementes the Debug trait.
-#[test]
-fn test_letter_suffix_style_debug() {
-    let style = LetterSuffixStyle::Upper;
-
-    let ret = format!("{:?}", style);
-
-    assert_eq!(ret, "Upper");
 }
 
 /// Tests that HouseNumberRange implements the Debug trait.

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -347,9 +347,6 @@ fn missing_housenumbers_view_txt(
     tokens.next_back();
     let relation_name = tokens.next_back().unwrap();
     let mut relation = relations.get_relation(relation_name)?;
-    let mut config = relation.get_config().clone();
-    config.set_letter_suffix_style(util::LetterSuffixStyle::Lower);
-    relation.set_config(&config);
 
     let output: String;
     if !ctx
@@ -383,9 +380,6 @@ fn missing_housenumbers_view_chkl(
     tokens.next_back();
     let relation_name = tokens.next_back().unwrap();
     let mut relation = relations.get_relation(relation_name)?;
-    let mut config = relation.get_config().clone();
-    config.set_letter_suffix_style(util::LetterSuffixStyle::Lower);
-    relation.set_config(&config);
 
     let output: String;
     if !ctx


### PR DESCRIPTION
This is less code and allows not emptying the osm_housenumbers cache in
Relation::set_config(), leading to a faster cron.

Change-Id: Idf50fcd90af08c622101e5a8561f8d9989211b5b
