### PR TITLE
Link to the relevant part of the documentation

### DIFF
--- a/po/hu/osm-gimmisn.po
+++ b/po/hu/osm-gimmisn.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: osm-gimmisn\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-13 20:27+0000\n"
-"PO-Revision-Date: 2022-01-21 21:56+0100\n"
+"POT-Creation-Date: 2023-01-13 20:32+0000\n"
+"PO-Revision-Date: 2023-01-13 21:33+0100\n"
 "Last-Translator: Miklos Vajna <osm-gimmisn@vmiklos.hu>\n"
 "Language-Team: Hungarian\n"
 "Language: hu\n"
@@ -136,7 +136,7 @@ msgstr "Területek listája"
 msgid "Waiting for Overpass..."
 msgstr "Overpass: várakozás..."
 
-#: src/webframe.rs:392 src/webframe.rs:1093 src/webframe.rs:1117
+#: src/webframe.rs:392 src/webframe.rs:1087 src/webframe.rs:1111
 #: src/wsgi.rs:1269
 msgid "Error from Overpass: "
 msgstr "Overpass hiba: "
@@ -145,7 +145,7 @@ msgstr "Overpass hiba: "
 msgid "Creating from reference..."
 msgstr "Létrehozás referenciából..."
 
-#: src/webframe.rs:397 src/webframe.rs:1141 src/webframe.rs:1161
+#: src/webframe.rs:397 src/webframe.rs:1135 src/webframe.rs:1155
 msgid "Error from reference: "
 msgstr "Hiba a referenciától: "
 
@@ -161,43 +161,47 @@ msgstr "Terület határa"
 msgid "Statistics"
 msgstr "Statisztikák"
 
-#: src/webframe.rs:443
+#: src/webframe.rs:436
+msgid "https://vmiklos.hu/osm-gimmisn"
+msgstr "https://wiki.openstreetmap.org/wiki/Hungary/osm-gimmisn"
+
+#: src/webframe.rs:437
 msgid "Documentation"
 msgstr "Dokumentáció"
 
-#: src/webframe.rs:518
+#: src/webframe.rs:512
 msgid "Internal error when serving {0}"
 msgstr "Belső hiba a {0} kiszolgálása során"
 
-#: src/webframe.rs:539
+#: src/webframe.rs:533
 msgid "Not Found"
 msgstr "Nem található"
 
-#: src/webframe.rs:543
+#: src/webframe.rs:537
 msgid "The requested URL was not found on this server."
 msgstr "A kért URL nem található ezen a kiszolgálón."
 
-#: src/webframe.rs:618 src/webframe.rs:882
+#: src/webframe.rs:612 src/webframe.rs:876
 msgid "City name"
 msgstr "Város neve"
 
-#: src/webframe.rs:619 src/webframe.rs:720 src/wsgi.rs:1370
+#: src/webframe.rs:613 src/webframe.rs:714 src/wsgi.rs:1370
 msgid "House number coverage"
 msgstr "Házszám lefedettség"
 
-#: src/webframe.rs:620 src/webframe.rs:721
+#: src/webframe.rs:614 src/webframe.rs:715
 msgid "OSM count"
 msgstr "OSM szám"
 
-#: src/webframe.rs:621 src/webframe.rs:722
+#: src/webframe.rs:615 src/webframe.rs:716
 msgid "Reference count"
 msgstr "Referencia szám"
 
-#: src/webframe.rs:644 src/webframe.rs:745 src/webframe.rs:994
+#: src/webframe.rs:638 src/webframe.rs:739 src/webframe.rs:988
 msgid "Note"
 msgstr "Megjegyzés"
 
-#: src/webframe.rs:649
+#: src/webframe.rs:643
 msgid ""
 "These statistics are estimates, not taking house number filters into "
 "account.\n"
@@ -206,11 +210,11 @@ msgstr ""
 "Ezek a statisztikák becslések, nem véve figyelembe a házszám szűrőket.\n"
 "Csak olyan városok szerepelnek benne, amiknek van az OSM-ben házszámuk."
 
