### PR TITLE
config: wrap the value of config keys in single quotes

### DIFF
--- a/data/wsgi.ini.template
+++ b/data/wsgi.ini.template
@@ -1,5 +1,5 @@
 [wsgi]
-reference_housenumbers = refdir/hazszamok_20221219.tsv refdir/hazszamok_kieg_20221219.tsv
-reference_street = refdir/utcak_20221219.tsv
-reference_citycounts = refdir/varosok_count_20221219.tsv
-reference_zipcounts = refdir/irsz_count_20221219.tsv
+reference_housenumbers = 'refdir/hazszamok_20221219.tsv refdir/hazszamok_kieg_20221219.tsv'
+reference_street = 'refdir/utcak_20221219.tsv'
+reference_citycounts = 'refdir/varosok_count_20221219.tsv'
+reference_zipcounts = 'refdir/irsz_count_20221219.tsv'

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,6 +19,8 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::util;
+
 /// File system interface.
 pub trait FileSystem {
     /// Test whether a path exists.
@@ -138,7 +140,7 @@ impl Ini {
             .config
             .get("wsgi", "reference_housenumbers")
             .context("no wsgi.reference_housenumbers in config")?;
-        let relpaths = value.split(' ');
+        let relpaths = util::strip_quotes(&value).split(' ');
         Ok(relpaths
             .map(|relpath| format!("{}/{}", self.root, relpath))
             .collect())
@@ -150,7 +152,7 @@ impl Ini {
             .config
             .get("wsgi", "reference_street")
             .context("no wsgi.reference_street in config")?;
-        Ok(format!("{}/{}", self.root, relpath))
+        Ok(format!("{}/{}", self.root, util::strip_quotes(&relpath)))
     }
 
     /// Gets the abs path of ref citycounts.
@@ -159,7 +161,7 @@ impl Ini {
             .config
             .get("wsgi", "reference_citycounts")
             .context("no wsgi.reference_citycounts in config")?;
-        Ok(format!("{}/{}", self.root, relpath))
+        Ok(format!("{}/{}", self.root, util::strip_quotes(&relpath)))
     }
 
     /// Gets the abs path of ref zipcounts.
@@ -168,7 +170,7 @@ impl Ini {
             .config
             .get("wsgi", "reference_zipcounts")
             .context("no wsgi.reference_zipcounts in config")?;
-        Ok(format!("{}/{}", self.root, relpath))
+        Ok(format!("{}/{}", self.root, util::strip_quotes(&relpath)))
     }
 
     /// Gets the global URI prefix.
@@ -178,7 +180,7 @@ impl Ini {
 
     fn get_with_fallback(&self, key: &str, fallback: &str) -> String {
         match self.config.get("wsgi", key) {
-            Some(value) => value,
+            Some(value) => util::strip_quotes(&value).to_string(),
             None => String::from(fallback),
         }
     }

--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -11,6 +11,7 @@
 //! Synchronizes reference data between a public instance and a local dev instance.
 
 use crate::context;
+use crate::util;
 use anyhow::Context as _;
 use std::collections::HashMap;
 use std::io::Write;
@@ -45,26 +46,38 @@ pub fn our_main(
         let config_data = ctx.get_file_system().read_to_string(&config_file)?;
         config.read(config_data.clone()).unwrap();
         let mut paths: Vec<String> = Vec::new();
-        let values = config
-            .get("wsgi", "reference_housenumbers")
-            .context("no wsgi.reference_housenumbers in config")?;
+        let values = util::strip_quotes(
+            &config
+                .get("wsgi", "reference_housenumbers")
+                .context("no wsgi.reference_housenumbers in config")?,
+        )
+        .to_string();
         paths.append(
             &mut values
                 .split(' ')
                 .map(|value| value.strip_prefix("refdir/").unwrap().to_string())
                 .collect(),
         );
-        let value = config
-            .get("wsgi", "reference_street")
-            .context("no wsgi.reference_street in config")?;
+        let value = util::strip_quotes(
+            &config
+                .get("wsgi", "reference_street")
+                .context("no wsgi.reference_street in config")?,
+        )
+        .to_string();
         paths.push(value.strip_prefix("refdir/").unwrap().to_string());
-        let value = config
-            .get("wsgi", "reference_citycounts")
-            .context("no wsgi.reference_citycounts in config")?;
+        let value = util::strip_quotes(
+            &config
+                .get("wsgi", "reference_citycounts")
+                .context("no wsgi.reference_citycounts in config")?,
+        )
+        .to_string();
         paths.push(value.strip_prefix("refdir/").unwrap().to_string());
-        let value = config
-            .get("wsgi", "reference_zipcounts")
-            .context("no wsgi.reference_zipcounts in config")?;
+        let value = util::strip_quotes(
+            &config
+                .get("wsgi", "reference_zipcounts")
+                .context("no wsgi.reference_zipcounts in config")?,
+        )
+        .to_string();
         paths.push(value.strip_prefix("refdir/").unwrap().to_string());
 
         let mut dests: Vec<String> = Vec::new();
@@ -145,19 +158,19 @@ pub fn our_main(
     let mut config: Vec<String> = Vec::new();
     config.push("[wsgi]".into());
     config.push(format!(
-        "reference_housenumbers = refdir/hazszamok_{}.tsv refdir/hazszamok_kieg_{}.tsv",
+        "reference_housenumbers = 'refdir/hazszamok_{}.tsv refdir/hazszamok_kieg_{}.tsv'",
         files["hazszamok"], files["hazszamok_kieg"]
     ));
     config.push(format!(
-        "reference_street = refdir/utcak_{}.tsv",
+        "reference_street = 'refdir/utcak_{}.tsv'",
         files["utcak"]
     ));
     config.push(format!(
-        "reference_citycounts = refdir/varosok_count_{}.tsv",
+        "reference_citycounts = 'refdir/varosok_count_{}.tsv'",
         files["varosok_count"]
     ));
     config.push(format!(
-        "reference_zipcounts = refdir/irsz_count_{}.tsv",
+        "reference_zipcounts = 'refdir/irsz_count_{}.tsv'",
         files["irsz_count"]
     ));
     config.push(String::new());

--- a/src/sync_ref/tests.rs
+++ b/src/sync_ref/tests.rs
@@ -48,10 +48,10 @@ fn test_main() {
         .read_to_string(&ctx.get_abspath("data/wsgi.ini.template"))
         .unwrap();
     let expected = r#"[wsgi]
-reference_housenumbers = refdir/hazszamok_20221001.tsv refdir/hazszamok_kieg_20221016.tsv
-reference_street = refdir/utcak_20221016.tsv
-reference_citycounts = refdir/varosok_count_20221001.tsv
-reference_zipcounts = refdir/irsz_count_20221001.tsv
+reference_housenumbers = 'refdir/hazszamok_20221001.tsv refdir/hazszamok_kieg_20221016.tsv'
+reference_street = 'refdir/utcak_20221016.tsv'
+reference_citycounts = 'refdir/varosok_count_20221001.tsv'
+reference_zipcounts = 'refdir/irsz_count_20221001.tsv'
 "#;
     assert_eq!(actual, expected);
 }
@@ -76,10 +76,10 @@ fn test_main_download() {
         write
             .write_all(
                 r#"[wsgi]
-reference_housenumbers = refdir/hazszamok_20190511.tsv refdir/hazszamok_kieg_20190808.tsv
-reference_street = refdir/utcak_20190514.tsv
-reference_citycounts = refdir/varosok_count_20190717.tsv
-reference_zipcounts = refdir/irsz_count_20200717.tsv
+reference_housenumbers = 'refdir/hazszamok_20190511.tsv refdir/hazszamok_kieg_20190808.tsv'
+reference_street = 'refdir/utcak_20190514.tsv'
+reference_citycounts = 'refdir/varosok_count_20190717.tsv'
+reference_zipcounts = 'refdir/irsz_count_20200717.tsv'
 "#
                 .as_bytes(),
             )

--- a/src/util.rs
+++ b/src/util.rs
@@ -1204,5 +1204,11 @@ pub fn get_mtime(ctx: &context::Context, path: &str) -> time::OffsetDateTime {
     mtime
 }
 
+/// Removes the leading and trailing ' from a string.
+pub fn strip_quotes(input: &str) -> &str {
+    let quote: &[_] = &['\''];
+    input.trim_matches(quote)
+}
+
 #[cfg(test)]
 mod tests;

--- a/tests/wsgi.ini
+++ b/tests/wsgi.ini
@@ -1,7 +1,7 @@
 [wsgi]
-reference_housenumbers = refdir/hazszamok_20190511.tsv refdir/hazszamok_kieg_20190808.tsv
-reference_street = refdir/utcak_20190514.tsv
-reference_citycounts = refdir/varosok_count_20190717.tsv
-reference_zipcounts = refdir/irsz_count_20190717.tsv
-uri_prefix = /osm
-overpass_uri = https://overpass-api.de
+reference_housenumbers = 'refdir/hazszamok_20190511.tsv refdir/hazszamok_kieg_20190808.tsv'
+reference_street = 'refdir/utcak_20190514.tsv'
+reference_citycounts = 'refdir/varosok_count_20190717.tsv'
+reference_zipcounts = 'refdir/irsz_count_20190717.tsv'
+uri_prefix = '/osm'
+overpass_uri = 'https://overpass-api.de'


### PR DESCRIPTION
Otherwise it'll be hard to parse this from toml, which would allow
type-safe access to config key values.

Change-Id: I8163af8a6a347ac5f25e49aaa178c24b198baca6
