### PR TITLE
validator: catch tabs in yaml files

### DIFF
--- a/data/relation-balatonboglar.yaml
+++ b/data/relation-balatonboglar.yaml
@@ -12,7 +12,7 @@ street-filters:
   - Bánom hegy
   # megváltozott
   - Téglagyár utca  # Bercsényi utca lett belőle
-  # Szöcske utca - https://www.openstreetmap.org/note/3307358 - nincs utcatábla	
+  # Szöcske utca - https://www.openstreetmap.org/note/3307358 - nincs utcatábla
   # Venyige köz - https://www.openstreetmap.org/note/3307352 - nincs utcatábla
 osm-street-filters:
   # parkok, sétányok

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -301,6 +301,12 @@ pub fn our_main(
     let yaml_path = argv[1].clone();
     let data = ctx.get_file_system().read_to_string(&yaml_path)?;
     let mut errors: Vec<String> = Vec::new();
+
+    if data.contains('\t') {
+        // serde can parse this, but not some of the 3rd-party parsers.
+        errors.push("expected indent with 2 spaces, not with tabs".to_string());
+    }
+
     if yaml_path.ends_with("relations.yaml") {
         let relations_dict: areas::RelationsDict =
             serde_yaml::from_str(&data).context("serde_yaml::from_str() failed")?;

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -231,6 +231,14 @@ fn test_relation_source_bad_type() {
     assert_failure_msg(content, expected);
 }
 
+/// Tests the relation path: bad tab indent.
+#[test]
+fn test_relation_tab() {
+    let content = "source:\tsurvey\n";
+    let expected = "expected indent with 2 spaces, not with tabs\nfailed to validate {0}\n";
+    assert_failure_msg(content, expected);
+}
+
 /// Tests the relation path: bad filters type.
 #[test]
 fn test_relation_filters_bad_type() {


### PR DESCRIPTION
We indent with 2 spaces and even serde rejects tabs in some cases. In
other cases it accepts them, but not Python's yaml parser. Just avoid
tabs, like we already enforce that for Rust code.

Change-Id: I2eb113972c8a4d6a9b322409c5fc705ac1412ac3