-#: src/webframe.rs:719
+#: src/webframe.rs:713
 msgid "ZIP code"
 msgstr "Irányítószám"
 
-#: src/webframe.rs:750
+#: src/webframe.rs:744
 msgid ""
 "These statistics are estimates, not taking house number filters into "
 "account.\n"
@@ -220,154 +224,154 @@ msgstr ""
 "Csak olyan irányítószámok szerepelnek benne, amiknek van az OSM-ben "
 "házszámuk."
 
-#: src/webframe.rs:850
+#: src/webframe.rs:844
 msgid "New house numbers, last 2 weeks, as of {}"
 msgstr "Új házszámok, utolsó 2 hét, frissítve: {}"
 
-#: src/webframe.rs:852
+#: src/webframe.rs:846
 msgid "During this day"
 msgstr "E nap folyamán"
 
-#: src/webframe.rs:853 src/webframe.rs:859 src/webframe.rs:917
+#: src/webframe.rs:847 src/webframe.rs:853 src/webframe.rs:911
 msgid "New house numbers"
 msgstr "Új házszámok"
 
-#: src/webframe.rs:856
+#: src/webframe.rs:850
 msgid "New house numbers, last year, as of {}"
 msgstr "Új házszámok, elmúlt év, frissítve: {}"
 
-#: src/webframe.rs:858
+#: src/webframe.rs:852
 msgid "During this month"
 msgstr "E hónap folyamán"
 
-#: src/webframe.rs:862
+#: src/webframe.rs:856
 msgid "All house numbers, last year, as of {}"
 msgstr "Összes házszám, elmúlt év, frissítve: {}"
 
-#: src/webframe.rs:864
+#: src/webframe.rs:858
 msgid "Latest for this month"
 msgstr "Legutóbbi erre a hónapra"
 
-#: src/webframe.rs:865 src/webframe.rs:871 src/webframe.rs:918
+#: src/webframe.rs:859 src/webframe.rs:865 src/webframe.rs:912
 msgid "All house numbers"
 msgstr "Minden házszám"
 
-#: src/webframe.rs:868
+#: src/webframe.rs:862
 msgid "All house numbers, last 2 weeks, as of {}"
 msgstr "Összes házszám, utolsó 2 hét, frissítve: {}"
 
-#: src/webframe.rs:870
+#: src/webframe.rs:864
 msgid "At the start of this day"
 msgstr "Ennek a napnak a kezdetén"
 
-#: src/webframe.rs:874
+#: src/webframe.rs:868
 msgid "Top house number editors, as of {}"
 msgstr "Legaktívabb házszám szerkesztők, frissítve: {}"
 
-#: src/webframe.rs:876
+#: src/webframe.rs:870
 msgid "User name"
 msgstr "Felhasználó neve"
 
-#: src/webframe.rs:879
+#: src/webframe.rs:873
 msgid "Number of house numbers last changed by this user"
 msgstr "Felhasználó által utoljára módosított házszámok száma"
 
-#: src/webframe.rs:881
+#: src/webframe.rs:875
 msgid "Top edited cities, as of {}"
 msgstr "Legaktívabb városok, frissítve: {}"
 
-#: src/webframe.rs:885
+#: src/webframe.rs:879
 msgid "Number of house numbers added in the past 30 days"
 msgstr "Az elmúlt 30 napban hozzáadott házszámok száma"
 
-#: src/webframe.rs:887
+#: src/webframe.rs:881
 msgid "(empty)"
 msgstr "(üres)"
 
-#: src/webframe.rs:888
+#: src/webframe.rs:882
 msgid "(invalid)"
 msgstr "(hibás)"
 
-#: src/webframe.rs:891
+#: src/webframe.rs:885
 msgid "Number of house number editors, as of {}"
 msgstr "Házszám szerkesztők száma, frissítve: {}"
 
-#: src/webframe.rs:893
+#: src/webframe.rs:887
 msgid "All editors"
 msgstr "Összes szerkesztő"
 
