### PR TITLE
get_sort_key: simplify error handling

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -292,7 +292,7 @@ fn write_city_count_path(
     let stream = ctx.get_file_system().open_write(city_count_path)?;
     let mut guard = stream.borrow_mut();
     let mut cities: Vec<_> = cities.iter().map(|(key, value)| (key, value)).collect();
-    cities.sort_by_key(|(key, _value)| util::get_sort_key(key).unwrap());
+    cities.sort_by_key(|(key, _value)| util::get_sort_key(key));
     cities.dedup();
     // Locale-aware sort, by key.
     for (key, value) in cities {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1128,20 +1128,20 @@ pub fn get_city_key(
 
 /// Returns a string comparator which allows locale-aware lexical sorting.
 #[cfg(feature = "icu")]
-pub fn get_sort_key(bytes: &str) -> anyhow::Result<Vec<u8>> {
+pub fn get_sort_key(bytes: &str) -> Vec<u8> {
     use rust_icu_ucol as ucol;
     use rust_icu_ustring as ustring;
 
     // This is good enough for now, English and Hungarian is all we support and this handles both.
-    let collator = ucol::UCollator::try_from("hu")?;
-    let string = ustring::UChar::try_from(bytes)?;
-    Ok(collator.get_sort_key(&string))
+    let collator = ucol::UCollator::try_from("hu").expect("UCollator::try_from() failed");
+    let string = ustring::UChar::try_from(bytes).expect("UChar::try_from() failed");
+    collator.get_sort_key(&string)
 }
 
 /// Returns the intput as-is to avoid depending on ICU.
 #[cfg(not(feature = "icu"))]
-pub fn get_sort_key(bytes: &str) -> anyhow::Result<Vec<u8>> {
-    Ok(bytes.as_bytes().to_vec())
+pub fn get_sort_key(bytes: &str) -> Vec<u8> {
+    bytes.as_bytes().to_vec()
 }
 
 /// Builds a set of valid settlement names.

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -768,7 +768,7 @@ fn test_get_timestamp_no_such_file() {
 fn test_get_lexical_sort_key() {
     // This is less naive than the classic "a, "á", "b", "c" list.
     let mut strings = vec!["Kőpor", "Kórház"];
-    strings.sort_by_key(|i| get_sort_key(i).unwrap());
+    strings.sort_by_key(|i| get_sort_key(i));
     assert_eq!(strings, ["Kórház", "Kőpor"]);
 }
 

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -616,7 +616,7 @@ fn handle_stats_cityprogress(
         .collect();
     let in_both = util::get_in_both(&ref_cities, &osm_cities);
     let mut cities: Vec<_> = in_both.iter().map(|i| i.get_osm_name()).collect();
-    cities.sort_by_key(|i| util::get_sort_key(i).unwrap());
+    cities.sort_by_key(|i| util::get_sort_key(i));
     let mut table: Vec<Vec<yattag::Doc>> = vec![vec![
         yattag::Doc::from_text(&tr("City name")),
         yattag::Doc::from_text(&tr("House number coverage")),
@@ -717,7 +717,7 @@ fn handle_stats_zipprogress(
         .collect();
     let in_both = util::get_in_both(&ref_zips, &osm_zips);
     let mut zips: Vec<_> = in_both.iter().map(|i| i.get_osm_name()).collect();
-    zips.sort_by_key(|i| util::get_sort_key(i).unwrap());
+    zips.sort_by_key(|i| util::get_sort_key(i));
     let mut table: Vec<Vec<yattag::Doc>> = vec![vec![
         yattag::Doc::from_text(&tr("ZIP code")),
         yattag::Doc::from_text(&tr("House number coverage")),

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -358,7 +358,7 @@ fn missing_streets_view_result(
     }
 
     let (todo_count, done_count, percent, mut streets) = relation.write_missing_streets()?;
-    streets.sort_by_key(|i| util::get_sort_key(i).unwrap());
+    streets.sort_by_key(|i| util::get_sort_key(i));
     let mut table = vec![vec![yattag::Doc::from_text(&tr("Street name"))]];
     for street in streets {
         table.push(vec![yattag::Doc::from_text(&street)]);
@@ -490,7 +490,7 @@ fn missing_housenumbers_view_txt(
         };
         table.push(row);
     }
-    table.sort_by_key(|i| util::get_sort_key(i).unwrap());
+    table.sort_by_key(|i| util::get_sort_key(i));
     let output = table.join("\n");
     Ok(output)
 }
@@ -558,7 +558,7 @@ fn missing_housenumbers_view_chkl(
                 }
             }
         }
-        table.sort_by_key(|i| util::get_sort_key(i).unwrap());
+        table.sort_by_key(|i| util::get_sort_key(i));
         output = table.join("\n");
     }
     Ok((output, relation_name.into()))
@@ -589,7 +589,7 @@ fn missing_streets_view_txt(
         output = tr("No reference streets");
     } else {
         let (mut todo_streets, _) = relation.get_missing_streets()?;
-        todo_streets.sort_by_key(|i| util::get_sort_key(i).unwrap());
+        todo_streets.sort_by_key(|i| util::get_sort_key(i));
         let mut lines: Vec<String> = Vec::new();
         for street in todo_streets {
             if chkl {

--- a/src/wsgi_additional.rs
+++ b/src/wsgi_additional.rs
@@ -45,7 +45,7 @@ pub fn additional_streets_view_txt(
         output = tr("No reference streets");
     } else {
         let mut streets = relation.get_additional_streets(/*sorted_result=*/ true)?;
-        streets.sort_by_key(|street| util::get_sort_key(street.get_osm_name()).unwrap());
+        streets.sort_by_key(|street| util::get_sort_key(street.get_osm_name()));
         let mut lines: Vec<String> = Vec::new();
         for street in streets {
             if chkl {
@@ -86,7 +86,7 @@ pub fn additional_streets_view_result(
         // Get "only in OSM" streets.
         let mut streets = relation.write_additional_streets()?;
         let count = streets.len();
-        streets.sort_by_key(|street| util::get_sort_key(street.get_osm_name()).unwrap());
+        streets.sort_by_key(|street| util::get_sort_key(street.get_osm_name()));
         let mut table = vec![vec![
             yattag::Doc::from_text(&tr("Identifier")),
             yattag::Doc::from_text(&tr("Type")),


### PR DESCRIPTION
The root of the problem is that we compare unicode strings with icu,
where API calls can fail, but rust wants a comparator that never fails.

This was solved by adding unwrap() around all uses of get_sort_key(),
but this is ugly.

Instead, it turns out that ucol::UCollator::try_from() ~never fails in
practice (even if you pass garbage to it) and we know that the input
string is valid utf8 (comes from Rust), so ustring::UChar::try_from()
won't fail in our case, either.

This means we can just use expect() around those two calls and then
get_sort_key() never fails, matching the expectations from Rust.

Change-Id: I157de8619e4c2686ac9023dc0f08ad81818314e7
