### PR TITLE
wsgi: add a /additional-housenumbers/.../view-result.json endpoint

### DIFF
--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -292,9 +292,12 @@ git push origin master:private/$USER/master
 
 === Developer API
 
-In case the `/osm/missing-housenumbers/.../view-result` HTML output looks interesting to you and you
+In case the `/missing-housenumbers/.../view-result` HTML output looks interesting to you and you
 would like to use that information in your application, no need to scrape the webpage, you can get
-the raw input of that analysis as `/osm/missing-housenumbers/.../view-result.json` instead.
+the raw input of that analysis as `/missing-housenumbers/.../view-result.json` instead.
+
+Similarly, the `/additional-housenumbers/.../view-result` HTML output has a matching
+`/additional-housenumbers/.../view-result.json`.
 
 == Reporting issues
 

--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -66,6 +66,11 @@ impl RelationFiles {
         format!("{}/{}.cache.json", self.workdir, self.name)
     }
 
+    /// Builds the file name of the additional house number json cache file of a relation.
+    pub fn get_additional_housenumbers_jsoncache_path(&self) -> String {
+        format!("{}/additional-cache-{}.json", self.workdir, self.name)
+    }
+
     /// Builds the file name of the street percent file of a relation.
     pub fn get_streets_percent_path(&self) -> String {
         format!("{}/{}-streets.percent", self.workdir, self.name)

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1055,7 +1055,7 @@ impl Relation {
     /// Compares ref and osm house numbers, prints the ones which are in osm, but not in ref.
     /// Return value is a list of streets.
     /// Each of of these is a pair of a street name and a house number list.
-    fn get_additional_housenumbers(&mut self) -> anyhow::Result<util::NumberedStreets> {
+    pub fn get_additional_housenumbers(&mut self) -> anyhow::Result<util::NumberedStreets> {
         let mut additional = Vec::new();
 
         let osm_street_names = self.get_osm_streets(/*sorted_result=*/ true)?;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -150,5 +150,47 @@ pub fn get_missing_housenumbers_json(
     Ok(output)
 }
 
+/// Decides if we have an up to date additional json cache entry or not.
+fn is_additional_housenumbers_json_cached(
+    ctx: &context::Context,
+    relation: &areas::Relation,
+) -> anyhow::Result<bool> {
+    let cache_path = relation
+        .get_files()
+        .get_additional_housenumbers_jsoncache_path();
+    let datadir = ctx.get_abspath("data");
+    let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
+    let dependencies = vec![
+        relation.get_files().get_osm_streets_path(),
+        relation.get_files().get_osm_housenumbers_path(),
+        relation.get_files().get_ref_housenumbers_path(),
+        relation_path,
+    ];
+    is_cache_current(ctx, &cache_path, &dependencies)
+}
+
+/// Gets the cached json of the additional housenumbers for a relation.
+pub fn get_additional_housenumbers_json(
+    ctx: &context::Context,
+    relation: &mut areas::Relation,
+) -> anyhow::Result<String> {
+    let output: String;
+    if is_additional_housenumbers_json_cached(ctx, relation)? {
+        let files = relation.get_files();
+        output = ctx
+            .get_file_system()
+            .read_to_string(&files.get_additional_housenumbers_jsoncache_path())?;
+        return Ok(output);
+    }
+
+    let additional_housenumbers = relation.get_additional_housenumbers()?;
+    output = serde_json::to_string(&additional_housenumbers)?;
+
+    let files = relation.get_files();
+    ctx.get_file_system()
+        .write_from_string(&output, &files.get_additional_housenumbers_jsoncache_path())?;
+    Ok(output)
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -100,6 +100,53 @@ fn test_get_missing_housenumbers_json() {
     assert_eq!(ret, "{'cached':'yes'}");
 }
 
+/// Tests get_additional_housenumbers_json(): the cached case.
+///
+/// The non-cached case is covered by higher level
+/// wsgi_json::tests::test_additional_housenumbers_view_result_json().
+#[test]
+fn test_get_additional_housenumbers_json() {
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let mut file_system = context::tests::TestFileSystem::new();
+    let yamls_cache = serde_json::json!({
+        "relations.yaml": {
+            "gazdagret": {
+                "osmrelation": 42,
+            },
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let json_cache_value = context::tests::TestFileSystem::make_file();
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[
+            ("data/yamls.cache", &yamls_cache_value),
+            ("workdir/additional-cache-gazdagret.json", &json_cache_value),
+        ],
+    );
+    file_system.set_files(&files);
+    file_system
+        .write_from_string(
+            "{'cached':'yes'}",
+            &ctx.get_abspath("workdir/additional-cache-gazdagret.json"),
+        )
+        .unwrap();
+    let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
+    mtimes.insert(
+        ctx.get_abspath("workdir/additional-cache-gazdagret.json"),
+        Rc::new(RefCell::new(9999999999_f64)),
+    );
+    file_system.set_mtimes(&mtimes);
+    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
+    ctx.set_file_system(&file_system_arc);
+    let mut relations = areas::Relations::new(&ctx).unwrap();
+    let mut relation = relations.get_relation("gazdagret").unwrap();
+
+    let ret = get_additional_housenumbers_json(&ctx, &mut relation).unwrap();
+
+    assert_eq!(ret, "{'cached':'yes'}");
+}
+
 /// Tests is_cache_current()
 #[test]
 fn test_is_cache_current() {

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -138,6 +138,9 @@ impl TestWsgi {
         let mut data = Vec::new();
         let (mut reader, _size) = response.data.into_reader_and_size();
         reader.read_to_end(&mut data).unwrap();
+        assert_eq!(data.is_empty(), false);
+        let output = String::from_utf8(data).unwrap();
+        println!("get_json_for_path: output is '{}'", output);
         // Make sure the built-in exception catcher is not kicking in.
         assert_eq!(response.status_code, 200);
         let headers_map: HashMap<_, _> = response.headers.into_iter().collect();
@@ -145,9 +148,7 @@ impl TestWsgi {
             headers_map["Content-type"],
             "application/json; charset=utf-8"
         );
-        assert_eq!(data.is_empty(), false);
-        let value: serde_json::Value =
-            serde_json::from_str(&String::from_utf8(data).unwrap()).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&output).unwrap();
         value
     }
 

--- a/src/wsgi_json.rs
+++ b/src/wsgi_json.rs
@@ -94,6 +94,19 @@ fn missing_housenumbers_view_result_json(
     cache::get_missing_housenumbers_json(ctx, &mut relation)
 }
 
+/// Expected request_uri: e.g. /osm/additional-housenumbers/ormezo/view-result.json.
+fn additional_housenumbers_view_result_json(
+    ctx: &context::Context,
+    relations: &mut areas::Relations,
+    request_uri: &str,
+) -> anyhow::Result<String> {
+    let mut tokens = request_uri.split('/');
+    tokens.next_back();
+    let relation_name = tokens.next_back().context("short tokens")?;
+    let mut relation = relations.get_relation(relation_name)?;
+    cache::get_additional_housenumbers_json(ctx, &mut relation)
+}
+
 /// Expected request_uri: e.g. /osm/missing-streets/ormezo/update-result.json.
 fn missing_streets_update_result_json(
     ctx: &context::Context,
@@ -131,6 +144,9 @@ pub fn our_application_json(
             // Assume view-result.json.
             output = missing_housenumbers_view_result_json(ctx, relations, request_uri)?;
         }
+    } else if request_uri.starts_with(&format!("{}/additional-housenumbers/", prefix)) {
+        // Assume view-result.json.
+        output = additional_housenumbers_view_result_json(ctx, relations, request_uri)?;
     } else {
         // Assume that request_uri starts with prefix + "/missing-streets/".
         output = missing_streets_update_result_json(ctx, relations, request_uri)?;


### PR DESCRIPTION
This is exposing the raw diff result, this is the input of the html
output.

Also add caching for this, which can be a replacement for the current
language-specific html cache.

Change-Id: If84d187d21e26ab515932387330c781de3a5086a
