### PR TITLE
stats: get_previous_month: return a time::OffsetDateTime

### DIFF
--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -355,8 +355,7 @@ fn test_get_previous_month() {
     let ctx = context::tests::make_test_context().unwrap();
     let today = ctx.get_time().now();
 
-    let actual =
-        time::OffsetDateTime::from_unix_timestamp(get_previous_month(&today, 2).unwrap()).unwrap();
+    let actual = get_previous_month(&today, 2).unwrap();
 
     let expected = time::macros::datetime!(2020-03-31 0:00:00).assume_utc();
     assert_eq!(actual, expected);


### PR DESCRIPTION
Going via unix_timestamp() + from_unix_timestamp() is unnecessary at
best.

Change-Id: I3915e9167d41796d48786fd8e12f8916b7bd59bd
