### PR TITLE
Introduce util::get_tz_offset()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.151", features = ["derive"] }
 serde_json = "1.0.89"
 serde_yaml = "0.9.14"
 simplelog = "0.12.0"
-time = { version = "0.3.16", features = ["formatting", "macros"] }
+time = { version = "0.3.16", features = ["formatting", "macros", "local-offset"] }
 unidecode = "0.3.0"
 url = "2.3.1"
 

--- a/src/context/system.rs
+++ b/src/context/system.rs
@@ -101,9 +101,8 @@ pub struct StdTime {}
 // Real time is intentionally mocked.
 impl Time for StdTime {
     fn now(&self) -> i64 {
-        let now = time::OffsetDateTime::now_local().expect("offset cannot be determined");
-        let offset = now.offset().whole_seconds() as i64;
-        now.unix_timestamp() + offset
+        let now = time::OffsetDateTime::now_utc();
+        now.unix_timestamp() as i64
     }
 
     fn sleep(&self, seconds: u64) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod parse_access_log;
 mod ranges;
 mod stats;
 pub mod sync_ref;
-mod util;
+pub mod util;
 pub mod validator;
 mod webframe;
 pub mod wsgi;

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ fn rouille_main(_: &[String], stream: &mut dyn Write, ctx: &osm_gimmisn::context
         port, prefix
     )
     .unwrap();
+    osm_gimmisn::util::get_tz_offset();
     rouille::start_server_with_pool(format!("127.0.0.1:{}", port), None, move |request| {
         rouille_app(request)
     });


### PR DESCRIPTION
We want to display time in the local timezone, but localtime_r() is not
safe to be called on a thread.

So get the local tz offset using a lazy static and call it before
rouille starts, which is the only case where we're multithreaded.

This also allows returning a UTC timestamp in context::system and the
callers can apply to_offset(util::get_tz_offset()) on the parsed result
if they want to display the date in local time.

Change-Id: I199dc5d9b11e4ec928c88dfbd47b023c829b1978
