### PR TITLE
stats: say which .citycount is missing if returning early

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -18,6 +18,12 @@ use std::collections::HashMap;
 use std::io::BufRead;
 use std::ops::DerefMut;
 
+#[cfg(not(test))]
+use log::info;
+
+#[cfg(test)]
+use std::println as info;
+
 /// Generates stats for a global progressbar.
 fn handle_progress(
     ctx: &context::Context,
@@ -173,6 +179,10 @@ pub fn get_topcities(ctx: &context::Context, src_root: &str) -> anyhow::Result<V
 
     let old_count_path = format!("{}/{}.citycount", src_root, old_day);
     if !ctx.get_file_system().path_exists(&old_count_path) {
+        info!(
+            "get_topcities: empty result: no such path: {}",
+            old_count_path
+        );
         return Ok(vec![]);
     }
     let stream = ctx.get_file_system().open_read(&old_count_path)?;


### PR DESCRIPTION
Then a manual fixup is possible: typically today's missing data can be
approximated with yesterday's outdated data.

Change-Id: I8659f2e923b0cdc020493333e5a3c2bb23a286e3