-#: src/webframe.rs:896
+#: src/webframe.rs:890
 msgid ""
 "Number of editors, at least one housenumber is last changed by these users"
 msgstr ""
 "Szerkesztők száma, legalább egy házszámot ezek a szerkesztők változtattak "
 "meg utoljára"
 
-#: src/webframe.rs:898
+#: src/webframe.rs:892
 msgid "Coverage is {1}%, as of {2}"
 msgstr "A lefedettség {1}%, frissítve: {2}"
 
-#: src/webframe.rs:901
+#: src/webframe.rs:895
 msgid "Number of house numbers in database"
 msgstr "Adatbázisban szereplő házszámok száma"
 
-#: src/webframe.rs:903
+#: src/webframe.rs:897
 msgid "Data source"
 msgstr "Adatforrás"
 
-#: src/webframe.rs:906
+#: src/webframe.rs:900
 msgid "Coverage is {1}% for the capital, as of {2}"
 msgstr "A főváros lefedettsége {1}%, frissítve: {2}"
 
-#: src/webframe.rs:910
+#: src/webframe.rs:904
 msgid "Number of house numbers in database for the capital"
 msgstr "Adatbázisban szereplő fővárosi házszámok száma"
 
-#: src/webframe.rs:912
+#: src/webframe.rs:906
 msgid "Reference"
 msgstr "Referencia"
 
-#: src/webframe.rs:919
+#: src/webframe.rs:913
 msgid "New house numbers, monthly"
 msgstr "Új házszámok, havonta"
 
-#: src/webframe.rs:920
+#: src/webframe.rs:914
 msgid "All house numbers, monthly"
 msgstr "Minden házszám, havonta"
 
-#: src/webframe.rs:921
+#: src/webframe.rs:915
 msgid "Top house number editors"
 msgstr "Legaktívabb házszám szerkesztők"
 
-#: src/webframe.rs:922
+#: src/webframe.rs:916
 msgid "Top edited cities"
 msgstr "Legaktívabb városok"
 
-#: src/webframe.rs:923
+#: src/webframe.rs:917
 msgid "All house number editors"
 msgstr "Összes házszám szerkesztő"
 
-#: src/webframe.rs:924
+#: src/webframe.rs:918
 msgid "Coverage"
 msgstr "Lefedettség"
 
-#: src/webframe.rs:925
+#: src/webframe.rs:919
 msgid "Capital coverage"
 msgstr "A főváros lefedettsége"
 
-#: src/webframe.rs:926
+#: src/webframe.rs:920
 msgid "Per-city coverage"
 msgstr "Városonkénti lefedettség"
 
-#: src/webframe.rs:927
+#: src/webframe.rs:921
 msgid "Per-ZIP coverage"
 msgstr "Irányítószámonkénti lefedettség"
 
-#: src/webframe.rs:928
+#: src/webframe.rs:922
 msgid "Invalid relation settings"
 msgstr "Érvénytelen területi beállítások"
 
-#: src/webframe.rs:999
+#: src/webframe.rs:993
 msgid ""
 "These statistics are provided purely for interested editors, and are not\n"
 "intended to reflect quality of work done by any given editor in OSM. If you "
@@ -381,39 +385,39 @@ msgstr ""
 "használni, hogy motiváljad magad, az rendben van, de ne felejtsd, hogy "
 "kevesebb hasznos munka többet ér, mint sok haszontalan munka."
 
-#: src/webframe.rs:1074
+#: src/webframe.rs:1068
 msgid "No such relation: {0}"
 msgstr "Nincs ilyen reláció: {0}"
 
-#: src/webframe.rs:1086
+#: src/webframe.rs:1080
 msgid "No existing streets: call Overpass to create..."
 msgstr "Nincsenek meglévő utcák: létrehozás Overpass hívásával..."
 
-#: src/webframe.rs:1091
+#: src/webframe.rs:1085
 msgid "No existing streets: waiting for Overpass..."
 msgstr "Nincsenek meglévő utcák: Overpass: várakozás..."
 
