### PR TITLE
cron: create state for new relations even if they are inactive

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -6,6 +6,7 @@
   analysis result for a relation in a machine-readable format.
 - New `/additional-housenumbers/.../view-result.json` endpoint, exposing the additional-housenumbers
   analysis result for a relation in a machine-readable format.
+- Resolves: gh#2592 cron now creates state for new, inactive relations
 
 == 7.4
 

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -597,6 +597,7 @@ pub fn our_main(
     let now = chrono::NaiveDateTime::from_timestamp(start, 0);
     let first_day_of_month = now.date().day() == 1;
     relations.activate_all(ctx.get_ini().get_cron_update_inactive() || first_day_of_month);
+    relations.activate_new();
     let refcounty = args.value_of("refcounty");
     relations.limit_to_refcounty(&refcounty)?;
     // Use map(), which handles optional values.


### PR DESCRIPTION
This is still cheap, since the 2nd iteration won't consider them new, so
it's a one-off cost.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/2592>.

Change-Id: I59e48de82e0e91eabec6ca8143e5f9a80c1ff970
