### PR TITLE
sync-ref: switch arg parsing to clap

### DIFF
--- a/src/sync_ref/tests.rs
+++ b/src/sync_ref/tests.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 fn test_main() {
     let argv = vec![
         "".to_string(),
+        "--url".to_string(),
         "https://www.example.com/osm/data/".to_string(),
     ];
     let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());


### PR DESCRIPTION
Towards adding a --mode switch: so one can choose between updating the
config (current behavior) and downloading the references (new mode).

Change-Id: I521a9252ba61867d22040c4c17323e14719a2c16
