### PR TITLE
webframe: static handling: fail nicer when there is no / in path

### DIFF
--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -467,7 +467,7 @@ pub fn handle_static(
     request_uri: &str,
 ) -> anyhow::Result<(Vec<u8>, String, Headers)> {
     let mut tokens = request_uri.split('/');
-    let path = tokens.next_back().unwrap();
+    let path = tokens.next_back().context("next_back() failed")?;
     let extra_headers = Vec::new();
 
     if request_uri.ends_with(".js") {


### PR DESCRIPTION
Even though this should not happen, since handle_static() is only called
with static/foo as argument.

Change-Id: Ie10381d47fac0936f4083aa3dc3b9b83ad8f8dc9
