### PR TITLE
write_additional_housenumbers: use the new json cache

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1101,7 +1101,11 @@ impl Relation {
     pub fn write_additional_housenumbers(
         &mut self,
     ) -> anyhow::Result<(usize, usize, yattag::HtmlTable)> {
-        let ongoing_streets = self.get_additional_housenumbers()?;
+        // TODO avoid this clone()
+        let ctx = self.ctx.clone();
+
+        let json = cache::get_additional_housenumbers_json(&ctx, self)?;
+        let ongoing_streets: util::NumberedStreets = serde_json::from_str(&json)?;
 
         let (table, todo_count) = self.numbered_streets_to_table(&ongoing_streets);
 

--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -23,6 +23,7 @@ fn test_get_additional_housenumbers_html() {
     let mut ctx = context::tests::make_test_context().unwrap();
     let relation_count = context::tests::TestFileSystem::make_file();
     let relation_htmlcache = context::tests::TestFileSystem::make_file();
+    let relation_jsoncache = context::tests::TestFileSystem::make_file();
     let mut file_system = context::tests::TestFileSystem::new();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
@@ -35,11 +36,19 @@ fn test_get_additional_housenumbers_html() {
                 "workdir/gazdagret.additional-htmlcache.en",
                 &relation_htmlcache,
             ),
+            (
+                "workdir/additional-cache-gazdagret.json",
+                &relation_jsoncache,
+            ),
         ],
     );
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
         ctx.get_abspath("workdir/gazdagret.additional-htmlcache.en"),
+        Rc::new(RefCell::new(0_f64)),
+    );
+    mtimes.insert(
+        ctx.get_abspath("workdir/additional-cache-gazdagret.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_files(&files);

--- a/src/wsgi_additional/tests.rs
+++ b/src/wsgi_additional/tests.rs
@@ -203,6 +203,7 @@ fn test_additional_housenumbers_well_formed() {
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
     let count_value = context::tests::TestFileSystem::make_file();
     let cache_value = context::tests::TestFileSystem::make_file();
+    let jsoncache_value = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         test_wsgi.get_ctx(),
         &[
@@ -212,6 +213,7 @@ fn test_additional_housenumbers_well_formed() {
                 &count_value,
             ),
             ("workdir/gazdagret.additional-htmlcache.en", &cache_value),
+            ("workdir/additional-cache-gazdagret.json", &jsoncache_value),
         ],
     );
     file_system.set_files(&files);
@@ -220,6 +222,12 @@ fn test_additional_housenumbers_well_formed() {
         test_wsgi
             .get_ctx()
             .get_abspath("workdir/gazdagret.additional-htmlcache.en"),
+        Rc::new(RefCell::new(0_f64)),
+    );
+    mtimes.insert(
+        test_wsgi
+            .get_ctx()
+            .get_abspath("workdir/additional-cache-gazdagret.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);

--- a/src/wsgi_json/tests.rs
+++ b/src/wsgi_json/tests.rs
@@ -351,7 +351,6 @@ fn test_additional_housenumbers_view_result_json() {
     let result = test_wsgi.get_json_for_path("/additional-housenumbers/budafok/view-result.json");
 
     // The json equivalent of test_additional_housenumbers_well_formed().
-    let additional_housenumbers: Vec<util::NumberedStreet> =
-        serde_json::from_value(result).unwrap();
+    let additional_housenumbers: util::NumberedStreets = serde_json::from_value(result).unwrap();
     assert_eq!(additional_housenumbers.len(), 0);
 }


### PR DESCRIPTION
Which means that the HTML cache can be removed in the future, since
write_additional_housenumbers() is no longer expensive. Includes:

- fix cache::tests::test_get_additional_housenumbers_html
- fix wsgi_additional::tests::test_additional_housenumbers_well_formed

Change-Id: Ia1b57f34719f5eb053f64f5450979a0c8e26bb4f
