### PR TITLE
cache::get_missing_housenumbers_txt: use the new json cache

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -141,7 +141,9 @@ pub fn get_missing_housenumbers_txt(
         return Ok(output);
     }
 
-    let ongoing_streets = relation.get_missing_housenumbers()?.ongoing_streets;
+    let json = get_missing_housenumbers_json(ctx, relation)?;
+    let missing_housenumbers: areas::MissingHousenumbers = serde_json::from_str(&json)?;
+    let ongoing_streets = missing_housenumbers.ongoing_streets;
     let mut table: Vec<String> = Vec::new();
     for result in ongoing_streets {
         let range_list = util::get_housenumber_ranges(&result.house_numbers);

--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -74,17 +74,23 @@ fn test_is_missing_housenumbers_txt_cached() {
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
     let txt_cache_value = context::tests::TestFileSystem::make_file();
+    let json_cache_value = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
         &[
             ("data/yamls.cache", &yamls_cache_value),
             ("workdir/gazdagret.txtcache", &txt_cache_value),
+            ("workdir/gazdagret.cache.json", &json_cache_value),
         ],
     );
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
         ctx.get_abspath("workdir/gazdagret.txtcache"),
+        Rc::new(RefCell::new(0_f64)),
+    );
+    mtimes.insert(
+        ctx.get_abspath("workdir/gazdagret.cache.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -113,7 +113,7 @@ impl TestWsgi {
         let (mut reader, _size) = response.data.into_reader_and_size();
         reader.read_to_end(&mut data).unwrap();
         let output = String::from_utf8(data).unwrap();
-        // println!("get_txt_for_path: output is '{}'", output);
+        println!("get_txt_for_path: output is '{}'", output);
         // Make sure the built-in exception catcher is not kicking in.
         assert_eq!(response.status_code, 200);
         let mut headers_map = HashMap::new();
@@ -615,14 +615,22 @@ fn test_missing_housenumbers_view_result_txt() {
     let mut test_wsgi = TestWsgi::new();
     let mut file_system = context::tests::TestFileSystem::new();
     let txt_cache = context::tests::TestFileSystem::make_file();
+    let json_cache = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &test_wsgi.ctx,
-        &[("workdir/budafok.txtcache", &txt_cache)],
+        &[
+            ("workdir/budafok.txtcache", &txt_cache),
+            ("workdir/budafok.cache.json", &json_cache),
+        ],
     );
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
         test_wsgi.ctx.get_abspath("workdir/budafok.txtcache"),
+        Rc::new(RefCell::new(0_f64)),
+    );
+    mtimes.insert(
+        test_wsgi.ctx.get_abspath("workdir/budafok.cache.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);
@@ -656,17 +664,23 @@ fn test_missing_housenumbers_view_result_txt_even_odd() {
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
     let txt_cache_value = context::tests::TestFileSystem::make_file();
+    let json_cache_value = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &test_wsgi.ctx,
         &[
             ("data/yamls.cache", &yamls_cache_value),
             ("workdir/gazdagret.txtcache", &txt_cache_value),
+            ("workdir/gazdagret.cache.json", &json_cache_value),
         ],
     );
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
         test_wsgi.ctx.get_abspath("workdir/gazdagret.txtcache"),
+        Rc::new(RefCell::new(0_f64)),
+    );
+    mtimes.insert(
+        test_wsgi.ctx.get_abspath("workdir/gazdagret.cache.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);


### PR DESCRIPTION
Which means that the txt cache can be removed in the future, since
generating the text output is no longer expensive. Includes:

- fix wsgi::tests::test_missing_housenumbers_view_result_txt_even_odd
- fix cache::tests::test_is_missing_housenumbers_txt_cached
- fix wsgi::tests::test_missing_housenumbers_view_result_txt

Change-Id: I0afcb8127823b24473aed2269e7376abc45380d8
