### PR TITLE
util: turn NumberedStreet into a struct

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -819,14 +819,20 @@ impl Relation {
                 /*osm_id=*/ 0,
             );
             if !only_in_reference.is_empty() {
-                ongoing_streets.push((street.clone(), only_in_reference))
+                ongoing_streets.push(util::NumberedStreet {
+                    street: street.clone(),
+                    house_numbers: only_in_reference,
+                })
             }
             if !in_both.is_empty() {
-                done_streets.push((street, in_both));
+                done_streets.push(util::NumberedStreet {
+                    street,
+                    house_numbers: in_both,
+                });
             }
         }
         // Sort by length, reverse.
-        ongoing_streets.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+        ongoing_streets.sort_by(|a, b| b.house_numbers.len().cmp(&a.house_numbers.len()));
 
         Ok((ongoing_streets, done_streets))
     }
@@ -956,12 +962,15 @@ impl Relation {
         let mut rows: Vec<Vec<yattag::Doc>> = Vec::new();
         for result in numbered_streets {
             // street, only_in_ref
-            let mut row: Vec<yattag::Doc> = vec![result.0.to_html()];
-            let number_ranges = util::get_housenumber_ranges(&result.1);
+            let mut row: Vec<yattag::Doc> = vec![result.street.to_html()];
+            let number_ranges = util::get_housenumber_ranges(&result.house_numbers);
             row.push(yattag::Doc::from_text(&number_ranges.len().to_string()));
 
             let doc = yattag::Doc::new();
-            if !self.config.get_street_is_even_odd(result.0.get_osm_name()) {
+            if !self
+                .config
+                .get_street_is_even_odd(result.street.get_osm_name())
+            {
                 let mut sorted = number_ranges.clone();
                 sorted.sort_by(|a, b| {
                     util::split_house_number_range(a).cmp(&util::split_house_number_range(b))
@@ -1009,7 +1018,7 @@ impl Relation {
 
         let mut done_count = 0;
         for result in done_streets {
-            let number_ranges = util::get_housenumber_ranges(&result.1);
+            let number_ranges = util::get_housenumber_ranges(&result.house_numbers);
             done_count += number_ranges.len();
         }
         let percent: f64 = if done_count > 0 || todo_count > 0 {
@@ -1066,11 +1075,14 @@ impl Relation {
                 /*osm_id=*/ 0,
             );
             if !only_in_osm.is_empty() {
-                additional.push((street, only_in_osm))
+                additional.push(util::NumberedStreet {
+                    street,
+                    house_numbers: only_in_osm,
+                })
             }
         }
         // Sort by length, reverse.
-        additional.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+        additional.sort_by(|a, b| b.house_numbers.len().cmp(&a.house_numbers.len()));
 
         Ok(additional)
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -276,7 +276,7 @@ pub fn get_missing_housenumbers_txt(
     let (ongoing_streets, _done_streets) = relation.get_missing_housenumbers()?;
     let mut table: Vec<String> = Vec::new();
     for result in ongoing_streets {
-        let range_list = util::get_housenumber_ranges(&result.1);
+        let range_list = util::get_housenumber_ranges(&result.house_numbers);
         let mut range_strings: Vec<String> = range_list
             .iter()
             .map(|i| i.get_lowercase_number())
@@ -284,17 +284,21 @@ pub fn get_missing_housenumbers_txt(
         // Street name, only_in_reference items.
         let row: String = if !relation
             .get_config()
-            .get_street_is_even_odd(result.0.get_osm_name())
+            .get_street_is_even_odd(result.street.get_osm_name())
         {
             range_strings.sort_by_key(|i| util::split_house_number(i));
             format!(
                 "{}\t[{}]",
-                result.0.get_osm_name(),
+                result.street.get_osm_name(),
                 range_strings.join(", ")
             )
         } else {
             let elements = util::format_even_odd(&range_list);
-            format!("{}\t[{}]", result.0.get_osm_name(), elements.join("], ["))
+            format!(
+                "{}\t[{}]",
+                result.street.get_osm_name(),
+                elements.join("], [")
+            )
         };
         table.push(row);
     }

--- a/src/missing_housenumbers.rs
+++ b/src/missing_housenumbers.rs
@@ -29,11 +29,16 @@ pub fn our_main(
 
     for result in ongoing_streets {
         // House number, # of only_in_reference items.
-        let range_list = util::get_housenumber_ranges(&result.1);
+        let range_list = util::get_housenumber_ranges(&result.house_numbers);
         let mut range_strings: Vec<&String> = range_list.iter().map(|i| i.get_number()).collect();
         range_strings.sort_by_key(|i| util::split_house_number(i));
         stream.write_all(
-            format!("{}\t{}\n", result.0.get_osm_name(), range_strings.len()).as_bytes(),
+            format!(
+                "{}\t{}\n",
+                result.street.get_osm_name(),
+                range_strings.len()
+            )
+            .as_bytes(),
         )?;
         // only_in_reference items.
         stream.write_all(format!("{:?}\n", range_strings).as_bytes())?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -218,7 +218,14 @@ pub struct HouseNumber {
 }
 
 pub type HouseNumbers = Vec<HouseNumber>;
-pub type NumberedStreet = (Street, HouseNumbers);
+
+/// A numbered street is a street with associated house numbers.
+#[derive(Clone, Debug)]
+pub struct NumberedStreet {
+    pub street: Street,
+    pub house_numbers: HouseNumbers,
+}
+
 pub type NumberedStreets = Vec<NumberedStreet>;
 
 impl HouseNumber {

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -855,3 +855,18 @@ fn test_house_number_debug() {
 
     assert_eq!(ret.starts_with("HouseNumber"), true);
 }
+
+/// Tests that NumberedStreet implements the Debug trait.
+#[test]
+fn test_numbered_street_debug() {
+    let street = Street::from_string("mystreet");
+    let house_numbers = Vec::new();
+    let numbered_street = NumberedStreet {
+        street,
+        house_numbers,
+    };
+
+    let ret = format!("{:?}", numbered_street);
+
+    assert_eq!(ret.starts_with("NumberedStreet"), true);
+}

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -193,8 +193,7 @@ fn missing_housenumbers_view_turbo(
     let (ongoing_streets, _done_streets) = relation.get_missing_housenumbers()?;
     let mut streets: Vec<String> = Vec::new();
     for result in ongoing_streets {
-        // Street name, # of only_in_reference items.
-        streets.push(result.0.get_osm_name().into());
+        streets.push(result.street.get_osm_name().into());
     }
     let query = areas::make_turbo_query_for_streets(&relation, &streets);
 
@@ -402,18 +401,17 @@ fn missing_housenumbers_view_chkl(
 
         let mut table: Vec<String> = Vec::new();
         for result in ongoing_streets {
-            let range_list = util::get_housenumber_ranges(&result.1);
-            // Street name, only_in_reference items.
+            let range_list = util::get_housenumber_ranges(&result.house_numbers);
             if !relation
                 .get_config()
-                .get_street_is_even_odd(result.0.get_osm_name())
+                .get_street_is_even_odd(result.street.get_osm_name())
             {
                 let mut result_sorted: Vec<String> =
                     range_list.iter().map(|i| i.get_number().into()).collect();
                 result_sorted.sort_by_key(|i| util::split_house_number(i));
                 let row = format!(
                     "[ ] {} [{}]",
-                    result.0.get_osm_name(),
+                    result.street.get_osm_name(),
                     result_sorted.join(", ")
                 );
                 table.push(row);
@@ -421,13 +419,13 @@ fn missing_housenumbers_view_chkl(
                 let elements = util::format_even_odd(&range_list);
                 if elements.len() > 1 && range_list.len() > 20 {
                     for element in elements {
-                        let row = format!("[ ] {} [{}]", result.0.get_osm_name(), element);
+                        let row = format!("[ ] {} [{}]", result.street.get_osm_name(), element);
                         table.push(row);
                     }
                 } else {
                     let row = format!(
                         "[ ] {} [{}]",
-                        result.0.get_osm_name(),
+                        result.street.get_osm_name(),
                         elements.join("], [")
                     );
                     table.push(row);


### PR DESCRIPTION
Because .street and .house_numbers is more readable than .0 and .1.

Change-Id: I5ea8737bbc064b70c97730d4cb3a217fc4fed86a
