### PR TITLE
Remove redundant relation-gazdagret-filter-invalid-good.yaml testcase

### DIFF
--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -17,7 +17,6 @@ use super::*;
 fn test_relations() {
     let paths = [
         "tests/data/relations.yaml",
-        "tests/data/relation-gazdagret-filter-invalid-good.yaml",
         "tests/data/relation-gazdagret-filter-invalid-good2.yaml",
         "tests/data/relation-gazdagret-filter-valid-good.yaml",
         "tests/data/relation-gazdagret-filter-valid-good2.yaml",

--- a/tests/data/relation-gazdagret-filter-invalid-good.yaml
+++ b/tests/data/relation-gazdagret-filter-invalid-good.yaml
@@ -1,3 +1,0 @@
-filters:
-  'Budaörsi út':
-    invalid: ['1c']


### PR DESCRIPTION
RelationFiltersDict.invalid already had an explicit string list type, so
if this goes wrong, serde will catch this for us without explicit code.

Change-Id: I0a39a2fa56864b34480efbf2b7791d2e1f15e82c
