### PR TITLE
CI: remove no longer needed locale-gen

### DIFF
--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -11,7 +11,6 @@
 
 if [ -n "${GITHUB_WORKFLOW}" ]; then
     sudo apt-get install tzdata locales
-    sudo locale-gen hu_HU.UTF-8
 
     sudo apt-get install gettext
 


### PR DESCRIPTION
We use icu for this today.

Change-Id: Idb61c5acecb6c403768c9d361250335e069a84ee
