### PR TITLE
wsgi: add a /missing-housenumbers/.../view-result.json endpoint

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -1,5 +1,10 @@
 = Version descriptions
 
+== master
+
+- New `/osm/missing-housenumbers/.../view-result.json` endpoint, exposing the missing-housenumbers
+  analysis result for a relation in a machine-readable format.
+
 == 7.4
 
 - Ported to chartjs v3, the javascript bundle size is now about 20% smaller

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -290,6 +290,12 @@ git push origin master:private/$USER/master
   https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request[Enable
   auto-merge] button.
 
+=== Developer API
+
+In case the `/osm/missing-housenumbers/.../view-result` HTML output looks interesting to you and you
+would like to use that information in your application, no need to scrape the webpage, you can get
+the raw input of that analysis as `/osm/missing-housenumbers/.../view-result.json` instead.
+
 == Reporting issues
 
 You can file a new issue (bugreport, feature request) at https://github.com/vmiklos/osm-gimmisn/issues/new[GitHub]. Please always describe a single problem.

--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -76,6 +76,11 @@ impl RelationFiles {
         format!("{}/{}.txtcache", self.workdir, self.name)
     }
 
+    /// Builds the file name of the house number json cache file of a relation.
+    pub fn get_housenumbers_jsoncache_path(&self) -> String {
+        format!("{}/{}.cache.json", self.workdir, self.name)
+    }
+
     /// Builds the file name of the street percent file of a relation.
     pub fn get_streets_percent_path(&self) -> String {
         format!("{}/{}-streets.percent", self.workdir, self.name)

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -331,6 +331,8 @@ impl RelationConfig {
 }
 
 /// Return type of Relation::get_missing_housenumbers().
+#[derive(serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct MissingHousenumbers {
     pub ongoing_streets: util::NumberedStreets,
     pub done_streets: util::NumberedStreets,

--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -345,6 +345,53 @@ fn test_get_missing_housenumbers_txt() {
     assert_eq!(ret, "cached");
 }
 
+/// Tests get_missing_housenumbers_json(): the cached case.
+///
+/// The non-cached case is covered by higher level
+/// wsgi_json::tests::test_missing_housenumbers_view_result_json().
+#[test]
+fn test_get_missing_housenumbers_json() {
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let mut file_system = context::tests::TestFileSystem::new();
+    let yamls_cache = serde_json::json!({
+        "relations.yaml": {
+            "gazdagret": {
+                "osmrelation": 42,
+            },
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let json_cache_value = context::tests::TestFileSystem::make_file();
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[
+            ("data/yamls.cache", &yamls_cache_value),
+            ("workdir/gazdagret.cache.json", &json_cache_value),
+        ],
+    );
+    file_system.set_files(&files);
+    file_system
+        .write_from_string(
+            "{'cached':'yes'}",
+            &ctx.get_abspath("workdir/gazdagret.cache.json"),
+        )
+        .unwrap();
+    let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
+    mtimes.insert(
+        ctx.get_abspath("workdir/gazdagret.cache.json"),
+        Rc::new(RefCell::new(9999999999_f64)),
+    );
+    file_system.set_mtimes(&mtimes);
+    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+    ctx.set_file_system(&file_system_arc);
+    let mut relations = areas::Relations::new(&ctx).unwrap();
+    let mut relation = relations.get_relation("gazdagret").unwrap();
+
+    let ret = get_missing_housenumbers_json(&ctx, &mut relation).unwrap();
+
+    assert_eq!(ret, "{'cached':'yes'}");
+}
+
 /// Tests get_missing_housenumbers_html().
 #[test]
 fn test_get_missing_housenumbers_html() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -107,7 +107,8 @@ pub trait Diff {
 
 /// A street has an OSM and a reference name. Ideally the two are the same. Sometimes the reference
 /// name differs.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct Street {
     osm_name: String,
     ref_name: String,
@@ -210,7 +211,7 @@ impl Eq for Street {}
 /// A house number is a string which remembers what was its provider range.  E.g. the "1-3" string
 /// can generate 3 house numbers, all of them with the same range.
 /// The comment is similar to source, it's ignored during eq() and hash().
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct HouseNumber {
     number: String,
     source: String,
@@ -220,7 +221,8 @@ pub struct HouseNumber {
 pub type HouseNumbers = Vec<HouseNumber>;
 
 /// A numbered street is a street with associated house numbers.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct NumberedStreet {
     pub street: Street,
     pub house_numbers: HouseNumbers,


### PR DESCRIPTION
This is exposing the raw diff result, this is the input of the txt and
html outputs.

Also add caching for this, which can be a replacement for the current
txt and language-specific html caches.

Change-Id: Ie79b9d613e8c91166a2fea06775ed386db350748
