### PR TITLE
cache tests: new cache is enough to be current

### DIFF
--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -51,9 +51,7 @@ fn test_get_missing_housenumbers_json() {
     let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
     mtimes.insert(
         ctx.get_abspath("workdir/cache-gazdagret.json"),
-        Rc::new(RefCell::new(
-            time::OffsetDateTime::from_unix_timestamp(9999999999).unwrap(),
-        )),
+        Rc::new(RefCell::new(time::OffsetDateTime::now_utc())),
     );
     file_system.set_mtimes(&mtimes);
     let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
@@ -100,9 +98,7 @@ fn test_get_additional_housenumbers_json() {
     let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
     mtimes.insert(
         ctx.get_abspath("workdir/additional-cache-gazdagret.json"),
-        Rc::new(RefCell::new(
-            time::OffsetDateTime::from_unix_timestamp(9999999999).unwrap(),
-        )),
+        Rc::new(RefCell::new(time::OffsetDateTime::now_utc())),
     );
     file_system.set_mtimes(&mtimes);
     let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);


### PR DESCRIPTION
"now" is good enough, less code, and then these tests will pass even if
now() > 9999999999.

Change-Id: I350ce9710cdd483baad22b77f37bf83e4b518222
