### PR TITLE
config: make the uri_prefix key optional

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -85,3 +85,11 @@ This allows accessing your local instance for development.
 ----
 
 See `target/release/osm-gimmisn cron --help` for details on what switches are supported for that tool.
+
+== Custom configuration
+
+`wsgi.ini` contains the configuration. Common keys to be customized (showing the defaults):
+
+----
+uri_prefix = /osm
+----

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ check-unit: Cargo.toml $(RS_OBJECTS) locale/hu/LC_MESSAGES/osm-gimmisn.mo data/y
 	cargo llvm-cov --lib -q --ignore-filename-regex system.rs --show-missing-lines --fail-under-lines 100 ${CARGO_OPTIONS} -- --test-threads=1
 
 src/browser/config.ts: wsgi.ini Makefile
-	printf 'const uriPrefix = "%s";\nexport { uriPrefix };\n' $(shell grep prefix wsgi.ini |sed 's/uri_prefix = //') > $@
+	printf 'const uriPrefix = "%s";\nexport { uriPrefix };\n' $(shell (grep uri_prefix wsgi.ini || echo "/osm") |sed 's/uri_prefix = //') > $@
 
 ifdef TSDEBUG
 WEBPACK_OPTIONS = --mode=development --devtool inline-source-map

--- a/data/wsgi.ini.template
+++ b/data/wsgi.ini.template
@@ -3,7 +3,6 @@ reference_housenumbers = refdir/hazszamok_20221001.tsv refdir/hazszamok_kieg_202
 reference_street = refdir/utcak_20221015.tsv
 reference_citycounts = refdir/varosok_count_20221001.tsv
 reference_zipcounts = refdir/irsz_count_20221001.tsv
-uri_prefix = /osm
 tcp_port = 8000
 overpass_uri = https://z.overpass-api.de
 cron_update_inactive = False

--- a/src/context.rs
+++ b/src/context.rs
@@ -175,10 +175,8 @@ impl Ini {
     }
 
     /// Gets the global URI prefix.
