### PR TITLE
yattag: rework to avoid unwrap()

### DIFF
--- a/src/yattag.rs
+++ b/src/yattag.rs
@@ -83,11 +83,11 @@ pub struct Tag {
 impl Tag {
     fn new(value: &Rc<RefCell<String>>, name: &str, attrs: &[(&str, &str)]) -> Tag {
         let mut guard = value.borrow_mut();
-        write!(guard, "<{}", name).unwrap();
+        guard.push_str(&format!("<{}", name));
         for attr in attrs {
             let key = attr.0;
             let val = html_escape::encode_double_quoted_attribute(&attr.1);
-            write!(guard, " {}=\"{}\"", key, val).unwrap();
+            guard.push_str(&format!(" {}=\"{}\"", key, val));
         }
         guard.push('>');
         let value = value.clone();


### PR DESCRIPTION
push_str() and format() does the same, but those know that string append
won't fail in practice.

Change-Id: Ib078d14c0fe3b1199fd4be603f1806b1a8f9346a
