### PR TITLE
tests: remove no longer needed refcounty-names.yaml

### DIFF
--- a/tests/data/refcounty-names.yaml
+++ b/tests/data/refcounty-names.yaml
@@ -1,2 +1,0 @@
-'01': 'Budapest'
-'67': 'Sixtyseven'


### PR DESCRIPTION
No test reads this from the filesystem, they provide it from code.

Change-Id: I42dc19c67955e130b03df0147517c05eeef7c576
