### PR TITLE
cache_yaml: don't read relations.yaml directly from the file-system

### DIFF
--- a/src/cache_yamls.rs
+++ b/src/cache_yamls.rs
@@ -54,8 +54,9 @@ pub fn our_main(argv: &[String], ctx: &context::Context) -> anyhow::Result<()> {
     let workdir = ctx.get_abspath(&argv[2]);
     let yaml_path = format!("{}/relations.yaml", datadir);
     let mut relation_ids: Vec<u64> = Vec::new();
-    let stream = std::fs::File::open(yaml_path)?;
-    let relations: areas::RelationsDict = serde_yaml::from_reader(stream)?;
+    let data = ctx.get_file_system().read_to_string(&yaml_path)?;
+    let relations: areas::RelationsDict = serde_yaml::from_str(&data)
+        .context(format!("serde_yaml::from_str() failed for {}", yaml_path))?;
     for (_key, value) in relations {
         relation_ids.push(value.osmrelation.context("no osmrelation")?);
     }

--- a/src/cache_yamls/tests.rs
+++ b/src/cache_yamls/tests.rs
@@ -11,7 +11,6 @@
 //! Tests for the cache_yamls module.
 
 use super::*;
-use crate::areas;
 use std::io::Seek;
 use std::io::SeekFrom;
 use std::sync::Arc;
@@ -25,11 +24,22 @@ fn test_main() {
     let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_hide_paths(&[cache_path]);
+    let relations_value = context::tests::TestFileSystem::make_file();
+    let relations_content = r#"gazdagret:
+    osmrelation: 2713748
+    refcounty: "01"
+    refsettlement: "011"
+"#;
+    relations_value
+        .borrow_mut()
+        .write_all(relations_content.as_bytes())
+        .unwrap();
     let cache_value = context::tests::TestFileSystem::make_file();
     let stats_value = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
         &[
+            ("data/relations.yaml", &relations_value),
             ("data/yamls.cache", &cache_value),
             ("workdir/stats/relations.json", &stats_value),
         ],
@@ -59,16 +69,7 @@ fn test_main() {
         .iter()
         .map(|i| i.as_u64().unwrap())
         .collect();
-    let mut relations = areas::Relations::new(&ctx).unwrap();
-    let mut osmids: Vec<_> = relations
-        .get_relations()
-        .unwrap()
-        .iter()
-        .map(|i| i.get_config().get_osmrelation())
-        .collect();
-    osmids.sort();
-    osmids.dedup();
-    assert_eq!(relation_ids, osmids);
+    assert_eq!(relation_ids, [2713748]);
 }
 
 /// Tests main() failure.

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -15,14 +15,24 @@ use super::*;
 /// Tests main(): valid relations.
 #[test]
 fn test_relations() {
-    let paths = ["tests/data/relations.yaml"];
-    for path in paths {
-        let argv = ["".to_string(), path.to_string()];
-        let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
-        let ctx = context::tests::make_test_context().unwrap();
-        let ret = main(&argv, &mut buf, &ctx);
-        assert_eq!(ret, 0);
-    }
+    let content = r#"gazdagret:
+    osmrelation: 2713748
+    refcounty: "01"
+    refsettlement: "011"
+"#;
+    let path = "data/relations.yaml";
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let argv: &[String] = &["".into(), ctx.get_abspath(path)];
+    let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
+    let file = context::tests::TestFileSystem::make_file();
+    file.borrow_mut().write_all(content.as_bytes()).unwrap();
+    let files = context::tests::TestFileSystem::make_files(&ctx, &[(path, &file)]);
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    ctx.set_file_system(&file_system);
+
+    let ret = main(argv, &mut buf, &ctx);
+
+    assert_eq!(ret, 0);
 }
 
 /// Tests the missing-osmrelation relations path.

--- a/tests/data/relations.yaml
+++ b/tests/data/relations.yaml
@@ -1,4 +1,0 @@
-gazdagret:
-    osmrelation: 2713748
-    refcounty: "01"
-    refsettlement: "011"


### PR DESCRIPTION
Allows folding tests/data/relations.yaml into code.

Change-Id: I28dcad6d40756f208dfdd678c81848444779a497
