### PR TITLE
sync-ref: switch from wget to curl

### DIFF
--- a/tools/sync-ref.sh
+++ b/tools/sync-ref.sh
@@ -20,7 +20,7 @@ mkdir refdir.new
 cd refdir.new
 for i in $refs
 do
-    wget --cipher 'DEFAULT:!DH' $1/$i
+    curl -O $1/$i
 done
 cd ..
 rm -rf refdir


### PR DESCRIPTION
wget needs a special option for me locally, but not on the server. curl
seems to work everywhere.

Change-Id: I393c30e3a0ec43fc2b3f898a6c8a9816161e87ec
