### PR TITLE
license: add cargo-about integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,11 @@ tags:
 	rusty-tags vi
 	ln -sf rusty-tags.vi tags
 
+guide:
+	cd guide && mdbook build
+	cargo about generate about.hbs > guide/book/license.html
+
 run-guide:
 	cd guide && mdbook serve --hostname 127.0.0.1
 
-.PHONY: tags
+.PHONY: tags guide

--- a/about.hbs
+++ b/about.hbs
@@ -1,0 +1,70 @@
+<html>
+
+<head>
+    <style>
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #333;
+                color: white;
+            }
+            a {
+                color: skyblue;
+            }
+        }
+        .container {
+            font-family: sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+        .intro {
+            text-align: center;
+        }
+        .licenses-list {
+            list-style-type: none;
+            margin: 0;
+            padding: 0;
+        }
+        .license-used-by {
+            margin-top: -10px;
+        }
+        .license-text {
+            max-height: 200px;
+            overflow-y: scroll;
+            white-space: pre-wrap;
+        }
+    </style>
+</head>
+
+<body>
+    <main class="container">
+        <div class="intro">
+            <h1>Third Party Licenses</h1>
+            <p>This page lists the licenses of the projects used in cargo-about.</p>
+        </div>
+    
+        <h2>Overview of licenses:</h2>
+        <ul class="licenses-overview">
+            {{#each overview}}
+            <li><a href="#{{id}}">{{name}}</a> ({{count}})</li>
+            {{/each}}
+        </ul>
+
+        <h2>All license text:</h2>
+        <ul class="licenses-list">
+            {{#each licenses}}
+            <li class="license">
+                <h3 id="{{id}}">{{name}}</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    {{#each used_by}}
+                    <li><a href="{{#if crate.repository}} {{crate.repository}} {{else}} https://crates.io/crates/{{crate.name}} {{/if}}">{{crate.name}} {{crate.version}}</a></li>
+                    {{/each}}
+                </ul>
+                <pre class="license-text">{{text}}</pre>
+            </li>
+            {{/each}}
+        </ul>
+    </main>
+</body>
+
+</html>

--- a/about.toml
+++ b/about.toml
@@ -1,0 +1,10 @@
+accepted = [
+    "Apache-2.0",
+    "MIT",
+    "BSD-3-Clause",
+    "Unicode-DFS-2016",
+    "ISC",
+    "BSD-2-Clause",
+    "CC0-1.0",
+    "Zlib",
+]

--- a/guide/src/README.md
+++ b/guide/src/README.md
@@ -31,3 +31,4 @@ osm-gimmisn has been used on Linux, but the data validator is known to work Wind
 ## License
 
 Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+See the [license bundle](license.html) for details.


### PR DESCRIPTION
See
<https://github.com/EmbarkStudios/cargo-about#generate-license-information-for-your-own-project>,
this can generate a license bundle, to credit all used dependencies
correctly.

Change-Id: I91df39edda795f8467c1b5879ae851dd6687d42e