-    pub fn get_uri_prefix(&self) -> anyhow::Result<String> {
-        self.config
-            .get("wsgi", "uri_prefix")
-            .context("no wsgi.uri_prefix in config")
+    pub fn get_uri_prefix(&self) -> String {
+        self.get_with_fallback("uri_prefix", "/osm")
     }
 
     fn get_with_fallback(&self, key: &str, fallback: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn rouille_app(request: &rouille::Request) -> rouille::Response {
 /// ProxyTimeout 120
 fn rouille_main(_: &[String], stream: &mut dyn Write, ctx: &osm_gimmisn::context::Context) -> i32 {
     let port = ctx.get_ini().get_tcp_port().unwrap();
-    let prefix = ctx.get_ini().get_uri_prefix().unwrap();
+    let prefix = ctx.get_ini().get_uri_prefix();
     writeln!(
         stream,
         "Starting the server at <http://127.0.0.1:{}{}/>.",

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -69,7 +69,7 @@ fn fill_header_function(
     items: &[yattag::Doc],
 ) -> anyhow::Result<Vec<yattag::Doc>> {
     let mut items: Vec<yattag::Doc> = items.to_vec();
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     if function == "missing-housenumbers" {
         // The OSM data source changes much more frequently than the ref one, so add a dedicated link
         // to update OSM house numbers first.
@@ -221,7 +221,7 @@ fn fill_missing_header_items(
     items: &[yattag::Doc],
 ) -> anyhow::Result<Vec<yattag::Doc>> {
     let mut items: Vec<yattag::Doc> = items.to_vec();
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     if streets != "only" {
         let doc = yattag::Doc::new();
         {
@@ -297,7 +297,7 @@ fn fill_existing_header_items(
     items: &[yattag::Doc],
 ) -> anyhow::Result<Vec<yattag::Doc>> {
     let mut items: Vec<yattag::Doc> = items.to_vec();
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     if streets != "only" {
         let doc = yattag::Doc::new();
         {
@@ -362,7 +362,7 @@ pub fn get_toolbar(
 
     let doc = yattag::Doc::new();
     {
-        let a = doc.tag("a", &[("href", &(ctx.get_ini().get_uri_prefix()? + "/"))]);
+        let a = doc.tag("a", &[("href", &(ctx.get_ini().get_uri_prefix() + "/"))]);
         a.text(&tr("Area list"))
     }
     items.push(doc);
@@ -422,7 +422,7 @@ pub fn get_toolbar(
                 "a",
                 &[(
                     "href",
-                    &(ctx.get_ini().get_uri_prefix()? + "/housenumber-stats/hungary/"),
+                    &(ctx.get_ini().get_uri_prefix() + "/housenumber-stats/hungary/"),
                 )],
             );
             a.text(&tr("Statistics"));
@@ -773,7 +773,7 @@ fn handle_invalid_refstreets(
         .get_value(),
     );
 
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     for relation in relations.get_relations()? {
         if !ctx
             .get_file_system()
@@ -842,7 +842,7 @@ pub fn handle_stats(
         .get_value(),
     );
 
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
 
     let string_pairs = &[
         (
@@ -1015,7 +1015,7 @@ pub fn get_request_uri(
 ) -> anyhow::Result<String> {
     let mut request_uri = request.url();
 
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     if !request_uri.is_empty() {
         // Compatibility.
         if request_uri.starts_with(&format!("{}/suspicious-streets/", prefix)) {
@@ -1053,7 +1053,7 @@ pub fn check_existing_relation(
     request_uri: &str,
 ) -> anyhow::Result<yattag::Doc> {
     let doc = yattag::Doc::new();
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     if !request_uri.starts_with(&format!("{}/streets/", prefix))
         && !request_uri.starts_with(&format!("{}/missing-streets/", prefix))
         && !request_uri.starts_with(&format!("{}/street-housenumbers/", prefix))

--- a/src/webframe/tests.rs
+++ b/src/webframe/tests.rs
@@ -36,7 +36,7 @@ fn test_handle_static() {
     let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
     ctx.set_file_system(&file_system_arc);
 
-    let prefix = ctx.get_ini().get_uri_prefix().unwrap();
+    let prefix = ctx.get_ini().get_uri_prefix();
     let (content, content_type, extra_headers) =
         handle_static(&ctx, &format!("{}/static/osm.min.css", prefix)).unwrap();
 
@@ -50,7 +50,7 @@ fn test_handle_static() {
 #[test]
 fn test_handle_static_generated_javascript() {
     let ctx = context::tests::make_test_context().unwrap();
-    let prefix = ctx.get_ini().get_uri_prefix().unwrap();
+    let prefix = ctx.get_ini().get_uri_prefix();
     let (content, content_type, extra_headers) =
         handle_static(&ctx, &format!("{}/static/bundle.js", prefix)).unwrap();
     assert_eq!("// bundle.js\n".as_bytes(), content);
@@ -63,7 +63,7 @@ fn test_handle_static_generated_javascript() {
 #[test]
 fn test_handle_static_json() {
     let ctx = context::tests::make_test_context().unwrap();
-    let prefix = ctx.get_ini().get_uri_prefix().unwrap();
+    let prefix = ctx.get_ini().get_uri_prefix();
     let (content, content_type, extra_headers) =
         handle_static(&ctx, &format!("{}/static/stats-empty.json", prefix)).unwrap();
     assert_eq!(content.starts_with(b"{"), true);
@@ -132,7 +132,7 @@ fn test_handle_static_svg() {
 #[test]
 fn test_handle_static_else() {
     let ctx = context::tests::make_test_context().unwrap();
-    let prefix = ctx.get_ini().get_uri_prefix().unwrap();
+    let prefix = ctx.get_ini().get_uri_prefix();
     let (content, content_type, extra_headers) =
         handle_static(&ctx, &format!("{}/static/test.xyz", prefix)).unwrap();
     assert_eq!(content.is_empty(), true);

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -67,7 +67,7 @@ fn handle_streets(
                 let streets = relation.get_config().should_check_missing_streets();
                 if streets != "only" {
                     doc.text(&tr("Update successful: "));
-                    let prefix = ctx.get_ini().get_uri_prefix()?;
+                    let prefix = ctx.get_ini().get_uri_prefix();
                     let link = format!(
                         "{}/missing-housenumbers/{}/view-result",
                         prefix, relation_name
@@ -133,7 +133,7 @@ fn handle_street_housenumbers(
         .get_value(),
     );
 
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     if action == "view-query" {
         let pre = doc.tag("pre", &[]);
         pre.text(&relation.get_osm_housenumbers_query()?);
@@ -214,10 +214,7 @@ fn missing_housenumbers_view_res_html(
 
     {
         let p = doc.tag("p", &[]);
-        let prefix = ctx
-            .get_ini()
-            .get_uri_prefix()
-            .context("get_uri_prefix() failed")?;
+        let prefix = ctx.get_ini().get_uri_prefix();
         let relation_name = relation.get_name();
         p.text(
             &tr("OpenStreetMap is possibly missing the below {0} house numbers for {1} streets.")
@@ -308,7 +305,7 @@ fn missing_housenumbers_view_res(
 
     let doc: yattag::Doc;
     let mut relation = relations.get_relation(relation_name)?;
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     if !ctx
         .get_file_system()
         .path_exists(&relation.get_files().get_osm_streets_path())
@@ -343,7 +340,7 @@ fn missing_streets_view_result(
     let relation = relations.get_relation(relation_name)?;
 
     let doc = yattag::Doc::new();
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     if !ctx
         .get_file_system()
         .path_exists(&relation.get_files().get_osm_streets_path())
@@ -617,7 +614,7 @@ fn missing_housenumbers_update(
     relation.write_ref_housenumbers(&references)?;
     let doc = yattag::Doc::new();
     doc.text(&tr("Update successful: "));
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     let link = format!(
         "{}/missing-housenumbers/{}/view-result",
         prefix, relation_name
@@ -879,7 +876,7 @@ fn handle_main_housenr_percent(
     ctx: &context::Context,
     relation: &areas::Relation,
 ) -> anyhow::Result<(yattag::Doc, f64)> {
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     let url = format!(
         "{}/missing-housenumbers/{}/view-result",
         prefix,
@@ -925,7 +922,7 @@ fn handle_main_street_percent(
     ctx: &context::Context,
     relation: &areas::Relation,
 ) -> anyhow::Result<(yattag::Doc, f64)> {
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     let url = format!(
         "{}/missing-streets/{}/view-result",
         prefix,
@@ -970,7 +967,7 @@ fn handle_main_street_additional_count(
     ctx: &context::Context,
     relation: &areas::Relation,
 ) -> anyhow::Result<yattag::Doc> {
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     let url = format!(
         "{}/additional-streets/{}/view-result",
         prefix,
@@ -1032,7 +1029,7 @@ pub fn handle_main_housenr_additional_count(
         return Ok(yattag::Doc::new());
     }
 
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     let url = format!(
         "{}/additional-housenumbers/{}/view-result",
         prefix,
@@ -1162,7 +1159,7 @@ fn handle_main_filters_refcounty(
         return Ok(doc);
     }
 
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     {
         let a = doc.tag(
             "a",
@@ -1220,7 +1217,7 @@ fn handle_main_filters(
     items.push(doc);
 
     doc = yattag::Doc::new();
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     {
         let a = doc.tag(
             "a",
@@ -1420,10 +1417,7 @@ fn get_html_title(request_uri: &str) -> String {
 
 /// Produces the <head> tag and its contents.
 fn write_html_head(ctx: &context::Context, doc: &yattag::Tag, title: &str) -> anyhow::Result<()> {
-    let prefix = ctx
-        .get_ini()
-        .get_uri_prefix()
-        .context("get_uri_prefix() failed")?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     let head = doc.tag("head", &[]);
     head.stag("meta", &[("charset", "UTF-8")]);
     head.stag(
@@ -1493,7 +1487,7 @@ fn our_application_txt(
 ) -> anyhow::Result<rouille::Response> {
     let mut content_type = "text/plain; charset=utf-8";
     let mut headers: webframe::Headers = Vec::new();
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     let mut chkl = false;
     let tokens: Vec<_> = request_uri.split('.').collect();
     if tokens.len() >= 2 {
@@ -1569,7 +1563,7 @@ lazy_static! {
 
 /// Decides request_uri matches what handler.
 fn get_handler(ctx: &context::Context, request_uri: &str) -> anyhow::Result<Option<Handler>> {
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     for (key, value) in HANDLERS.iter() {
         if request_uri.starts_with(&format!("{}{}", prefix, key)) {
             return Ok(Some(*value));
@@ -1599,10 +1593,7 @@ fn our_application(
         return our_application_txt(ctx, &mut relations, &request_uri);
     }
 
-    let prefix = ctx
-        .get_ini()
-        .get_uri_prefix()
-        .context("get_uri_prefix() failed")?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     if !(request_uri == "/" || request_uri.starts_with(&prefix)) {
         let doc = webframe::handle_404();
         return Ok(webframe::make_response(

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -64,7 +64,7 @@ impl TestWsgi {
 
     /// Generates an XML DOM for a given wsgi path.
     pub fn get_dom_for_path(&mut self, path: &str) -> sxd_document::Package {
-        let prefix = self.ctx.get_ini().get_uri_prefix().unwrap();
+        let prefix = self.ctx.get_ini().get_uri_prefix();
         let abspath: String;
         if self.absolute_path {
             abspath = path.into();
@@ -105,7 +105,7 @@ impl TestWsgi {
 
     /// Generates a string for a given wsgi path.
     pub fn get_txt_for_path(&mut self, path: &str) -> String {
-        let prefix = self.ctx.get_ini().get_uri_prefix().unwrap();
+        let prefix = self.ctx.get_ini().get_uri_prefix();
         let abspath = format!("{}{}", prefix, path);
         let request = rouille::Request::fake_http("GET", abspath, vec![], vec![]);
         let response = application(&request, &self.ctx);
@@ -131,7 +131,7 @@ impl TestWsgi {
 
     /// Generates an json value for a given wsgi path.
     pub fn get_json_for_path(&mut self, path: &str) -> serde_json::Value {
-        let prefix = self.ctx.get_ini().get_uri_prefix().unwrap();
+        let prefix = self.ctx.get_ini().get_uri_prefix();
         let abspath = format!("{}{}", prefix, path);
         let request = rouille::Request::fake_http("GET", abspath, vec![], vec![]);
         let response = application(&request, &self.ctx);
@@ -154,7 +154,7 @@ impl TestWsgi {
 
     /// Generates a CSS string for a given wsgi path.
     fn get_css_for_path(&mut self, path: &str) -> String {
-        let prefix = self.ctx.get_ini().get_uri_prefix().unwrap();
+        let prefix = self.ctx.get_ini().get_uri_prefix();
         let abspath = format!("{}{}", prefix, path);
         let request = rouille::Request::fake_http("GET", abspath, vec![], vec![]);
         let response = application(&request, &self.ctx);
@@ -1011,7 +1011,7 @@ fn test_missing_housenumbers_update_result_link() {
 
     let mut guard = housenumbers_value.borrow_mut();
     assert_eq!(guard.seek(SeekFrom::Current(0)).unwrap() > 0, true);
-    let prefix = test_wsgi.ctx.get_ini().get_uri_prefix().unwrap();
+    let prefix = test_wsgi.ctx.get_ini().get_uri_prefix();
     let results = TestWsgi::find_all(
         &root,
         &format!(
@@ -1045,7 +1045,7 @@ fn test_housenumbers_view_result_update_result_link() {
 
     let uri = format!(
         "{}/missing-housenumbers/gazdagret/view-result",
-        test_wsgi.ctx.get_ini().get_uri_prefix().unwrap()
+        test_wsgi.ctx.get_ini().get_uri_prefix()
     );
     let results = TestWsgi::find_all(
         &root,

--- a/src/wsgi_additional.rs
+++ b/src/wsgi_additional.rs
@@ -71,7 +71,7 @@ pub fn additional_streets_view_result(
     let relation = relations.get_relation(relation_name)?;
 
     let doc = yattag::Doc::new();
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     if !ctx
         .get_file_system()
         .path_exists(&relation.get_files().get_osm_streets_path())
@@ -181,7 +181,7 @@ pub fn additional_housenumbers_view_result(
     let mut relation = relations.get_relation(relation_name)?;
 
     let doc: yattag::Doc;
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     if !ctx
         .get_file_system()
         .path_exists(&relation.get_files().get_osm_streets_path())

--- a/src/wsgi_json.rs
+++ b/src/wsgi_json.rs
@@ -131,7 +131,7 @@ pub fn our_application_json(
     request_uri: &str,
 ) -> anyhow::Result<rouille::Response> {
     let mut headers: webframe::Headers = Vec::new();
-    let prefix = ctx.get_ini().get_uri_prefix()?;
+    let prefix = ctx.get_ini().get_uri_prefix();
     let output: String;
     if request_uri.starts_with(&format!("{}/streets/", prefix)) {
         output = streets_update_result_json(ctx, relations, request_uri)?;


### PR DESCRIPTION
Moving the default to code + documenting it is still simpler than all
these error handlings.

Change-Id: Ifff2ae5ca34a506a49d800c0ecac01459a9a7d0a
