### PR TITLE
area_files: remove no longer needed get_additional_housenumbers_htmlcache_path()

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -11,7 +11,6 @@
 //! The area_files module contains file handling functionality, to be used by the areas module.
 
 use crate::context;
-use crate::i18n;
 use anyhow::Context;
 use std::cell::RefCell;
 use std::io::Read;
@@ -86,16 +85,6 @@ impl RelationFiles {
         format!(
             "{}/{}-additional-housenumbers.count",
             self.workdir, self.name
-        )
-    }
-
-    /// Builds the file name of the additional house number HTML cache file of a relation.
-    pub fn get_additional_housenumbers_htmlcache_path(&self) -> String {
-        format!(
-            "{}/{}.additional-htmlcache.{}",
-            self.workdir,
-            self.name,
-            i18n::get_language()
         )
     }
 

--- a/src/wsgi_additional.rs
+++ b/src/wsgi_additional.rs
@@ -198,7 +198,7 @@ pub fn additional_housenumbers_view_result(
     {
         doc = webframe::handle_no_ref_housenumbers(&prefix, relation_name);
     } else {
-        doc = additional_housenumbers_view_result_html(ctx, &mut relation)?;
+        doc = additional_housenumbers_view_result_html(&mut relation)?;
     }
     Ok(doc)
 }
@@ -224,7 +224,6 @@ pub fn additional_streets_view_turbo(
 
 /// The actual HTML part of additional_housenumbers_view_result().
 fn additional_housenumbers_view_result_html(
-    ctx: &context::Context,
     relation: &mut areas::Relation,
 ) -> anyhow::Result<yattag::Doc> {
     let doc = yattag::Doc::new();
@@ -254,12 +253,6 @@ fn additional_housenumbers_view_result_html(
     doc.append_value(
         util::invalid_filter_keys_to_html(&relation.get_invalid_filter_keys()?).get_value(),
     );
-
-    let files = relation.get_files();
-    ctx.get_file_system().write_from_string(
-        &doc.get_value(),
-        &files.get_additional_housenumbers_htmlcache_path(),
-    )?;
 
     Ok(doc)
 }

--- a/src/wsgi_additional/tests.rs
+++ b/src/wsgi_additional/tests.rs
@@ -203,7 +203,6 @@ fn test_additional_housenumbers_well_formed() {
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
     let count_value = context::tests::TestFileSystem::make_file();
     let cache_value = context::tests::TestFileSystem::make_file();
-    let jsoncache_value = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         test_wsgi.get_ctx(),
         &[
@@ -212,18 +211,11 @@ fn test_additional_housenumbers_well_formed() {
                 "workdir/gazdagret-additional-housenumbers.count",
                 &count_value,
             ),
-            ("workdir/gazdagret.additional-htmlcache.en", &cache_value),
-            ("workdir/additional-cache-gazdagret.json", &jsoncache_value),
+            ("workdir/additional-cache-gazdagret.json", &cache_value),
         ],
     );
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
-    mtimes.insert(
-        test_wsgi
-            .get_ctx()
-            .get_abspath("workdir/gazdagret.additional-htmlcache.en"),
-        Rc::new(RefCell::new(0_f64)),
-    );
     mtimes.insert(
         test_wsgi
             .get_ctx()


### PR DESCRIPTION
Which was the last trace of the locale-dependent cache.

Change-Id: Iff833b3ff771e32131f7655a00b3b8b4a9ee3df9
