### PR TITLE
yattag: document Doc::new() and HtmlTable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osm-gimmisn"
-version = "7.3.0"
+version = "7.4.0"
 edition = "2021"
 
 [dependencies]

--- a/src/yattag.rs
+++ b/src/yattag.rs
@@ -24,6 +24,7 @@ pub struct Doc {
 }
 
 impl Doc {
+    /// Creates an empty Doc.
     pub fn new() -> Doc {
         Doc {
             value: Rc::new(RefCell::new(String::from(""))),
@@ -64,6 +65,7 @@ impl Doc {
     }
 }
 
+/// HtmlTable is a matrix (rows, then cols) of Doc instances.
 pub type HtmlTable = Vec<Vec<Doc>>;
 
 impl Default for Doc {


### PR DESCRIPTION
Found by locally making yattag a public module. Also fix the version
number in Cargo.toml.

Change-Id: I814a540a97054577e2331cf8e8659b4454440d33
