### PR TITLE
write_missing_housenumbers: use the new json cache

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -11,6 +11,7 @@
 //! The areas module contains the Relations class and associated functionality.
 
 use crate::area_files;
+use crate::cache;
 use crate::context;
 use crate::i18n::translate as tr;
 use crate::ranges;
@@ -1019,9 +1020,11 @@ impl Relation {
     pub fn write_missing_housenumbers(
         &mut self,
     ) -> anyhow::Result<(usize, usize, usize, f64, yattag::HtmlTable)> {
-        let missing_housenumbers = self
-            .get_missing_housenumbers()
-            .context("get_missing_housenumbers() failed")?;
+        // TODO avoid this clone()
+        let ctx = self.ctx.clone();
+
+        let json = cache::get_missing_housenumbers_json(&ctx, self)?;
+        let missing_housenumbers: MissingHousenumbers = serde_json::from_str(&json)?;
 
         let (table, todo_count) =
             self.numbered_streets_to_table(&missing_housenumbers.ongoing_streets);

--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -24,17 +24,23 @@ fn test_is_missing_housenumbers_html_cached() {
     let mut file_system = context::tests::TestFileSystem::new();
     let percent_value = context::tests::TestFileSystem::make_file();
     let html_cache_value = context::tests::TestFileSystem::make_file();
+    let json_cache_value = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
         &[
             ("workdir/gazdagret.percent", &percent_value),
             ("workdir/gazdagret.htmlcache.en", &html_cache_value),
+            ("workdir/gazdagret.cache.json", &json_cache_value),
         ],
     );
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
         ctx.get_abspath("workdir/gazdagret.htmlcache.en"),
+        Rc::new(RefCell::new(0_f64)),
+    );
+    mtimes.insert(
+        ctx.get_abspath("workdir/gazdagret.cache.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -246,6 +246,7 @@ fn test_update_missing_housenumbers() {
     let count_file2 = context::tests::TestFileSystem::make_file();
     let html_cache1 = context::tests::TestFileSystem::make_file();
     let html_cache2 = context::tests::TestFileSystem::make_file();
+    let json_cache = context::tests::TestFileSystem::make_file();
     let txt_cache = context::tests::TestFileSystem::make_file();
     let ref_housenumbers = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
@@ -256,6 +257,7 @@ fn test_update_missing_housenumbers() {
             ("workdir/ujbuda.percent", &count_file2),
             ("workdir/gazdagret.htmlcache.en", &html_cache1),
             ("workdir/gazdagret.htmlcache.hu", &html_cache2),
+            ("workdir/gazdagret.cache.json", &json_cache),
             ("workdir/gazdagret.txtcache", &txt_cache),
             (
                 "workdir/street-housenumbers-reference-gazdagret.lst",
@@ -280,6 +282,10 @@ fn test_update_missing_housenumbers() {
     );
     mtimes.insert(
         ctx.get_abspath("workdir/gazdagret.htmlcache.hu"),
+        Rc::new(RefCell::new(0_f64)),
+    );
+    mtimes.insert(
+        ctx.get_abspath("workdir/gazdagret.cache.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     mtimes.insert(
@@ -973,6 +979,7 @@ fn test_our_main() {
     let missing_housenumbers_txt = context::tests::TestFileSystem::make_file();
     let missing_housenumbers_html_en = context::tests::TestFileSystem::make_file();
     let missing_housenumbers_html_hu = context::tests::TestFileSystem::make_file();
+    let missing_housenumbers_json = context::tests::TestFileSystem::make_file();
     let template_value = context::tests::TestFileSystem::make_file();
     template_value
         .borrow_mut()
@@ -1024,6 +1031,7 @@ fn test_our_main() {
                 "workdir/gazdagret.htmlcache.hu",
                 &missing_housenumbers_html_hu,
             ),
+            ("workdir/gazdagret.cache.json", &missing_housenumbers_json),
             ("data/streets-template.txt", &template_value),
             ("data/street-housenumbers-template.txt", &housenr_template),
         ],
@@ -1034,6 +1042,8 @@ fn test_our_main() {
     let path = ctx.get_abspath("workdir/gazdagret.htmlcache.en");
     mtimes.insert(path.to_string(), Rc::new(RefCell::new(0_f64)));
     let path = ctx.get_abspath("workdir/gazdagret.htmlcache.hu");
+    mtimes.insert(path.to_string(), Rc::new(RefCell::new(0_f64)));
+    let path = ctx.get_abspath("workdir/gazdagret.cache.json");
     mtimes.insert(path.to_string(), Rc::new(RefCell::new(0_f64)));
     let path = ctx.get_abspath("workdir/gazdagret.txtcache");
     mtimes.insert(path.to_string(), Rc::new(RefCell::new(0_f64)));


### PR DESCRIPTION
Which means that the HTML cache can be removed in the future, since
write_missing_housenumbers() is no longer expensive. Includes:

- fix wsgi::tests::test_missing_housenumbers_well_formed
- fix wsgi::tests::test_missing_housenumbers_compat_relation
- fix wsgi::tests::test_missing_housenumbers_compat
- fix cron::tests::test_update_missing_housenumbers
- fix cache::tests::test_is_missing_housenumbers_html_cached
- fix areas::tests::test_relation_write_missing_housenumbers_sorting
- fix areas::tests::test_relation_write_missing_housenumbers_interpolation_all
- fix areas::tests::test_relation_write_missing_housenumbers_empty
- fix areas::tests::test_relation_write_missing_housenumbers

Change-Id: I35fed5a98e3632bfb7817d5b388d6b6e50ec7d85
