### PR TITLE
context::FileSystem: let getmtime() return a time::OffsetDateTime

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -25,7 +25,7 @@ pub trait FileSystem {
     fn path_exists(&self, path: &str) -> bool;
 
     /// Return the last modification time of a file.
-    fn getmtime(&self, path: &str) -> anyhow::Result<f64>;
+    fn getmtime(&self, path: &str) -> anyhow::Result<time::OffsetDateTime>;
 
     /// Opens a file for reading in binary mode.
     fn open_read(&self, path: &str) -> anyhow::Result<Rc<RefCell<dyn Read>>>;

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -508,10 +508,9 @@ fn update_stats(ctx: &context::Context, overpass: bool) -> anyhow::Result<()> {
             continue;
         }
 
-        let last_modified = ctx.get_time().now().unix_timestamp() as f64
-            - ctx.get_file_system().getmtime(&file_name)?;
+        let last_modified = ctx.get_time().now() - ctx.get_file_system().getmtime(&file_name)?;
 
-        if last_modified >= 24_f64 * 3600_f64 * 7_f64 {
+        if last_modified.whole_seconds() >= 24_i64 * 3600_i64 * 7_i64 {
             ctx.get_file_system().unlink(&file_name)?;
             info!("update_stats: removed old {}", file_name);
         }

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -135,7 +135,7 @@ fn test_update_ref_housenumbers() {
     update_ref_housenumbers(&ctx, &mut relations, /*update=*/ true).unwrap();
 
     let mtime = ctx.get_file_system().getmtime(&path).unwrap();
-    assert!(mtime > 0_f64);
+    assert!(mtime > time::OffsetDateTime::UNIX_EPOCH);
 
     update_ref_housenumbers(&ctx, &mut relations, /*update=*/ false).unwrap();
 
@@ -204,7 +204,7 @@ fn test_update_ref_streets() {
     update_ref_streets(&ctx, &mut relations, /*update=*/ true).unwrap();
 
     let mtime = ctx.get_file_system().getmtime(&path).unwrap();
-    assert!(mtime > 0_f64);
+    assert!(mtime > time::OffsetDateTime::UNIX_EPOCH);
 
     update_ref_streets(&ctx, &mut relations, /*update=*/ false).unwrap();
 
@@ -284,7 +284,7 @@ fn test_update_missing_housenumbers() {
     update_missing_housenumbers(&ctx, &mut relations, /*update=*/ true).unwrap();
 
     let expected_mtime = file_system_arc.getmtime(&path1).unwrap();
-    assert_eq!(expected_mtime > 0_f64, true);
+    assert!(expected_mtime > time::OffsetDateTime::UNIX_EPOCH);
 
     update_missing_housenumbers(&ctx, &mut relations, /*update=*/ false).unwrap();
 
@@ -345,7 +345,7 @@ fn test_update_missing_streets() {
     update_missing_streets(&ctx, &mut relations, /*update=*/ true).unwrap();
 
     let expected_mtime = ctx.get_file_system().getmtime(&path1).unwrap();
-    assert_eq!(expected_mtime > 0_f64, true);
+    assert!(expected_mtime > time::OffsetDateTime::UNIX_EPOCH);
 
     update_missing_streets(&ctx, &mut relations, /*update=*/ false).unwrap();
 
@@ -614,7 +614,7 @@ fn test_update_osm_streets() {
     update_osm_streets(&ctx, &mut relations, /*update=*/ true).unwrap();
 
     let mtime = ctx.get_file_system().getmtime(&path).unwrap();
-    assert!(mtime > 0_f64);
+    assert!(mtime > time::OffsetDateTime::UNIX_EPOCH);
 
     update_osm_streets(&ctx, &mut relations, /*update=*/ false).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn rouille_main(_: &[String], stream: &mut dyn Write, ctx: &osm_gimmisn::context
         port, prefix
     )
     .unwrap();
-    osm_gimmisn::util::get_tz_offset();
+    osm_gimmisn::context::system::get_tz_offset();
     rouille::start_server_with_pool(format!("127.0.0.1:{}", port), None, move |request| {
         rouille_app(request)
     });

--- a/src/util.rs
+++ b/src/util.rs
@@ -36,7 +36,6 @@ lazy_static! {
     static ref NUMBER_SUFFIX: regex::Regex = regex::Regex::new(r"^.*/([0-9])\*?$").unwrap();
     static ref NULL_END: regex::Regex = regex::Regex::new(r" null$").unwrap();
     static ref GIT_HASH: regex::Regex = regex::Regex::new(r".*-g([0-9a-f]+)(-modified)?").unwrap();
-    static ref TZ_OFFSET: time::UtcOffset = time::UtcOffset::current_local_offset().unwrap();
 }
 
 /// A house number range is a string that may expand to one or more HouseNumber instances in the
@@ -1012,11 +1011,6 @@ pub fn git_link(version: &str, prefix: &str) -> yattag::Doc {
     doc
 }
 
-/// Gets the current timezone offset. Has to be first called when there are no threads yet.
-pub fn get_tz_offset() -> time::UtcOffset {
-    *TZ_OFFSET
-}
-
 /// Sorts strings according to their numerical value, not alphabetically.
 pub fn sort_numerically(strings: &[HouseNumber]) -> Vec<HouseNumber> {
     let mut ret: Vec<HouseNumber> = strings.to_owned();
@@ -1204,12 +1198,8 @@ pub fn format_percent(parsed: f64) -> anyhow::Result<String> {
 /// Gets the mtime of a file if it exists, 0 otherwise.
 pub fn get_mtime(ctx: &context::Context, path: &str) -> time::OffsetDateTime {
     let mtime = match ctx.get_file_system().getmtime(path) {
-        Ok(value) => time::OffsetDateTime::from_unix_timestamp(value as i64)
-            .unwrap()
-            .to_offset(get_tz_offset()),
-        Err(_) => {
-            return time::OffsetDateTime::UNIX_EPOCH;
-        }
+        Ok(value) => value,
+        Err(_) => time::OffsetDateTime::UNIX_EPOCH,
     };
 
     mtime

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -1226,11 +1226,10 @@ fn get_content_with_meta(ctx: &context::Context, path: &str) -> anyhow::Result<(
         .get_file_system()
         .getmtime(path)
         .context("getmtime() failed")?;
-    let date_time = time::OffsetDateTime::from_unix_timestamp(mtime as i64)?;
 
     let extra_headers: Headers = vec![(
         "Last-Modified".into(),
-        date_time
+        mtime
             .format(&time::format_description::well_known::Rfc2822)?
             .into(),
     )];


### PR DESCRIPTION
Towards just working with time::OffsetDateTime everywhere, without
serialize + load to a timestamp that has no timezone info.

This also means that get_tz_offset() can be moved to context/system.rs,
so a threaded 'cargo test' passes again (getting the current timezone
from the system on a thread would fail to be safe).

Change-Id: Ide4c36fad19d1bd48641ffcb042fc83d4bd1d139