-#: src/webframe.rs:1109
+#: src/webframe.rs:1103
 msgid "No existing house numbers: call Overpass to create..."
 msgstr "Nincsenek meglévő házszámok: létrehozás Overpass hívásával..."
 
-#: src/webframe.rs:1115
+#: src/webframe.rs:1109
 msgid "No existing house numbers: waiting for Overpass..."
 msgstr "Nincsenek meglévő házszámok: Overpass: várakozás..."
 
-#: src/webframe.rs:1133
+#: src/webframe.rs:1127
 msgid "No reference house numbers: create from reference..."
 msgstr "Nincsenek referencia házszámok: létrehozás referenciából..."
 
-#: src/webframe.rs:1139
+#: src/webframe.rs:1133
 msgid "No reference house numbers: creating from reference..."
 msgstr "Nincsenek referencia házszámok: létrehozás referenciából..."
 
-#: src/webframe.rs:1154
+#: src/webframe.rs:1148
 msgid "No street list: create from reference..."
 msgstr "Nincsenek referencia utcák: létrehozás referenciából..."
 
-#: src/webframe.rs:1159
+#: src/webframe.rs:1153
 msgid "No reference streets: creating from reference..."
 msgstr "Nincsenek referencia utcák: létrehozás referenciából..."
 
@@ -445,7 +449,12 @@ msgstr ""
 msgid " (existing: {0}, ready: {1})."
 msgstr " (meglévő: {0}, készültség: {1})."
 
-#: src/wsgi.rs:239 src/wsgi_additional.rs:247
+#: src/wsgi.rs:236 src/wsgi_additional.rs:245
+msgid ""
+"https://vmiklos.hu/osm-gimmisn/usage.html#filtering-out-incorrect-information"
+msgstr "https://wiki.openstreetmap.org/wiki/Hungary/osm-gimmisn#T%C3%A9ves_inform%C3%A1ci%C3%B3_kisz%C5%B1r%C3%A9se"
+
+#: src/wsgi.rs:239 src/wsgi_additional.rs:249
 msgid "Filter incorrect information"
 msgstr "Téves információ szűrése"
 
@@ -556,6 +565,10 @@ msgstr "Terület"
 #: src/wsgi.rs:1372
 msgid "Street coverage"
 msgstr "Utca lefedettség"
+
+#: src/wsgi.rs:1390
+msgid "https://vmiklos.hu/osm-gimmisn/usage.html#how-to-add-a-new-area"
+msgstr "https://wiki.openstreetmap.org/wiki/Hungary/osm-gimmisn#%C3%9Aj_rel%C3%A1ci%C3%B3_hozz%C3%A1ad%C3%A1sa"
 
 #: src/wsgi.rs:1393
 msgid "Add new area"

--- a/po/osm-gimmisn.pot
+++ b/po/osm-gimmisn.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-13 20:27+0000\n"
+"POT-Creation-Date: 2023-01-13 20:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -125,7 +125,7 @@ msgstr ""
 msgid "Waiting for Overpass..."
 msgstr ""
 
-#: src/webframe.rs:392 src/webframe.rs:1093 src/webframe.rs:1117 src/wsgi.rs:1269
+#: src/webframe.rs:392 src/webframe.rs:1087 src/webframe.rs:1111 src/wsgi.rs:1269
 msgid "Error from Overpass: "
 msgstr ""
 
@@ -133,7 +133,7 @@ msgstr ""
 msgid "Creating from reference..."
 msgstr ""
 
-#: src/webframe.rs:397 src/webframe.rs:1141 src/webframe.rs:1161
+#: src/webframe.rs:397 src/webframe.rs:1135 src/webframe.rs:1155
 msgid "Error from reference: "
 msgstr ""
 
@@ -149,240 +149,244 @@ msgstr ""
 msgid "Statistics"
 msgstr ""
 
