### PR TITLE
webframe: format_timestamp: avoid from_unix_timestamp()

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1201,12 +1201,14 @@ pub fn format_percent(parsed: f64) -> anyhow::Result<String> {
     Ok(formatted.replace('.', decimal_point))
 }
 
-/// Gets the timestamp of a file if it exists, 0 otherwise.
-pub fn get_timestamp(ctx: &context::Context, path: &str) -> f64 {
+/// Gets the mtime of a file if it exists, 0 otherwise.
+pub fn get_mtime(ctx: &context::Context, path: &str) -> time::OffsetDateTime {
     let mtime = match ctx.get_file_system().getmtime(path) {
-        Ok(value) => value,
+        Ok(value) => time::OffsetDateTime::from_unix_timestamp(value as i64)
+            .unwrap()
+            .to_offset(get_tz_offset()),
         Err(_) => {
-            return 0.0;
+            return time::OffsetDateTime::UNIX_EPOCH;
         }
     };
 

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -756,11 +756,11 @@ fn test_get_column_junk() {
     assert_eq!(natnum(&get_column(&row, 2)), 0);
 }
 
-/// Tests get_timestamp(): what happens when the file is not there.
+/// Tests get_mtime(): what happens when the file is not there.
 #[test]
-fn test_get_timestamp_no_such_file() {
+fn test_get_mtime_no_such_file() {
     let ctx = context::tests::make_test_context().unwrap();
-    assert_eq!(get_timestamp(&ctx, ""), 0_f64);
+    assert_eq!(get_mtime(&ctx, ""), time::OffsetDateTime::UNIX_EPOCH);
 }
 
 /// Tests get_lexical_sort_key().

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -548,11 +548,9 @@ pub fn handle_404() -> yattag::Doc {
 }
 
 /// Formats timestamp as UI date-time.
-pub fn format_timestamp(timestamp: i64) -> anyhow::Result<String> {
-    let now =
-        time::OffsetDateTime::from_unix_timestamp(timestamp)?.to_offset(util::get_tz_offset());
+pub fn format_timestamp(timestamp: &time::OffsetDateTime) -> anyhow::Result<String> {
     let format = time::format_description::parse("[year]-[month]-[day] [hour]:[minute]")?;
-    Ok(now.format(&format)?)
+    Ok(timestamp.format(&format)?)
 }
 
 /// Expected request_uri: e.g. /osm/housenumber-stats/hungary/cityprogress.

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 
 /// Gets the update date string of a file.
 fn get_last_modified(ctx: &context::Context, path: &str) -> anyhow::Result<String> {
-    webframe::format_timestamp(util::get_timestamp(ctx, path) as i64)
+    webframe::format_timestamp(&util::get_mtime(ctx, path))
 }
 
 /// Gets the update date of streets for a relation.
@@ -644,10 +644,9 @@ fn ref_housenumbers_last_modified(
     name: &str,
 ) -> anyhow::Result<String> {
     let relation = relations.get_relation(name)?;
-    let t_ref = util::get_timestamp(ctx, &relation.get_files().get_ref_housenumbers_path());
-    let t_housenumbers =
-        util::get_timestamp(ctx, &relation.get_files().get_osm_housenumbers_path());
-    webframe::format_timestamp(std::cmp::max(t_ref as i64, t_housenumbers as i64))
+    let t_ref = util::get_mtime(ctx, &relation.get_files().get_ref_housenumbers_path());
+    let t_housenumbers = util::get_mtime(ctx, &relation.get_files().get_osm_housenumbers_path());
+    webframe::format_timestamp(std::cmp::max(&t_ref, &t_housenumbers))
 }
 
 /// Expected request_uri: e.g. /osm/missing-housenumbers/ormezo/view-[result|query].
@@ -735,9 +734,9 @@ fn relation_streets_get_last_modified(
     ctx: &context::Context,
     relation: &areas::Relation,
 ) -> anyhow::Result<String> {
-    let t_ref = util::get_timestamp(ctx, &relation.get_files().get_ref_streets_path()) as i64;
-    let t_osm = util::get_timestamp(ctx, &relation.get_files().get_osm_streets_path()) as i64;
-    webframe::format_timestamp(std::cmp::max(t_ref, t_osm))
+    let t_ref = util::get_mtime(ctx, &relation.get_files().get_ref_streets_path());
+    let t_osm = util::get_mtime(ctx, &relation.get_files().get_osm_streets_path());
+    webframe::format_timestamp(std::cmp::max(&t_ref, &t_osm))
 }
 
 /// Expected request_uri: e.g. /osm/missing-streets/ujbuda/view-[result|query].
@@ -833,9 +832,9 @@ fn relation_housenumbers_get_last_modified(
     ctx: &context::Context,
     relation: &areas::Relation,
 ) -> anyhow::Result<String> {
-    let t_ref = util::get_timestamp(ctx, &relation.get_files().get_ref_housenumbers_path()) as i64;
-    let t_osm = util::get_timestamp(ctx, &relation.get_files().get_osm_housenumbers_path()) as i64;
-    webframe::format_timestamp(std::cmp::max(t_ref, t_osm))
+    let t_ref = util::get_mtime(ctx, &relation.get_files().get_ref_housenumbers_path());
+    let t_osm = util::get_mtime(ctx, &relation.get_files().get_osm_housenumbers_path());
+    webframe::format_timestamp(std::cmp::max(&t_ref, &t_osm))
 }
 
 /// Expected request_uri: e.g. /osm/additional-housenumbers/ujbuda/view-[result|query].


### PR DESCRIPTION
Towards just working with time::OffsetDateTime everywhere, without
serialize + load to a timestamp that has no timezone info.

Change-Id: I66f3d3c65676a9f3ce76433199123c67ae36b277
