### PR TITLE
write_missing_housenumbers: avoid cloning the context

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1016,10 +1016,7 @@ impl Relation {
     pub fn write_missing_housenumbers(
         &mut self,
     ) -> anyhow::Result<(usize, usize, usize, f64, yattag::HtmlTable)> {
-        // TODO avoid this clone()
-        let ctx = self.ctx.clone();
-
-        let json = cache::get_missing_housenumbers_json(&ctx, self)?;
+        let json = cache::get_missing_housenumbers_json(self)?;
         let missing_housenumbers: MissingHousenumbers = serde_json::from_str(&json)?;
 
         let (table, todo_count) =

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -51,25 +51,24 @@ fn is_missing_housenumbers_json_cached(relation: &mut areas::Relation) -> anyhow
 }
 
 /// Gets the cached json of the missing housenumbers for a relation.
-pub fn get_missing_housenumbers_json(
-    ctx: &context::Context,
-    relation: &mut areas::Relation,
-) -> anyhow::Result<String> {
+pub fn get_missing_housenumbers_json(relation: &mut areas::Relation) -> anyhow::Result<String> {
     let output: String;
+    let jsoncache_path = relation.get_files().get_housenumbers_jsoncache_path();
     if is_missing_housenumbers_json_cached(relation)? {
-        let files = relation.get_files();
-        output = ctx
+        output = relation
+            .get_ctx()
             .get_file_system()
-            .read_to_string(&files.get_housenumbers_jsoncache_path())?;
+            .read_to_string(&jsoncache_path)?;
         return Ok(output);
     }
 
     let missing_housenumbers = relation.get_missing_housenumbers()?;
     output = serde_json::to_string(&missing_housenumbers)?;
 
-    let files = relation.get_files();
-    ctx.get_file_system()
-        .write_from_string(&output, &files.get_housenumbers_jsoncache_path())?;
+    relation
+        .get_ctx()
+        .get_file_system()
+        .write_from_string(&output, &jsoncache_path)?;
     Ok(output)
 }
 

--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -59,7 +59,7 @@ fn test_get_missing_housenumbers_json() {
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let mut relation = relations.get_relation("gazdagret").unwrap();
 
-    let ret = get_missing_housenumbers_json(&ctx, &mut relation).unwrap();
+    let ret = get_missing_housenumbers_json(&mut relation).unwrap();
 
     assert_eq!(ret, "{'cached':'yes'}");
 }

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -459,7 +459,7 @@ fn missing_housenumbers_view_txt(
         return Ok(tr("No reference house numbers"));
     }
 
-    let json = cache::get_missing_housenumbers_json(ctx, &mut relation)?;
+    let json = cache::get_missing_housenumbers_json(&mut relation)?;
     let missing_housenumbers: areas::MissingHousenumbers = serde_json::from_str(&json)?;
     let ongoing_streets = missing_housenumbers.ongoing_streets;
     let mut table: Vec<String> = Vec::new();

--- a/src/wsgi_json.rs
+++ b/src/wsgi_json.rs
@@ -83,7 +83,6 @@ fn missing_housenumbers_update_result_json(
 
 /// Expected request_uri: e.g. /osm/missing-housenumbers/ormezo/view-result.json.
 fn missing_housenumbers_view_result_json(
-    ctx: &context::Context,
     relations: &mut areas::Relations,
     request_uri: &str,
 ) -> anyhow::Result<String> {
@@ -91,7 +90,7 @@ fn missing_housenumbers_view_result_json(
     tokens.next_back();
     let relation_name = tokens.next_back().context("short tokens")?;
     let mut relation = relations.get_relation(relation_name)?;
-    cache::get_missing_housenumbers_json(ctx, &mut relation)
+    cache::get_missing_housenumbers_json(&mut relation)
 }
 
 /// Expected request_uri: e.g. /osm/additional-housenumbers/ormezo/view-result.json.
@@ -142,7 +141,7 @@ pub fn our_application_json(
             output = missing_housenumbers_update_result_json(ctx, relations, request_uri)?;
         } else {
             // Assume view-result.json.
-            output = missing_housenumbers_view_result_json(ctx, relations, request_uri)?;
+            output = missing_housenumbers_view_result_json(relations, request_uri)?;
         }
     } else if request_uri.starts_with(&format!("{}/additional-housenumbers/", prefix)) {
         // Assume view-result.json.


### PR DESCRIPTION
It's less code to use Relation.get_ctx().

Change-Id: Ifa22051c5dc66da71cfa3d0cbf4662b0526737ad
