### PR TITLE
sync-ref subcommand: write what is the max version of the various references

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,11 @@ fn sync_ref_main(
     // Write config.
     let config_file = "data/wsgi.ini.template";
     std::fs::write(config_file, config.join("\n")).unwrap();
-    println!("Updated {} successfully.", config_file);
+    let max = files.iter().map(|(_k, v)| v).max().unwrap();
+    println!(
+        "Now you can run: git commit -m 'Update reference to {}'",
+        max
+    );
     0
 }
 


### PR DESCRIPTION
So I don't have to search for it manually.

Change-Id: Ic39fc58785c9d58daf93e435e77a4b9b319fd886
