### PR TITLE
validator: remove redundant test_relation_filters_valid_bad_type()

### DIFF
--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -499,21 +499,6 @@ fn test_relation_filters_valid_bad2() {
     assert_failure_msg(content, expected);
 }
 
-/// Tests the relation path: bad type for the filters -> ... -> valid subkey.
-#[test]
-fn test_relation_filters_valid_bad_type() {
-    let content = r#"filters:
-  'Budaörsi út':
-    valid: "hello"
-"#;
-    let expected = r#"failed to validate {0}
-
-Caused by:
-    filters.Budaörsi út.valid: invalid type: string "hello", expected a sequence at line 3 column 12
-"#;
-    assert_failure_msg(content, expected);
-}
-
 /// Tests that we do not accept whitespace in the value of the 'start' key.
 #[test]
 fn test_start_whitespace() {


### PR DESCRIPTION
Serde checks this for us.

Change-Id: I183d6c1852f595169cf00c008c4966773ecbc092
