### PR TITLE
write_additional_housenumbers: avoid cloning the context

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1098,10 +1098,7 @@ impl Relation {
     pub fn write_additional_housenumbers(
         &mut self,
     ) -> anyhow::Result<(usize, usize, yattag::HtmlTable)> {
-        // TODO avoid this clone()
-        let ctx = self.ctx.clone();
-
-        let json = cache::get_additional_housenumbers_json(&ctx, self)?;
+        let json = cache::get_additional_housenumbers_json(self)?;
         let ongoing_streets: util::NumberedStreets = serde_json::from_str(&json)?;
 
         let (table, todo_count) = self.numbered_streets_to_table(&ongoing_streets);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -89,25 +89,26 @@ fn is_additional_housenumbers_json_cached(relation: &mut areas::Relation) -> any
 }
 
 /// Gets the cached json of the additional housenumbers for a relation.
-pub fn get_additional_housenumbers_json(
-    ctx: &context::Context,
-    relation: &mut areas::Relation,
-) -> anyhow::Result<String> {
+pub fn get_additional_housenumbers_json(relation: &mut areas::Relation) -> anyhow::Result<String> {
     let output: String;
+    let jsoncache_path = relation
+        .get_files()
+        .get_additional_housenumbers_jsoncache_path();
     if is_additional_housenumbers_json_cached(relation)? {
-        let files = relation.get_files();
-        output = ctx
+        output = relation
+            .get_ctx()
             .get_file_system()
-            .read_to_string(&files.get_additional_housenumbers_jsoncache_path())?;
+            .read_to_string(&jsoncache_path)?;
         return Ok(output);
     }
 
     let additional_housenumbers = relation.get_additional_housenumbers()?;
     output = serde_json::to_string(&additional_housenumbers)?;
 
-    let files = relation.get_files();
-    ctx.get_file_system()
-        .write_from_string(&output, &files.get_additional_housenumbers_jsoncache_path())?;
+    relation
+        .get_ctx()
+        .get_file_system()
+        .write_from_string(&output, &jsoncache_path)?;
     Ok(output)
 }
 

--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -106,7 +106,7 @@ fn test_get_additional_housenumbers_json() {
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let mut relation = relations.get_relation("gazdagret").unwrap();
 
-    let ret = get_additional_housenumbers_json(&ctx, &mut relation).unwrap();
+    let ret = get_additional_housenumbers_json(&mut relation).unwrap();
 
     assert_eq!(ret, "{'cached':'yes'}");
 }

--- a/src/wsgi_json.rs
+++ b/src/wsgi_json.rs
@@ -95,7 +95,6 @@ fn missing_housenumbers_view_result_json(
 
 /// Expected request_uri: e.g. /osm/additional-housenumbers/ormezo/view-result.json.
 fn additional_housenumbers_view_result_json(
-    ctx: &context::Context,
     relations: &mut areas::Relations,
     request_uri: &str,
 ) -> anyhow::Result<String> {
@@ -103,7 +102,7 @@ fn additional_housenumbers_view_result_json(
     tokens.next_back();
     let relation_name = tokens.next_back().context("short tokens")?;
     let mut relation = relations.get_relation(relation_name)?;
-    cache::get_additional_housenumbers_json(ctx, &mut relation)
+    cache::get_additional_housenumbers_json(&mut relation)
 }
 
 /// Expected request_uri: e.g. /osm/missing-streets/ormezo/update-result.json.
@@ -145,7 +144,7 @@ pub fn our_application_json(
         }
     } else if request_uri.starts_with(&format!("{}/additional-housenumbers/", prefix)) {
         // Assume view-result.json.
-        output = additional_housenumbers_view_result_json(ctx, relations, request_uri)?;
+        output = additional_housenumbers_view_result_json(relations, request_uri)?;
     } else {
         // Assume that request_uri starts with prefix + "/missing-streets/".
         output = missing_streets_update_result_json(ctx, relations, request_uri)?;


### PR DESCRIPTION
It's less code to use Relation.get_ctx().

Change-Id: Ib08144f2b4308e76a1cc3f1448ae85b027fced52
