### PR TITLE
area_files: fix inconsistent json cache name

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -62,7 +62,7 @@ impl RelationFiles {
 
     /// Builds the file name of the house number json cache file of a relation.
     pub fn get_housenumbers_jsoncache_path(&self) -> String {
-        format!("{}/{}.cache.json", self.workdir, self.name)
+        format!("{}/cache-{}.json", self.workdir, self.name)
     }
 
     /// Builds the file name of the additional house number json cache file of a relation.

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -1855,14 +1855,14 @@ fn test_relation_write_missing_housenumbers() {
         &[
             ("workdir/gazdagret.percent", &percent_value),
             ("data/yamls.cache", &yamls_cache_value),
-            ("workdir/gazdagret.cache.json", &json_value),
+            ("workdir/cache-gazdagret.json", &json_value),
         ],
     );
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
-        ctx.get_abspath("workdir/gazdagret.cache.json"),
+        ctx.get_abspath("workdir/cache-gazdagret.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);
@@ -1906,14 +1906,14 @@ fn test_relation_write_missing_housenumbers_empty() {
         &ctx,
         &[
             ("workdir/empty.percent", &percent_value),
-            ("workdir/empty.cache.json", &json_value),
+            ("workdir/cache-empty.json", &json_value),
         ],
     );
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
-        ctx.get_abspath("workdir/empty.cache.json"),
+        ctx.get_abspath("workdir/cache-empty.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);
@@ -1940,13 +1940,13 @@ fn test_relation_write_missing_housenumbers_interpolation_all() {
         &ctx,
         &[
             ("workdir/budafok.percent", &percent_value),
-            ("workdir/budafok.cache.json", &json_value),
+            ("workdir/cache-budafok.json", &json_value),
         ],
     );
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
-    let path = ctx.get_abspath("workdir/budafok.cache.json");
+    let path = ctx.get_abspath("workdir/cache-budafok.json");
     mtimes.insert(path.to_string(), Rc::new(RefCell::new(0_f64)));
     file_system.set_mtimes(&mtimes);
     let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -1984,14 +1984,14 @@ fn test_relation_write_missing_housenumbers_sorting() {
         &ctx,
         &[
             ("workdir/gh414.percent", &percent_value),
-            ("workdir/gh414.cache.json", &json_value),
+            ("workdir/cache-gh414.json", &json_value),
         ],
     );
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
-        ctx.get_abspath("workdir/gh414.cache.json"),
+        ctx.get_abspath("workdir/cache-gh414.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);

--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -38,19 +38,19 @@ fn test_get_missing_housenumbers_json() {
         &ctx,
         &[
             ("data/yamls.cache", &yamls_cache_value),
-            ("workdir/gazdagret.cache.json", &json_cache_value),
+            ("workdir/cache-gazdagret.json", &json_cache_value),
         ],
     );
     file_system.set_files(&files);
     file_system
         .write_from_string(
             "{'cached':'yes'}",
-            &ctx.get_abspath("workdir/gazdagret.cache.json"),
+            &ctx.get_abspath("workdir/cache-gazdagret.json"),
         )
         .unwrap();
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
-        ctx.get_abspath("workdir/gazdagret.cache.json"),
+        ctx.get_abspath("workdir/cache-gazdagret.json"),
         Rc::new(RefCell::new(9999999999_f64)),
     );
     file_system.set_mtimes(&mtimes);

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -252,7 +252,7 @@ fn test_update_missing_housenumbers() {
             ("data/yamls.cache", &yamls_cache_value),
             ("workdir/gazdagret.percent", &count_file1),
             ("workdir/ujbuda.percent", &count_file2),
-            ("workdir/gazdagret.cache.json", &json_cache),
+            ("workdir/cache-gazdagret.json", &json_cache),
             (
                 "workdir/street-housenumbers-reference-gazdagret.lst",
                 &ref_housenumbers,
@@ -271,7 +271,7 @@ fn test_update_missing_housenumbers() {
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(path1.to_string(), Rc::new(RefCell::new(0_f64)));
     mtimes.insert(
-        ctx.get_abspath("workdir/gazdagret.cache.json"),
+        ctx.get_abspath("workdir/cache-gazdagret.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);
@@ -994,7 +994,7 @@ fn test_our_main() {
                 "refdir/hazszamok_kieg_20190808.tsv-01-v1.cache",
                 &ref_housenumbers_extra_cache_value,
             ),
-            ("workdir/gazdagret.cache.json", &missing_housenumbers_json),
+            ("workdir/cache-gazdagret.json", &missing_housenumbers_json),
             ("data/streets-template.txt", &template_value),
             ("data/street-housenumbers-template.txt", &housenr_template),
         ],
@@ -1002,7 +1002,7 @@ fn test_our_main() {
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
-    let path = ctx.get_abspath("workdir/gazdagret.cache.json");
+    let path = ctx.get_abspath("workdir/cache-gazdagret.json");
     mtimes.insert(path.to_string(), Rc::new(RefCell::new(0_f64)));
     file_system.set_mtimes(&mtimes);
     let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -390,13 +390,13 @@ fn test_missing_housenumbers_well_formed() {
         &[
             ("data/yamls.cache", &yamls_cache_value),
             ("workdir/gazdagret.percent", &percent_value),
-            ("workdir/gazdagret.cache.json", &json_cache_value),
+            ("workdir/cache-gazdagret.json", &json_cache_value),
         ],
     );
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
-        test_wsgi.ctx.get_abspath("workdir/gazdagret.cache.json"),
+        test_wsgi.ctx.get_abspath("workdir/cache-gazdagret.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);
@@ -445,14 +445,14 @@ fn test_missing_housenumbers_compat() {
         &[
             ("data/yamls.cache", &yamls_cache_value),
             ("workdir/gazdagret.percent", &streets_value),
-            ("workdir/gazdagret.cache.json", &jsoncache_value),
+            ("workdir/cache-gazdagret.json", &jsoncache_value),
         ],
     );
     file_system.set_files(&files);
     // Make sure the cache is outdated.
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
-        test_wsgi.ctx.get_abspath("workdir/gazdagret.cache.json"),
+        test_wsgi.ctx.get_abspath("workdir/cache-gazdagret.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);
@@ -496,7 +496,7 @@ fn test_missing_housenumbers_compat_relation() {
         &test_wsgi.ctx,
         &[
             ("data/yamls.cache", &yamls_cache_value),
-            ("workdir/budafok.cache.json", &jsoncache_value),
+            ("workdir/cache-budafok.json", &jsoncache_value),
             ("workdir/budafok.percent", &percent_value),
         ],
     );
@@ -504,7 +504,7 @@ fn test_missing_housenumbers_compat_relation() {
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
-        test_wsgi.ctx.get_abspath("workdir/budafok.cache.json"),
+        test_wsgi.ctx.get_abspath("workdir/cache-budafok.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);
@@ -618,12 +618,12 @@ fn test_missing_housenumbers_view_result_txt() {
     let json_cache = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &test_wsgi.ctx,
-        &[("workdir/budafok.cache.json", &json_cache)],
+        &[("workdir/cache-budafok.json", &json_cache)],
     );
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
-        test_wsgi.ctx.get_abspath("workdir/budafok.cache.json"),
+        test_wsgi.ctx.get_abspath("workdir/cache-budafok.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);
@@ -664,13 +664,13 @@ fn test_missing_housenumbers_view_result_txt_even_odd() {
         &test_wsgi.ctx,
         &[
             ("data/yamls.cache", &yamls_cache_value),
-            ("workdir/gazdagret.cache.json", &json_cache_value),
+            ("workdir/cache-gazdagret.json", &json_cache_value),
         ],
     );
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
-        test_wsgi.ctx.get_abspath("workdir/gazdagret.cache.json"),
+        test_wsgi.ctx.get_abspath("workdir/cache-gazdagret.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);

--- a/src/wsgi_json/tests.rs
+++ b/src/wsgi_json/tests.rs
@@ -290,14 +290,14 @@ fn test_missing_housenumbers_view_result_json() {
     let json_cache = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &test_wsgi.get_ctx(),
-        &[("workdir/budafok.cache.json", &json_cache)],
+        &[("workdir/cache-budafok.json", &json_cache)],
     );
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<f64>>> = HashMap::new();
     mtimes.insert(
         test_wsgi
             .get_ctx()
-            .get_abspath("workdir/budafok.cache.json"),
+            .get_abspath("workdir/cache-budafok.json"),
         Rc::new(RefCell::new(0_f64)),
     );
     file_system.set_mtimes(&mtimes);


### PR DESCRIPTION
Previous naming format was:

- workdir/streets-budapest_11.csv or
- workdir/streets-reference-budapest_11.lst

cache-budapest_11.json fits this format better than
budapest_11.cache.json.

Change-Id: I93ce2477ba3be7570717dabe79582165548d9cfe
