### PR TITLE
is_additional_housenumbers_json_cached: no need to take both a ctx and a relation

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -73,14 +73,11 @@ pub fn get_missing_housenumbers_json(relation: &mut areas::Relation) -> anyhow::
 }
 
 /// Decides if we have an up to date additional json cache entry or not.
-fn is_additional_housenumbers_json_cached(
-    ctx: &context::Context,
-    relation: &areas::Relation,
-) -> anyhow::Result<bool> {
+fn is_additional_housenumbers_json_cached(relation: &mut areas::Relation) -> anyhow::Result<bool> {
     let cache_path = relation
         .get_files()
         .get_additional_housenumbers_jsoncache_path();
-    let datadir = ctx.get_abspath("data");
+    let datadir = relation.get_ctx().get_abspath("data");
     let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
     let dependencies = vec![
         relation.get_files().get_osm_streets_path(),
@@ -88,7 +85,7 @@ fn is_additional_housenumbers_json_cached(
         relation.get_files().get_ref_housenumbers_path(),
         relation_path,
     ];
-    is_cache_current(ctx, &cache_path, &dependencies)
+    is_cache_current(relation.get_ctx(), &cache_path, &dependencies)
 }
 
 /// Gets the cached json of the additional housenumbers for a relation.
@@ -97,7 +94,7 @@ pub fn get_additional_housenumbers_json(
     relation: &mut areas::Relation,
 ) -> anyhow::Result<String> {
     let output: String;
-    if is_additional_housenumbers_json_cached(ctx, relation)? {
+    if is_additional_housenumbers_json_cached(relation)? {
         let files = relation.get_files();
         output = ctx
             .get_file_system()


### PR DESCRIPTION
A Relation already has a Context.

Change-Id: I84d20ac55c67835093b6c34dcd8813c169873830