-#: src/webframe.rs:443
+#: src/webframe.rs:436
+msgid "https://vmiklos.hu/osm-gimmisn"
+msgstr ""
+
+#: src/webframe.rs:437
 msgid "Documentation"
 msgstr ""
 
-#: src/webframe.rs:518
+#: src/webframe.rs:512
 msgid "Internal error when serving {0}"
 msgstr ""
 
-#: src/webframe.rs:539
+#: src/webframe.rs:533
 msgid "Not Found"
 msgstr ""
 
-#: src/webframe.rs:543
+#: src/webframe.rs:537
 msgid "The requested URL was not found on this server."
 msgstr ""
 
-#: src/webframe.rs:618 src/webframe.rs:882
+#: src/webframe.rs:612 src/webframe.rs:876
 msgid "City name"
 msgstr ""
 
-#: src/webframe.rs:619 src/webframe.rs:720 src/wsgi.rs:1370
+#: src/webframe.rs:613 src/webframe.rs:714 src/wsgi.rs:1370
 msgid "House number coverage"
 msgstr ""
 
-#: src/webframe.rs:620 src/webframe.rs:721
+#: src/webframe.rs:614 src/webframe.rs:715
 msgid "OSM count"
 msgstr ""
 
-#: src/webframe.rs:621 src/webframe.rs:722
+#: src/webframe.rs:615 src/webframe.rs:716
 msgid "Reference count"
 msgstr ""
 
-#: src/webframe.rs:644 src/webframe.rs:745 src/webframe.rs:994
+#: src/webframe.rs:638 src/webframe.rs:739 src/webframe.rs:988
 msgid "Note"
 msgstr ""
 
-#: src/webframe.rs:649
+#: src/webframe.rs:643
 msgid "These statistics are estimates, not taking house number filters into account.\n"
 "Only cities with house numbers in OSM are considered."
 msgstr ""
 
-#: src/webframe.rs:719
+#: src/webframe.rs:713
 msgid "ZIP code"
 msgstr ""
 
-#: src/webframe.rs:750
+#: src/webframe.rs:744
 msgid "These statistics are estimates, not taking house number filters into account.\n"
 "Only zip codes with house numbers in OSM are considered."
 msgstr ""
 
-#: src/webframe.rs:850
+#: src/webframe.rs:844
 msgid "New house numbers, last 2 weeks, as of {}"
 msgstr ""
 
-#: src/webframe.rs:852
+#: src/webframe.rs:846
 msgid "During this day"
 msgstr ""
 
-#: src/webframe.rs:853 src/webframe.rs:859 src/webframe.rs:917
+#: src/webframe.rs:847 src/webframe.rs:853 src/webframe.rs:911
 msgid "New house numbers"
 msgstr ""
 
-#: src/webframe.rs:856
+#: src/webframe.rs:850
 msgid "New house numbers, last year, as of {}"
 msgstr ""
 
-#: src/webframe.rs:858
+#: src/webframe.rs:852
 msgid "During this month"
 msgstr ""
 
-#: src/webframe.rs:862
+#: src/webframe.rs:856
 msgid "All house numbers, last year, as of {}"
 msgstr ""
 
-#: src/webframe.rs:864
+#: src/webframe.rs:858
 msgid "Latest for this month"
 msgstr ""
 
-#: src/webframe.rs:865 src/webframe.rs:871 src/webframe.rs:918
+#: src/webframe.rs:859 src/webframe.rs:865 src/webframe.rs:912
 msgid "All house numbers"
 msgstr ""
 
-#: src/webframe.rs:868
+#: src/webframe.rs:862
 msgid "All house numbers, last 2 weeks, as of {}"
 msgstr ""
 
-#: src/webframe.rs:870
+#: src/webframe.rs:864
 msgid "At the start of this day"
 msgstr ""
 
-#: src/webframe.rs:874
+#: src/webframe.rs:868
 msgid "Top house number editors, as of {}"
 msgstr ""
 
-#: src/webframe.rs:876
+#: src/webframe.rs:870
 msgid "User name"
 msgstr ""
 
