### PR TITLE
Rename workdir/osm.min.css to target/browser/osm.min.css

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,9 @@ package-lock.json: package.json
 	npm install
 	touch $@
 
-css: workdir/osm.min.css
+css: target/browser/osm.min.css
 
-workdir/osm.min.css: static/osm.css package-lock.json
+target/browser/osm.min.css: static/osm.css package-lock.json
 	mkdir -p workdir
 	[ -x "./node_modules/.bin/cleancss" ] && npx cleancss -o $@ $< || cp -a $< $@
 

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -144,7 +144,9 @@ impl FileSystem for TestFileSystem {
             ret.borrow_mut().seek(SeekFrom::Start(0))?;
             return Ok(ret);
         }
-        let ret: Rc<RefCell<dyn Read>> = Rc::new(RefCell::new(std::fs::File::open(path)?));
+        let ret: Rc<RefCell<dyn Read>> = Rc::new(RefCell::new(
+            std::fs::File::open(path).context(format!("failed to open '{}'", path))?,
+        ));
         Ok(ret)
     }
 

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -477,7 +477,7 @@ pub fn handle_static(
     if request_uri.ends_with(".css") {
         let content_type = "text/css; charset=utf-8";
         let (content, extra_headers) =
-            get_content_with_meta(ctx, &format!("{}/{}", ctx.get_ini().get_workdir(), path))
+            get_content_with_meta(ctx, &ctx.get_abspath(&format!("target/browser/{}", path)))
                 .context("get_content_with_meta() failed")?;
         return Ok((content, content_type.into(), extra_headers));
     }

--- a/src/webframe/tests.rs
+++ b/src/webframe/tests.rs
@@ -26,9 +26,10 @@ fn test_handle_static() {
         write.write_all(b"/* comment */").unwrap();
     }
     let mut file_system = context::tests::TestFileSystem::new();
-    let files = context::tests::TestFileSystem::make_files(&ctx, &[("workdir/osm.min.css", &css)]);
+    let files =
+        context::tests::TestFileSystem::make_files(&ctx, &[("target/browser/osm.min.css", &css)]);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
-    let path = ctx.get_abspath("workdir/osm.min.css");
+    let path = ctx.get_abspath("target/browser/osm.min.css");
     mtimes.insert(path.to_string(), Rc::new(RefCell::new(0_f64)));
     file_system.set_files(&files);
     file_system.set_mtimes(&mtimes);

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1329,7 +1329,7 @@ fn write_html_head(ctx: &context::Context, doc: &yattag::Tag, title: &str) -> an
         ],
     );
 
-    let css_path = format!("{}/{}", ctx.get_ini().get_workdir(), "osm.min.css");
+    let css_path = ctx.get_abspath("target/browser/osm.min.css");
     if ctx.get_file_system().path_exists(&css_path) {
         let stream = ctx.get_file_system().open_read(&css_path)?;
         let mut buf: Vec<u8> = Vec::new();

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -1682,7 +1682,8 @@ fn test_application_error() {
         write.write_all(b"/* comment */").unwrap();
     }
     let mut file_system = context::tests::TestFileSystem::new();
-    let files = context::tests::TestFileSystem::make_files(&ctx, &[("workdir/osm.min.css", &css)]);
+    let files =
+        context::tests::TestFileSystem::make_files(&ctx, &[("target/browser/osm.min.css", &css)]);
     file_system.set_files(&files);
     let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
     ctx.set_file_system(&file_system_arc);
@@ -1776,12 +1777,12 @@ fn test_static_css() {
     css_value.borrow_mut().write_all(b"{}").unwrap();
     let files = context::tests::TestFileSystem::make_files(
         &test_wsgi.ctx,
-        &[("workdir/osm.min.css", &css_value)],
+        &[("target/browser/osm.min.css", &css_value)],
     );
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
-        test_wsgi.ctx.get_abspath("workdir/osm.min.css"),
+        test_wsgi.ctx.get_abspath("target/browser/osm.min.css"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);


### PR DESCRIPTION
This way:

- refdir/ and workdir/ only contains data

- target/ contains built code / generated data

Change-Id: Ia54b6edc5f053d7eb0e245d9770a67a658f3beba
