### PR TITLE
yattag: use variables directly in the format string

### DIFF
--- a/src/yattag.rs
+++ b/src/yattag.rs
@@ -55,7 +55,7 @@ impl Doc {
 
     /// Starts a new tag and closes it as well.
     pub fn stag(&self, name: &str) {
-        self.append_value(format!("<{} />", name));
+        self.append_value(format!("<{name} />"));
     }
 
     /// Appends unescaped content to the document.
@@ -83,11 +83,11 @@ pub struct Tag {
 impl Tag {
     fn new(value: &Rc<RefCell<String>>, name: &str, attrs: &[(&str, &str)]) -> Tag {
         let mut guard = value.borrow_mut();
-        guard.push_str(&format!("<{}", name));
+        guard.push_str(&format!("<{name}"));
         for attr in attrs {
             let key = attr.0;
             let val = html_escape::encode_double_quoted_attribute(&attr.1);
-            guard.push_str(&format!(" {}=\"{}\"", key, val));
+            guard.push_str(&format!(" {key}=\"{val}\""));
         }
         guard.push('>');
         let value = value.clone();
@@ -110,11 +110,11 @@ impl Tag {
 
     /// Starts a new tag and closes it as well, inside a tag.
     pub fn stag(&self, name: &str, attrs: &[(&str, &str)]) {
-        self.append_value(format!("<{}", name));
+        self.append_value(format!("<{name}"));
         for attr in attrs {
             let key = attr.0;
             let value = html_escape::encode_double_quoted_attribute(&attr.1);
-            self.append_value(format!(" {}=\"{}\"", key, value));
+            self.append_value(format!(" {key}=\"{value}\""));
         }
         self.append_value(String::from("/>"))
     }


### PR DESCRIPTION
Change-Id: I5855ed9aa561dc44eeacc609a099e6d1604aa50e
