### PR TITLE
webframe: test get_toolbar()

### DIFF
--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -354,10 +354,12 @@ pub fn get_toolbar(
 
     let mut streets: String = "".into();
     let mut additional_housenumbers = false;
-    if relations.is_some() && !relation_name.is_empty() {
-        let relation = relations.unwrap().get_relation(relation_name)?;
-        streets = relation.get_config().should_check_missing_streets();
-        additional_housenumbers = relation.get_config().should_check_additional_housenumbers();
+    if let Some(relations) = relations {
+        if !relation_name.is_empty() {
+            let relation = relations.get_relation(relation_name)?;
+            streets = relation.get_config().should_check_missing_streets();
+            additional_housenumbers = relation.get_config().should_check_additional_housenumbers();
+        }
     }
 
     let doc = yattag::Doc::new();

--- a/src/webframe/tests.rs
+++ b/src/webframe/tests.rs
@@ -185,3 +185,13 @@ fn test_handle_error() {
     let output = String::from_utf8(data).unwrap();
     assert_eq!(output.contains("TestError"), true);
 }
+
+/// Tests get_toolbar().
+#[test]
+fn test_get_toolbar() {
+    let ctx = context::tests::make_test_context().unwrap();
+
+    let ret = get_toolbar(&ctx, None, "myfunc", "myrel", 42).unwrap();
+
+    assert_eq!(ret.get_value().is_empty(), false);
+}


### PR DESCRIPTION
The case when it gets no relations.

Also turn an `is_some()` + `unwrap()` combo into a nicer `if let
Some(...)` syntax.

Change-Id: I1c7620f5572d227ef21582cd0203f2b67b603b8e