-#: src/webframe.rs:879
+#: src/webframe.rs:873
 msgid "Number of house numbers last changed by this user"
 msgstr ""
 
-#: src/webframe.rs:881
+#: src/webframe.rs:875
 msgid "Top edited cities, as of {}"
 msgstr ""
 
-#: src/webframe.rs:885
+#: src/webframe.rs:879
 msgid "Number of house numbers added in the past 30 days"
 msgstr ""
 
-#: src/webframe.rs:887
+#: src/webframe.rs:881
 msgid "(empty)"
 msgstr ""
 
-#: src/webframe.rs:888
+#: src/webframe.rs:882
 msgid "(invalid)"
 msgstr ""
 
-#: src/webframe.rs:891
+#: src/webframe.rs:885
 msgid "Number of house number editors, as of {}"
 msgstr ""
 
-#: src/webframe.rs:893
+#: src/webframe.rs:887
 msgid "All editors"
 msgstr ""
 
-#: src/webframe.rs:896
+#: src/webframe.rs:890
 msgid "Number of editors, at least one housenumber is last changed by these users"
 msgstr ""
 
-#: src/webframe.rs:898
+#: src/webframe.rs:892
 msgid "Coverage is {1}%, as of {2}"
 msgstr ""
 
-#: src/webframe.rs:901
+#: src/webframe.rs:895
 msgid "Number of house numbers in database"
 msgstr ""
 
-#: src/webframe.rs:903
+#: src/webframe.rs:897
 msgid "Data source"
 msgstr ""
 
-#: src/webframe.rs:906
+#: src/webframe.rs:900
 msgid "Coverage is {1}% for the capital, as of {2}"
 msgstr ""
 
-#: src/webframe.rs:910
+#: src/webframe.rs:904
 msgid "Number of house numbers in database for the capital"
 msgstr ""
 
-#: src/webframe.rs:912
+#: src/webframe.rs:906
 msgid "Reference"
 msgstr ""
 
-#: src/webframe.rs:919
+#: src/webframe.rs:913
 msgid "New house numbers, monthly"
 msgstr ""
 
-#: src/webframe.rs:920
+#: src/webframe.rs:914
 msgid "All house numbers, monthly"
 msgstr ""
 
-#: src/webframe.rs:921
+#: src/webframe.rs:915
 msgid "Top house number editors"
 msgstr ""
 
-#: src/webframe.rs:922
+#: src/webframe.rs:916
 msgid "Top edited cities"
 msgstr ""
 
-#: src/webframe.rs:923
+#: src/webframe.rs:917
 msgid "All house number editors"
 msgstr ""
 
-#: src/webframe.rs:924
+#: src/webframe.rs:918
 msgid "Coverage"
 msgstr ""
 
-#: src/webframe.rs:925
+#: src/webframe.rs:919
 msgid "Capital coverage"
 msgstr ""
 
-#: src/webframe.rs:926
+#: src/webframe.rs:920
 msgid "Per-city coverage"
 msgstr ""
 
-#: src/webframe.rs:927
+#: src/webframe.rs:921
 msgid "Per-ZIP coverage"
 msgstr ""
 
-#: src/webframe.rs:928
+#: src/webframe.rs:922
 msgid "Invalid relation settings"
 msgstr ""
 
-#: src/webframe.rs:999
+#: src/webframe.rs:993
 msgid "These statistics are provided purely for interested editors, and are not\n"
 "intended to reflect quality of work done by any given editor in OSM. If you want to use\n"
 "them to motivate yourself, that's fine, but keep in mind that a bit of useful work is\n"
 "more meaningful than a lot of useless work."
 msgstr ""
 
-#: src/webframe.rs:1074
+#: src/webframe.rs:1068
 msgid "No such relation: {0}"
 msgstr ""
 
-#: src/webframe.rs:1086
+#: src/webframe.rs:1080
 msgid "No existing streets: call Overpass to create..."
 msgstr ""
 
