### PR TITLE
context: let Time::now() return a timezone as well

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -68,8 +68,8 @@ pub use system::StdNetwork;
 
 /// Time interface.
 pub trait Time {
-    /// Calculates the current Unix timestamp from GMT.
-    fn now(&self) -> i64;
+    /// Calculates the current time.
+    fn now(&self) -> time::OffsetDateTime;
 
     /// Delay execution for a given number of seconds.
     fn sleep(&self, seconds: u64);

--- a/src/context/system.rs
+++ b/src/context/system.rs
@@ -11,6 +11,7 @@
 //! Trait implementations using the real file system, network, time, etc.
 
 use super::*;
+use crate::util;
 use isahc::config::Configurable as _;
 use isahc::ReadResponseExt as _;
 use isahc::RequestExt as _;
@@ -100,9 +101,9 @@ pub struct StdTime {}
 
 // Real time is intentionally mocked.
 impl Time for StdTime {
-    fn now(&self) -> i64 {
+    fn now(&self) -> time::OffsetDateTime {
         let now = time::OffsetDateTime::now_utc();
-        now.unix_timestamp() as i64
+        now.to_offset(util::get_tz_offset())
     }
 
     fn sleep(&self, seconds: u64) {

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -169,10 +169,9 @@ impl FileSystem for TestFileSystem {
         }
 
         if let Some(ref value) = self.mtimes.get(path) {
-            let now = time::OffsetDateTime::now_local().expect("offset cannot be determined");
-            let offset = now.offset().whole_seconds() as i64;
+            let now = time::OffsetDateTime::now_utc();
             let mut guard = value.borrow_mut();
-            *guard = (now.unix_timestamp() + offset) as f64;
+            *guard = now.unix_timestamp() as f64;
         }
 
         let ret = self.files[path].clone();
@@ -209,7 +208,7 @@ impl FileSystem for TestFileSystem {
 
 /// Time implementation, for test purposes.
 pub struct TestTime {
-    now: i64,
+    now: time::OffsetDateTime,
     sleep: Rc<RefCell<u64>>,
 }
 
@@ -222,7 +221,7 @@ impl TestTime {
         )
         .unwrap()
         .midnight();
-        let now = date.assume_utc().unix_timestamp();
+        let now = date.assume_utc();
         let sleep = Rc::new(RefCell::new(0_u64));
         TestTime { now, sleep }
     }
@@ -234,7 +233,7 @@ impl TestTime {
 }
 
 impl Time for TestTime {
-    fn now(&self) -> i64 {
+    fn now(&self) -> time::OffsetDateTime {
         self.now
     }
 

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -468,7 +468,7 @@ fn update_stats(ctx: &context::Context, overpass: bool) -> anyhow::Result<()> {
         .get_file_system()
         .read_to_string(&ctx.get_abspath("data/street-housenumbers-hungary.txt"))?;
     let statedir = ctx.get_abspath("workdir/stats");
-    let now = time::OffsetDateTime::from_unix_timestamp(ctx.get_time().now()).unwrap();
+    let now = ctx.get_time().now();
     let format = time::format_description::parse("[year]-[month]-[day]")?;
     let today = now.format(&format)?;
     let csv_path = format!("{}/{}.csv", statedir, today);
@@ -508,8 +508,8 @@ fn update_stats(ctx: &context::Context, overpass: bool) -> anyhow::Result<()> {
             continue;
         }
 
-        let last_modified =
-            ctx.get_time().now() as f64 - ctx.get_file_system().getmtime(&file_name)?;
+        let last_modified = ctx.get_time().now().unix_timestamp() as f64
+            - ctx.get_file_system().getmtime(&file_name)?;
 
         if last_modified >= 24_f64 * 3600_f64 * 7_f64 {
             ctx.get_file_system().unlink(&file_name)?;
@@ -595,7 +595,7 @@ pub fn our_main(
 
     let start = ctx.get_time().now();
     // Query inactive relations once a month.
-    let now = time::OffsetDateTime::from_unix_timestamp(ctx.get_time().now()).unwrap();
+    let now = ctx.get_time().now();
     let first_day_of_month = now.date().day() == 1;
     relations.activate_all(ctx.get_ini().get_cron_update_inactive() || first_day_of_month);
     relations.activate_new();
@@ -613,7 +613,7 @@ pub fn our_main(
         update,
         overpass,
     )?;
-    let duration = time::Duration::new(ctx.get_time().now() - start, 0);
+    let duration = ctx.get_time().now() - start;
     let seconds = duration.whole_seconds() % 60;
     let minutes = duration.whole_minutes() % 60;
     let hours = duration.whole_hours();

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -759,7 +759,7 @@ fn test_update_stats() {
     let path = ctx.get_abspath("workdir/stats/2020-05-10.csv");
     mtimes.insert(
         path.to_string(),
-        Rc::new(RefCell::new(ctx.get_time().now() as f64)),
+        Rc::new(RefCell::new(ctx.get_time().now().unix_timestamp() as f64)),
     );
     let path = ctx.get_abspath("workdir/stats/old.csv");
     mtimes.insert(path.to_string(), Rc::new(RefCell::new(0_f64)));
@@ -767,7 +767,7 @@ fn test_update_stats() {
     let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
     ctx.set_file_system(&file_system_arc);
 
-    let now = time::OffsetDateTime::from_unix_timestamp(ctx.get_time().now()).unwrap();
+    let now = ctx.get_time().now();
     let format = time::format_description::parse("[year]-[month]-[day]").unwrap();
     let today = now.format(&format).unwrap();
     let path = ctx.get_abspath(&format!("workdir/stats/{}.csv", today));
@@ -1104,7 +1104,7 @@ fn test_our_main_stats() {
     let path = ctx.get_abspath("workdir/stats/2020-05-10.csv");
     mtimes.insert(
         path.to_string(),
-        Rc::new(RefCell::new(ctx.get_time().now() as f64)),
+        Rc::new(RefCell::new(ctx.get_time().now().unix_timestamp() as f64)),
     );
     file_system.set_mtimes(&mtimes);
     let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);

--- a/src/parse_access_log.rs
+++ b/src/parse_access_log.rs
@@ -162,7 +162,7 @@ fn is_relation_recently_added(
     create_dates: &HashMap<String, time::OffsetDateTime>,
     name: &str,
 ) -> bool {
-    let today = time::OffsetDateTime::from_unix_timestamp(ctx.get_time().now()).unwrap();
+    let today = ctx.get_time().now();
     let month_ago = today - time::Duration::days(30);
     create_dates.contains_key(name) && create_dates[name] > month_ago
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -38,8 +38,7 @@ fn handle_progress(
         .parse()
         .context("failed to parse ref.count")?;
     let today = {
-        let now = time::OffsetDateTime::from_unix_timestamp(ctx.get_time().now())?
-            .to_offset(util::get_tz_offset());
+        let now = ctx.get_time().now();
         let format = time::format_description::parse("[year]-[month]-[day]")?;
         now.format(&format)?
     };
@@ -97,8 +96,7 @@ fn handle_capital_progress(
         }
     }
 
-    let now = time::OffsetDateTime::from_unix_timestamp(ctx.get_time().now())?
-        .to_offset(util::get_tz_offset());
+    let now = ctx.get_time().now();
     let format = time::format_description::parse("[year]-[month]-[day]")?;
     let today = now.format(&format)?;
     let mut osm_count = 0;
@@ -143,8 +141,7 @@ fn handle_topusers(
     j: &mut serde_json::Value,
 ) -> anyhow::Result<()> {
     let today = {
-        let now = time::OffsetDateTime::from_unix_timestamp(ctx.get_time().now())?
-            .to_offset(util::get_tz_offset());
+        let now = ctx.get_time().now();
         let format = time::format_description::parse("[year]-[month]-[day]")?;
         now.format(&format)?
     };
@@ -176,8 +173,7 @@ fn handle_topusers(
 
 /// Generates a list of cities, sorted by how many new hours numbers they got recently.
 pub fn get_topcities(ctx: &context::Context, src_root: &str) -> anyhow::Result<Vec<(String, i64)>> {
-    let now = time::OffsetDateTime::from_unix_timestamp(ctx.get_time().now())?
-        .to_offset(util::get_tz_offset());
+    let now = ctx.get_time().now();
     let ymd = time::format_description::parse("[year]-[month]-[day]")?;
     let new_day = now.format(&ymd)?;
     let day_delta = now - time::Duration::days(30);
@@ -251,8 +247,7 @@ fn handle_user_total(
     day_range: i64,
 ) -> anyhow::Result<()> {
     let mut ret: Vec<(String, u64)> = Vec::new();
-    let now = time::OffsetDateTime::from_unix_timestamp(ctx.get_time().now())?
-        .to_offset(util::get_tz_offset());
+    let now = ctx.get_time().now();
     let ymd = time::format_description::parse("[year]-[month]-[day]")?;
     for day_offset in (0..=day_range).rev() {
         let day_delta = now - time::Duration::days(day_offset);
@@ -285,8 +280,7 @@ fn handle_daily_new(
     let mut ret: Vec<(String, i64)> = Vec::new();
     let mut prev_count = 0;
     let mut prev_day: String = "".into();
-    let now = time::OffsetDateTime::from_unix_timestamp(ctx.get_time().now())?
-        .to_offset(util::get_tz_offset());
+    let now = ctx.get_time().now();
     let ymd = time::format_description::parse("[year]-[month]-[day]")?;
     for day_offset in (0..=day_range).rev() {
         let day_delta = now - time::Duration::days(day_offset);
@@ -314,9 +308,8 @@ fn handle_daily_new(
 }
 
 /// Returns a date that was today N months ago.
-fn get_previous_month(today: i64, months: i64) -> anyhow::Result<i64> {
-    let today = time::OffsetDateTime::from_unix_timestamp(today)?.to_offset(util::get_tz_offset());
-    let mut month_ago = today;
+fn get_previous_month(today: &time::OffsetDateTime, months: i64) -> anyhow::Result<i64> {
+    let mut month_ago = *today;
     for _month in 0..months {
         let first_of_current = month_ago.replace_day(1).unwrap();
         month_ago = first_of_current - time::Duration::days(1);
@@ -337,7 +330,7 @@ fn handle_monthly_new(
     let ym = time::format_description::parse("[year]-[month]")?;
     for month_offset in (0..=month_range).rev() {
         let month_delta = time::OffsetDateTime::from_unix_timestamp(get_previous_month(
-            ctx.get_time().now(),
+            &ctx.get_time().now(),
             month_offset,
         )?)?
         .to_offset(util::get_tz_offset());
@@ -360,8 +353,7 @@ fn handle_monthly_new(
     }
 
     // Also show the current, incomplete month.
-    let now = time::OffsetDateTime::from_unix_timestamp(ctx.get_time().now())?
-        .to_offset(util::get_tz_offset());
+    let now = ctx.get_time().now();
     let ymd = time::format_description::parse("[year]-[month]-[day]")?;
     let mut month = now.format(&ymd)?;
     let count_path = format!("{}/{}.count", src_root, month);
@@ -390,8 +382,7 @@ fn handle_daily_total(
     day_range: i64,
 ) -> anyhow::Result<()> {
     let mut ret: Vec<(String, i64)> = Vec::new();
-    let now = time::OffsetDateTime::from_unix_timestamp(ctx.get_time().now())?
-        .to_offset(util::get_tz_offset());
+    let now = ctx.get_time().now();
     let ymd = time::format_description::parse("[year]-[month]-[day]")?;
     for day_offset in (0..=day_range).rev() {
         let day_delta = now - time::Duration::days(day_offset);
@@ -427,10 +418,10 @@ fn handle_monthly_total(
     let ymd = time::format_description::parse("[year]-[month]-[day]")?;
     for month_offset in (0..=month_range).rev() {
         let month_delta =
-            time::OffsetDateTime::from_unix_timestamp(get_previous_month(today, month_offset)?)?
+            time::OffsetDateTime::from_unix_timestamp(get_previous_month(&today, month_offset)?)?
                 .to_offset(util::get_tz_offset());
         let prev_month_delta = time::OffsetDateTime::from_unix_timestamp(get_previous_month(
-            today,
+            &today,
             month_offset + 1,
         )?)?
         .to_offset(util::get_tz_offset());

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -356,7 +356,7 @@ fn test_get_previous_month() {
     let today = ctx.get_time().now();
 
     let actual =
-        time::OffsetDateTime::from_unix_timestamp(get_previous_month(today, 2).unwrap()).unwrap();
+        time::OffsetDateTime::from_unix_timestamp(get_previous_month(&today, 2).unwrap()).unwrap();
 
     let expected = time::macros::datetime!(2020-03-31 0:00:00).assume_utc();
     assert_eq!(actual, expected);

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -590,9 +590,7 @@ fn handle_stats_cityprogress(
         let count: u64 = row.get(1).unwrap().parse()?;
         ref_citycounts.insert(city.into(), count);
     }
-    let timestamp = ctx.get_time().now();
-    let date_time =
-        time::OffsetDateTime::from_unix_timestamp(timestamp)?.to_offset(util::get_tz_offset());
+    let date_time = ctx.get_time().now();
     let format = time::format_description::parse("[year]-[month]-[day]")?;
     let today = date_time.format(&format)?;
     let mut osm_citycounts: HashMap<String, u64> = HashMap::new();
@@ -693,9 +691,7 @@ fn handle_stats_zipprogress(
         let count: u64 = row.get(1).unwrap().parse()?;
         ref_zipcounts.insert(zip.into(), count);
     }
-    let timestamp = ctx.get_time().now();
-    let now =
-        time::OffsetDateTime::from_unix_timestamp(timestamp)?.to_offset(util::get_tz_offset());
+    let now = ctx.get_time().now();
     let format = time::format_description::parse("[year]-[month]-[day]")?;
     let today = now.format(&format)?;
     let mut osm_zipcounts: HashMap<String, u64> = HashMap::new();


### PR DESCRIPTION
Otherwise we need to assume a timezone at the caller side, and we can't
get the current timezone when running the tests on multiple threads.

Change-Id: Icd559f88de48e634007b7f39c94be0e25f6c9ea8
