### PR TITLE
Update to rust 1.63

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.62.0
+          toolchain: 1.63.0
           components: rustfmt, clippy, llvm-tools-preview
           default: true
       - name: Rust Cache
@@ -26,7 +26,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-1.62.0-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-1.63.0-${{ hashFiles('**/Cargo.toml') }}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:

--- a/src/util.rs
+++ b/src/util.rs
@@ -265,7 +265,7 @@ impl HouseNumber {
             let mut iter = NUMBER_SUFFIX.captures_iter(house_number);
             if let Some(cap) = iter.next() {
                 suffix = "/".into();
-                suffix += &cap[1].to_string();
+                suffix += &cap[1];
             }
         }
 


### PR DESCRIPTION
Also fix this new clippy warning:

> unnecessary use of `to_string`

Change-Id: If48898b25e113becc39b58698efc40caf03966d4
