### PR TITLE
check-unit: show missing lines at the end of the output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ build: $(RS_OBJECTS) Cargo.toml Makefile
 
 # Without coverage: cargo test --lib
 check-unit: Cargo.toml $(RS_OBJECTS) locale/hu/LC_MESSAGES/osm-gimmisn.mo data/yamls.cache
-	cargo llvm-cov --lib -q --ignore-filename-regex system.rs --html --fail-under-lines 100 ${CARGO_OPTIONS} -- --test-threads=1
+	cargo llvm-cov --lib -q --ignore-filename-regex system.rs --show-missing-lines --fail-under-lines 100 ${CARGO_OPTIONS} -- --test-threads=1
 
 src/browser/config.ts: wsgi.ini Makefile
 	printf 'const uriPrefix = "%s";\nexport { uriPrefix };\n' $(shell grep prefix wsgi.ini |sed 's/uri_prefix = //') > $@

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -15,11 +15,11 @@ if [ -n "${GITHUB_WORKFLOW}" ]; then
 
     sudo apt-get install gettext
 
-    # Build from source: cargo install --version 0.4.4 cargo-llvm-cov
+    # Build from source: cargo install --version 0.4.6 cargo-llvm-cov
     # Binary install:
     wget https://github.com/ryankurte/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-gnu.tgz
     tar -xvf cargo-binstall-x86_64-unknown-linux-gnu.tgz
-    ./cargo-binstall --no-confirm --version 0.4.4 cargo-llvm-cov
+    ./cargo-binstall --no-confirm --version 0.4.6 cargo-llvm-cov
 fi
 make -j$(getconf _NPROCESSORS_ONLN) check RSDEBUG=1
 


### PR DESCRIPTION
Similar to how coverage.py was called with --show-missing in the past.

Change-Id: Ie9d40192c5296c3f43143b289387fd074fe9359c
