### PR TITLE
webframe: fix git commit link in the footer when the commit matches a tag

### DIFF
--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -16,7 +16,6 @@ use crate::i18n::translate as tr;
 use crate::util;
 use crate::yattag;
 use anyhow::Context;
-use git_version::git_version;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -32,7 +31,7 @@ pub fn get_footer(last_updated: &str) -> yattag::Doc {
         doc.text(&tr("Version: "));
         doc.append_value(
             util::git_link(
-                git_version!(),
+                git_version::git_version!(args = ["--always", "--long"]),
                 "https://github.com/vmiklos/osm-gimmisn/commit/",
             )
             .get_value(),


### PR DESCRIPTION
Which is rare, since data/ is updated frequently, so we typically a
random commit is deployed, not an exact tag; but it can still happen.

Old output for a match was:

	v7.5-rc1

New output:

	v7.5-rc1-0-g6ddad82e

util::git_link() works better with the later.

Change-Id: I92a50d955296b449886c6bb2e9ec01d34e19c0ff
