### PR TITLE
context: don't fail if wsgi.ini is missing

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -52,12 +52,6 @@ Populate the reference directory with TSV files for the house number and street 
 cargo build --release --no-default-features
 ----
 
-- Create a default config:
-
-----
-copy data\wsgi.ini.template wsgi.ini
-----
-
 - Run the validator:
 
 ----

--- a/src/context.rs
+++ b/src/context.rs
@@ -119,8 +119,10 @@ impl Ini {
         root: &str,
     ) -> anyhow::Result<Self> {
         let mut config = configparser::ini::Ini::new();
-        if let Err(err) = config.read(file_system.read_to_string(config_path)?) {
-            return Err(anyhow::anyhow!("failed to load {}: {}", config_path, err));
+        if let Ok(data) = file_system.read_to_string(config_path) {
+            if let Err(err) = config.read(data) {
+                return Err(anyhow::anyhow!("failed to load {}: {}", config_path, err));
+            }
         }
         Ok(Ini {
             config,


### PR DESCRIPTION
Useful for the validator that doesn't need a config, really.

Change-Id: Id2c5fc98673b1f1c45d80e8ff411c91aa2a92ef8
