### PR TITLE
validator: remove redundant relation-gazdagret-filter-invalid-good2 testcase

### DIFF
--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -17,7 +17,6 @@ use super::*;
 fn test_relations() {
     let paths = [
         "tests/data/relations.yaml",
-        "tests/data/relation-gazdagret-filter-invalid-good2.yaml",
         "tests/data/relation-gazdagret-filter-valid-good.yaml",
         "tests/data/relation-gazdagret-filter-valid-good2.yaml",
     ];

--- a/tests/data/relation-gazdagret-filter-invalid-good2.yaml
+++ b/tests/data/relation-gazdagret-filter-invalid-good2.yaml
@@ -1,3 +1,0 @@
-filters:
-  'Budaörsi út':
-    invalid: ['42/1']


### PR DESCRIPTION
If this goes wrong, serde will catch this for us without explicit code.

Change-Id: I924a4cea31876180f1dfbfb5bf308feb7297998f
