### PR TITLE
cache: remove no longer needed get_additional_housenumbers_html()

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -209,13 +209,4 @@ impl RelationFiles {
         let mut guard = write.borrow_mut();
         Ok(guard.write(result.as_bytes())?)
     }
-
-    /// Opens the additional house number HTML cache file of a relation for reading.
-    pub fn get_additional_housenumbers_htmlcache_read_stream(
-        &self,
-        ctx: &context::Context,
-    ) -> anyhow::Result<Rc<RefCell<dyn Read>>> {
-        let path = self.get_additional_housenumbers_htmlcache_path();
-        ctx.get_file_system().open_read(&path)
-    }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -12,9 +12,6 @@
 
 use crate::areas;
 use crate::context;
-use crate::i18n::translate as tr;
-use crate::util;
-use crate::yattag;
 
 /// Decides if we have an up to date cache entry or not.
 fn is_cache_current(
@@ -37,77 +34,6 @@ fn is_cache_current(
     }
 
     Ok(true)
-}
-
-/// Decides if we have an up to date HTML cache entry for additional house numbers or not.
-fn is_additional_housenumbers_html_cached(
-    ctx: &context::Context,
-    relation: &areas::Relation,
-) -> anyhow::Result<bool> {
-    let cache_path = relation
-        .get_files()
-        .get_additional_housenumbers_htmlcache_path();
-    let datadir = ctx.get_abspath("data");
-    let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
-    let dependencies = vec![
-        relation.get_files().get_osm_streets_path(),
-        relation.get_files().get_osm_housenumbers_path(),
-        relation.get_files().get_ref_housenumbers_path(),
-        relation_path,
-    ];
-    is_cache_current(ctx, &cache_path, &dependencies)
-}
-
-/// Gets the cached HTML of the additional housenumbers for a relation.
-pub fn get_additional_housenumbers_html(
-    ctx: &context::Context,
-    relation: &mut areas::Relation,
-) -> anyhow::Result<yattag::Doc> {
-    let doc = yattag::Doc::new();
-    if is_additional_housenumbers_html_cached(ctx, relation)? {
-        let files = relation.get_files();
-        let stream = files.get_additional_housenumbers_htmlcache_read_stream(ctx)?;
-        let mut guard = stream.borrow_mut();
-        let mut buffer: Vec<u8> = Vec::new();
-        guard.read_to_end(&mut buffer)?;
-        doc.append_value(String::from_utf8(buffer)?);
-        return Ok(doc);
-    }
-
-    let (todo_street_count, todo_count, table) = relation.write_additional_housenumbers()?;
-
-    {
-        let p = doc.tag("p", &[]);
-        p.text(
-            &tr("OpenStreetMap additionally has the below {0} house numbers for {1} streets.")
-                .replace("{0}", &todo_count.to_string())
-                .replace("{1}", &todo_street_count.to_string()),
-        );
-        doc.stag("br");
-        let a = doc.tag(
-            "a",
-            &[(
-                "href",
-                "https://github.com/vmiklos/osm-gimmisn/tree/master/doc",
-            )],
-        );
-        a.text(&tr("Filter incorrect information"));
-    }
-
-    doc.append_value(util::html_table_from_list(&table).get_value());
-    let (osm_invalids, ref_invalids) = relation.get_invalid_refstreets()?;
-    doc.append_value(util::invalid_refstreets_to_html(&osm_invalids, &ref_invalids).get_value());
-    doc.append_value(
-        util::invalid_filter_keys_to_html(&relation.get_invalid_filter_keys()?).get_value(),
-    );
-
-    let files = relation.get_files();
-    ctx.get_file_system().write_from_string(
-        &doc.get_value(),
-        &files.get_additional_housenumbers_htmlcache_path(),
-    )?;
-
-    Ok(doc)
 }
 
 /// Decides if we have an up to date json cache entry or not.

--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -17,51 +17,6 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
-/// Tests get_additional_housenumbers_html(): the case when we find the result in cache
-#[test]
-fn test_get_additional_housenumbers_html() {
-    let mut ctx = context::tests::make_test_context().unwrap();
-    let relation_count = context::tests::TestFileSystem::make_file();
-    let relation_htmlcache = context::tests::TestFileSystem::make_file();
-    let relation_jsoncache = context::tests::TestFileSystem::make_file();
-    let mut file_system = context::tests::TestFileSystem::new();
-    let files = context::tests::TestFileSystem::make_files(
-        &ctx,
-        &[
-            (
-                "workdir/gazdagret-additional-housenumbers.count",
-                &relation_count,
-            ),
-            (
-                "workdir/gazdagret.additional-htmlcache.en",
-                &relation_htmlcache,
-            ),
-            (
-                "workdir/additional-cache-gazdagret.json",
-                &relation_jsoncache,
-            ),
-        ],
-    );
-    let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
-    mtimes.insert(
-        ctx.get_abspath("workdir/gazdagret.additional-htmlcache.en"),
-        Rc::new(RefCell::new(0_f64)),
-    );
-    mtimes.insert(
-        ctx.get_abspath("workdir/additional-cache-gazdagret.json"),
-        Rc::new(RefCell::new(0_f64)),
-    );
-    file_system.set_files(&files);
-    file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
-    let mut relations = areas::Relations::new(&ctx).unwrap();
-    let mut relation = relations.get_relation("gazdagret").unwrap();
-    let first = get_additional_housenumbers_html(&ctx, &mut relation).unwrap();
-    let second = get_additional_housenumbers_html(&ctx, &mut relation).unwrap();
-    assert_eq!(first.get_value(), second.get_value());
-}
-
 /// Tests get_missing_housenumbers_json(): the cached case.
 ///
 /// The non-cached case is covered by higher level

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -68,4 +68,4 @@ pub fn translate(english: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests;
+pub mod tests;

--- a/src/i18n/tests.rs
+++ b/src/i18n/tests.rs
@@ -13,23 +13,31 @@
 use super::*;
 
 /// Context manager for translate().
-struct LanguageContext<'a> {
-    ctx: &'a context::Context,
-}
+struct LanguageContext {}
 
-impl<'a> LanguageContext<'a> {
+impl LanguageContext {
     /// Switches to the new language.
-    fn new(ctx: &'a context::Context, language: &str) -> Self {
+    fn new(ctx: &context::Context, language: &str) -> Self {
         set_language(ctx, language);
-        LanguageContext { ctx }
+        LanguageContext {}
     }
 }
 
-impl<'a> Drop for LanguageContext<'a> {
+impl<'a> Drop for LanguageContext {
     /// Switches back to the old language.
     fn drop(&mut self) {
-        set_language(self.ctx, "en");
+        reset_language();
     }
+}
+
+/// Resets the language.
+pub fn reset_language() {
+    LANGUAGE.with(|it| {
+        *it.borrow_mut() = None;
+    });
+    TRANSLATIONS.with(|it| {
+        *it.borrow_mut() = None;
+    });
 }
 
 /// Tests translate().
@@ -38,4 +46,12 @@ fn test_translate() {
     let ctx = context::tests::make_test_context().unwrap();
     let _lc = LanguageContext::new(&ctx, "hu");
     assert_eq!(translate("Area"), "Terület");
+}
+
+/// Tests get_language() when its value is None.
+#[test]
+fn test_get_language_none() {
+    reset_language();
+
+    assert_eq!(get_language(), "en");
 }


### PR DESCRIPTION
Because it used write_additional_housenumbers() internally, which
already uses the JSON cache. This way the locale-dependent HTML cache
can be removed.

Change-Id: Ia047b053e770e3d603bcf5f142bd2012dc948c13
