### PR TITLE
Update to Rust 1.62

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.61.0
+          toolchain: 1.62.0
           components: rustfmt, clippy, llvm-tools-preview
           default: true
       - name: Rust Cache
@@ -26,7 +26,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-1.61.0-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-1.62.0-${{ hashFiles('**/Cargo.toml') }}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -19,6 +19,7 @@ use crate::yattag;
 use anyhow::Context;
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::io::BufRead;
 use std::io::Read;
 use std::ops::DerefMut;
@@ -1476,8 +1477,8 @@ area(@AREA@)->.searchArea;
 "#;
     let mut query = util::process_template(header, relation.config.get_osmrelation());
     for street in streets {
-        query += &format!("way[\"name\"=\"{}\"](r.searchRelation);\n", street);
-        query += &format!("way[\"name\"=\"{}\"](area.searchArea);\n", street);
+        writeln!(query, "way[\"name\"=\"{}\"](r.searchRelation);", street).unwrap();
+        writeln!(query, "way[\"name\"=\"{}\"](area.searchArea);", street).unwrap();
     }
     query += r#");
 out body;
@@ -1504,7 +1505,7 @@ area(@AREA@)->.searchArea;
     ids.sort();
     ids.dedup();
     for (osm_type, osm_id) in ids {
-        query += &format!("{}({});\n", osm_type, osm_id);
+        writeln!(query, "{}({});", osm_type, osm_id).unwrap();
     }
     query += r#");
 out body;

--- a/src/yattag.rs
+++ b/src/yattag.rs
@@ -14,6 +14,7 @@
 //! <https://crates.io/crates/html-builder> would require you to manually escape attribute values.
 
 use std::cell::RefCell;
+use std::fmt::Write as _;
 use std::rc::Rc;
 
 /// Generates xml/html documents.
@@ -80,11 +81,11 @@ pub struct Tag {
 impl Tag {
     fn new(value: &Rc<RefCell<String>>, name: &str, attrs: &[(&str, &str)]) -> Tag {
         let mut guard = value.borrow_mut();
-        guard.push_str(&format!("<{}", name));
+        write!(guard, "<{}", name).unwrap();
         for attr in attrs {
             let key = attr.0;
             let val = html_escape::encode_double_quoted_attribute(&attr.1);
-            guard.push_str(&format!(" {}=\"{}\"", key, val));
+            write!(guard, " {}=\"{}\"", key, val).unwrap();
         }
         guard.push('>');
         let value = value.clone();
@@ -124,9 +125,7 @@ impl Tag {
 
 impl Drop for Tag {
     fn drop(&mut self) {
-        self.value
-            .borrow_mut()
-            .push_str(&format!("</{}>", self.name));
+        let _ = write!(self.value.borrow_mut(), "</{}>", self.name);
     }
 }
 


### PR DESCRIPTION
Use `write!` to avoid introducing an extra, avoidable heap allocation.

Change-Id: If6d3b86798c09b194f8ff784cca53288f844c211