-#: src/webframe.rs:1091
+#: src/webframe.rs:1085
 msgid "No existing streets: waiting for Overpass..."
 msgstr ""
 
-#: src/webframe.rs:1109
+#: src/webframe.rs:1103
 msgid "No existing house numbers: call Overpass to create..."
 msgstr ""
 
-#: src/webframe.rs:1115
+#: src/webframe.rs:1109
 msgid "No existing house numbers: waiting for Overpass..."
 msgstr ""
 
-#: src/webframe.rs:1133
+#: src/webframe.rs:1127
 msgid "No reference house numbers: create from reference..."
 msgstr ""
 
-#: src/webframe.rs:1139
+#: src/webframe.rs:1133
 msgid "No reference house numbers: creating from reference..."
 msgstr ""
 
-#: src/webframe.rs:1154
+#: src/webframe.rs:1148
 msgid "No street list: create from reference..."
 msgstr ""
 
-#: src/webframe.rs:1159
+#: src/webframe.rs:1153
 msgid "No reference streets: creating from reference..."
 msgstr ""
 
@@ -410,7 +414,11 @@ msgstr ""
 msgid " (existing: {0}, ready: {1})."
 msgstr ""
 
-#: src/wsgi.rs:239 src/wsgi_additional.rs:247
+#: src/wsgi.rs:236 src/wsgi_additional.rs:245
+msgid "https://vmiklos.hu/osm-gimmisn/usage.html#filtering-out-incorrect-information"
+msgstr ""
+
+#: src/wsgi.rs:239 src/wsgi_additional.rs:249
 msgid "Filter incorrect information"
 msgstr ""
 
@@ -520,6 +528,10 @@ msgstr ""
 
 #: src/wsgi.rs:1372
 msgid "Street coverage"
+msgstr ""
+
+#: src/wsgi.rs:1390
+msgid "https://vmiklos.hu/osm-gimmisn/usage.html#how-to-add-a-new-area"
 msgstr ""
 
 #: src/wsgi.rs:1393

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -433,13 +433,7 @@ pub fn get_toolbar(
 
         let doc = yattag::Doc::new();
         {
-            let a = doc.tag(
-                "a",
-                &[(
-                    "href",
-                    "https://github.com/vmiklos/osm-gimmisn/tree/master/doc",
-                )],
-            );
+            let a = doc.tag("a", &[("href", &tr("https://vmiklos.hu/osm-gimmisn"))]);
             a.text(&tr("Documentation"));
         }
         items.push(doc);

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -233,7 +233,7 @@ fn missing_housenumbers_view_res_html(
                 "a",
                 &[(
                     "href",
-                    "https://github.com/vmiklos/osm-gimmisn/tree/master/doc",
+                    &tr("https://vmiklos.hu/osm-gimmisn/usage.html#filtering-out-incorrect-information"),
                 )],
             );
             a.text(&tr("Filter incorrect information"));
@@ -1387,7 +1387,7 @@ fn handle_main(
             "a",
             &[(
                 "href",
-                "https://github.com/vmiklos/osm-gimmisn/tree/master/doc",
+                &tr("https://vmiklos.hu/osm-gimmisn/usage.html#how-to-add-a-new-area"),
             )],
         );
         a.text(&tr("Add new area"));

--- a/src/wsgi_additional.rs
+++ b/src/wsgi_additional.rs
@@ -241,7 +241,9 @@ fn additional_housenumbers_view_result_html(
             "a",
             &[(
                 "href",
-                "https://github.com/vmiklos/osm-gimmisn/tree/master/doc",
+                &tr(
+                    "https://vmiklos.hu/osm-gimmisn/usage.html#filtering-out-incorrect-information",
+                ),
             )],
         );
         a.text(&tr("Filter incorrect information"));


### PR DESCRIPTION
Now that the guide is in markdown + the translation is in the wiki, we
can always link to the guide in general, or to the sections that add a
new area or filter noise, take advantage of this.

Change-Id: I191d44ac63c25a1d99eea8b4864507148340b235
