### PR TITLE
wsgi: improve error handling in get_last_modified()

### DIFF
--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -28,13 +28,13 @@ use std::ops::DerefMut;
 use std::sync::Arc;
 
 /// Gets the update date string of a file.
-fn get_last_modified(ctx: &context::Context, path: &str) -> String {
-    webframe::format_timestamp(util::get_timestamp(ctx, path) as i64).unwrap()
+fn get_last_modified(ctx: &context::Context, path: &str) -> anyhow::Result<String> {
+    webframe::format_timestamp(util::get_timestamp(ctx, path) as i64)
 }
 
 /// Gets the update date of streets for a relation.
 fn get_streets_last_modified(ctx: &context::Context, relation: &areas::Relation) -> String {
-    get_last_modified(ctx, &relation.get_files().get_osm_streets_path())
+    get_last_modified(ctx, &relation.get_files().get_osm_streets_path()).unwrap()
 }
 
 /// Expected request_uri: e.g. /osm/streets/ormezo/view-query.
@@ -102,10 +102,7 @@ fn get_housenumbers_last_modified(
     ctx: &context::Context,
     relation: &areas::Relation,
 ) -> anyhow::Result<String> {
-    Ok(get_last_modified(
-        ctx,
-        &relation.get_files().get_osm_housenumbers_path(),
-    ))
+    get_last_modified(ctx, &relation.get_files().get_osm_housenumbers_path())
 }
 
 /// Expected request_uri: e.g. /osm/street-housenumbers/ormezo/view-query.
@@ -686,7 +683,7 @@ fn handle_missing_housenumbers(
             guard.read_to_end(&mut buffer)?;
             pre.text(&String::from_utf8(buffer)?);
         }
-        date = get_last_modified(ctx, &relation.get_files().get_ref_housenumbers_path());
+        date = get_last_modified(ctx, &relation.get_files().get_ref_housenumbers_path())?;
     } else if action == "update-result" {
         doc.append_value(missing_housenumbers_update(ctx, relations, relation_name)?.get_value())
     } else {
@@ -893,7 +890,7 @@ fn handle_main_housenr_percent(
 
     let doc = yattag::Doc::new();
     if let Some(percent) = percent {
-        let date = get_last_modified(ctx, &files.get_housenumbers_percent_path());
+        let date = get_last_modified(ctx, &files.get_housenumbers_percent_path())?;
         let strong = doc.tag("strong", &[]);
         let a = strong.tag(
             "a",
@@ -938,7 +935,7 @@ fn handle_main_street_percent(
 
     let doc = yattag::Doc::new();
     if let Some(percent) = percent {
-        let date = get_last_modified(ctx, &relation.get_files().get_streets_percent_path());
+        let date = get_last_modified(ctx, &relation.get_files().get_streets_percent_path())?;
         let strong = doc.tag("strong", &[]);
         let a = strong.tag(
             "a",
@@ -979,7 +976,7 @@ fn handle_main_street_additional_count(
 
     let doc = yattag::Doc::new();
     if !additional_count.is_empty() {
-        let date = get_last_modified(ctx, &path);
+        let date = get_last_modified(ctx, &path)?;
         let strong = doc.tag("strong", &[]);
         let a = strong.tag(
             "a",
@@ -1037,7 +1034,7 @@ pub fn handle_main_housenr_additional_count(
 
     let doc = yattag::Doc::new();
     if !additional_count.is_empty() {
-        let date = get_last_modified(ctx, &files.get_housenumbers_additional_count_path());
+        let date = get_last_modified(ctx, &files.get_housenumbers_additional_count_path())?;
         let strong = doc.tag("strong", &[]);
         let a = strong.tag(
             "a",


### PR DESCRIPTION
Let's not abort just because we can't find a timetamp.

Change-Id: I2b847722e5c3b69c8f2247e6f5a3251ad4b6ed33
