### PR TITLE
cargo: declare license in the package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "osm-gimmisn"
 version = "7.4.0"
 edition = "2021"
+license = "MIT"
 
 [dependencies]
 accept-language = "2.0.0"


### PR DESCRIPTION
E.g. cargo-license reads this.

Change-Id: Iedaf2a8922a1f254b8bfe341b83d4813f6100bb7
