### PR TITLE
cron: fix default of the --no-update and --no-overpass switches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 accept-language = "2.0.0"
 anyhow = "1.0.66"
-chrono = "0.4.22"
+chrono = "=0.4.22"
 clap = "=4.0.18"
 configparser = "3.0.2"
 csv = "1.1.6"

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -601,8 +601,8 @@ pub fn our_main(
     // Use map(), which handles optional values.
     let refsettlement: Option<&String> = args.get_one("refsettlement");
     relations.limit_to_refsettlement(&refsettlement)?;
-    let update = !args.contains_id("no-update");
-    let overpass = !args.contains_id("no-overpass");
+    let update = !args.get_one::<bool>("no-update").unwrap();
+    let overpass = !args.get_one::<bool>("no-overpass").unwrap();
     our_main_inner(
         ctx,
         &mut relations,


### PR DESCRIPTION
These are meant to be off by default, i.e. update and overpass are true
by default.

Regression from commit 651b191f732f3030fc2fc05b144676cbbee1331f (Clean
up tcp_port from wsgi.ini.template, 2022-10-24).

Change-Id: Ice94d133febf409d9cd467329816061f53c67c05
