### PR TITLE
Use variables directly in the format string

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -371,12 +371,12 @@ impl Relation {
     ) -> anyhow::Result<Self> {
         let mut my_config = RelationDict::default();
         let file = area_files::RelationFiles::new(&ctx.get_ini().get_workdir(), name);
-        let relation_path = format!("relation-{}.yaml", name);
+        let relation_path = format!("relation-{name}.yaml");
         // Intentionally don't require this cache to be present, it's fine to omit it for simple
         // relations.
         if let Some(value) = yaml_cache.get(&relation_path) {
             my_config = serde_json::from_value(value.clone())
-                .context(format!("failed to parse '{}'", relation_path))?;
+                .context(format!("failed to parse '{relation_path}'"))?;
         }
         let config = RelationConfig::new(parent_config, &my_config);
         // osm street name -> house number list map, so we don't have to read the on-disk list of the
@@ -898,7 +898,7 @@ impl Relation {
         };
 
         // Write the bottom line to a file, so the index page show it fast.
-        let string = format!("{0:.2}", percent);
+        let string = format!("{percent:.2}");
         self.ctx
             .get_file_system()
             .write_from_string(&string, &self.file.get_streets_percent_path())?;
@@ -1017,7 +1017,7 @@ impl Relation {
 
         // Write the bottom line to a file, so the index page show it fast.
         self.ctx.get_file_system().write_from_string(
-            &format!("{0:.2}", percent),
+            &format!("{percent:.2}"),
             &self.file.get_housenumbers_percent_path(),
         )?;
 
@@ -1232,7 +1232,7 @@ impl Relations {
 
     /// Gets a sorted list of relation names.
     pub fn get_names(&self) -> Vec<String> {
-        let mut ret: Vec<String> = self.dict.iter().map(|(key, _value)| key.into()).collect();
+        let mut ret: Vec<String> = self.dict.keys().map(|key| key.into()).collect();
         ret.sort();
         ret.dedup();
         ret
@@ -1323,8 +1323,7 @@ impl Relations {
                 return Ok(());
             }
         };
-        let relation_names: Vec<String> =
-            self.dict.iter().map(|(key, _value)| key.clone()).collect();
+        let relation_names: Vec<String> = self.dict.keys().cloned().collect();
         for relation_name in relation_names {
             let relation = self.get_relation(&relation_name)?;
             if relation.config.get_refcounty() == refcounty {
@@ -1347,8 +1346,7 @@ impl Relations {
                 return Ok(());
             }
         };
-        let relation_names: Vec<String> =
-            self.dict.iter().map(|(key, _value)| key.clone()).collect();
+        let relation_names: Vec<String> = self.dict.keys().cloned().collect();
         for relation_name in relation_names {
             let relation = self.get_relation(&relation_name)?;
             if relation.config.get_refsettlement() == refsettlement {
@@ -1511,8 +1509,8 @@ area(@AREA@)->.searchArea;
 "#;
     let mut query = util::process_template(header, relation.config.get_osmrelation());
     for street in streets {
-        writeln!(query, "way[\"name\"=\"{}\"](r.searchRelation);", street).unwrap();
-        writeln!(query, "way[\"name\"=\"{}\"](area.searchArea);", street).unwrap();
+        writeln!(query, "way[\"name\"=\"{street}\"](r.searchRelation);").unwrap();
+        writeln!(query, "way[\"name\"=\"{street}\"](area.searchArea);").unwrap();
     }
     query += r#");
 out body;
@@ -1539,7 +1537,7 @@ area(@AREA@)->.searchArea;
     ids.sort();
     ids.dedup();
     for (osm_type, osm_id) in ids {
-        writeln!(query, "{}({});", osm_type, osm_id).unwrap();
+        writeln!(query, "{osm_type}({osm_id});").unwrap();
     }
     query += r#");
 out body;

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -1101,9 +1101,7 @@ fn test_relation_get_ref_street_from_osm_street_refstreets() {
     let relation_name = "myrelation";
     let relation = relations.get_relation(relation_name).unwrap();
     let refcounty = relation.get_config().get_refcounty();
-    let street = relation
-        .get_config()
-        .get_ref_street_from_osm_street(&street);
+    let street = relation.get_config().get_ref_street_from_osm_street(street);
     assert_eq!(refcounty, "01");
     assert_eq!(
         relation.get_config().get_street_refsettlement(&street),
@@ -1878,7 +1876,7 @@ fn test_relation_write_missing_housenumbers() {
     assert_eq!(todo_street_count, 3);
     assert_eq!(todo_count, 5);
     assert_eq!(done_count, 6);
-    assert_eq!(format!("{0:.2}", percent), "54.55");
+    assert_eq!(format!("{percent:.2}"), "54.55");
     let string_table = table_doc_to_string(&table);
     assert_eq!(
         string_table,
@@ -1948,7 +1946,7 @@ fn test_relation_write_missing_housenumbers_interpolation_all() {
     let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
     let path = ctx.get_abspath("workdir/cache-budafok.json");
     mtimes.insert(
-        path.to_string(),
+        path,
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
@@ -2065,7 +2063,7 @@ fn test_write_missing_streets() {
 
     assert_eq!(todo_count, 1);
     assert_eq!(done_count, 4);
-    assert_eq!(format!("{0:.2}", percent), "80.00");
+    assert_eq!(format!("{percent:.2}"), "80.00");
     assert_eq!(streets, ["Only In Ref utca"]);
     let mut guard = percent_value.borrow_mut();
     guard.seek(SeekFrom::Start(0)).unwrap();
@@ -2094,7 +2092,7 @@ fn test_write_missing_streets_empty() {
     let mut guard = percent_value.borrow_mut();
     assert_eq!(guard.seek(SeekFrom::Current(0)).unwrap() > 0, true);
     let (_todo_count, _done_count, percent, _streets) = ret;
-    assert_eq!(format!("{0:.2}", percent), "100.00");
+    assert_eq!(format!("{percent:.2}"), "100.00");
 }
 
 /// Tests Relation::build_ref_housenumbers().
@@ -2126,7 +2124,7 @@ fn test_relation_build_ref_housenumbers() {
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
     let mut relations = Relations::new(&ctx).unwrap();
-    let refpath = format!("{}/hazszamok_20190511.tsv", refdir);
+    let refpath = format!("{refdir}/hazszamok_20190511.tsv");
     let memory_cache = util::build_reference_cache(&ctx, &refpath, "01").unwrap();
     let relation_name = "myrelation";
     let street = "Törökugrató utca";
@@ -2170,7 +2168,7 @@ fn test_relation_build_ref_housenumbers_missing() {
     ctx.set_file_system(&file_system);
     let mut relations = Relations::new(&ctx).unwrap();
     let refdir = ctx.get_abspath("refdir");
-    let refpath = format!("{}/hazszamok_20190511.tsv", refdir);
+    let refpath = format!("{refdir}/hazszamok_20190511.tsv");
     let memory_cache = util::build_reference_cache(&ctx, &refpath, "01").unwrap();
     let relation_name = "myrelation";
     let street = "mystreet";
@@ -2204,7 +2202,7 @@ fn test_relation_build_ref_streets() {
         ],
     );
     let refdir = ctx.get_abspath("refdir");
-    let refpath = format!("{}/utcak_20190514.tsv", refdir);
+    let refpath = format!("{refdir}/utcak_20190514.tsv");
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
     let memory_cache = util::build_street_reference_cache(&ctx, &refpath).unwrap();
@@ -2249,8 +2247,8 @@ fn test_relation_writer_ref_housenumbers() {
     let ref_housenumbers_cache = context::tests::TestFileSystem::make_file();
     let ref_housenumbers2_cache = context::tests::TestFileSystem::make_file();
     let refdir = ctx.get_abspath("refdir");
-    let refpath = format!("{}/hazszamok_20190511.tsv", refdir);
-    let refpath2 = format!("{}/hazszamok_kieg_20190808.tsv", refdir);
+    let refpath = format!("{refdir}/hazszamok_20190511.tsv");
+    let refpath2 = format!("{refdir}/hazszamok_kieg_20190808.tsv");
     let ref_value = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
@@ -2275,7 +2273,7 @@ fn test_relation_writer_ref_housenumbers() {
     let mut relations = Relations::new(&ctx).unwrap();
     let relation_name = "gazdagret";
     let expected = String::from_utf8(
-        std::fs::read(&ctx.get_abspath("workdir/street-housenumbers-reference-gazdagret.lst"))
+        std::fs::read(ctx.get_abspath("workdir/street-housenumbers-reference-gazdagret.lst"))
             .unwrap(),
     )
     .unwrap();
@@ -2309,7 +2307,7 @@ fn test_relation_writer_ref_housenumbers_nosuchrefcounty() {
     let ref_streets_cache = context::tests::TestFileSystem::make_file();
     let ref_hns_cache = context::tests::TestFileSystem::make_file();
     let refdir = ctx.get_abspath("refdir");
-    let refpath = format!("{}/hazszamok_20190511.tsv", refdir);
+    let refpath = format!("{refdir}/hazszamok_20190511.tsv");
     let ref_value = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
@@ -2348,7 +2346,7 @@ fn test_relation_writer_ref_housenumbers_nosuchrefsettlement() {
     let ref_streets_cache = context::tests::TestFileSystem::make_file();
     let ref_hns_cache = context::tests::TestFileSystem::make_file();
     let refdir = ctx.get_abspath("refdir");
-    let refpath = format!("{}/hazszamok_20190511.tsv", refdir);
+    let refpath = format!("{refdir}/hazszamok_20190511.tsv");
     let ref_value = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
@@ -2398,12 +2396,12 @@ fn test_relation_write_ref_streets() {
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
     let refdir = ctx.get_abspath("refdir");
-    let refpath = format!("{}/utcak_20190514.tsv", refdir);
+    let refpath = format!("{refdir}/utcak_20190514.tsv");
     let mut relations = Relations::new(&ctx).unwrap();
     let relation_name = "gazdagret";
     let relation = relations.get_relation(relation_name).unwrap();
     let expected = String::from_utf8(
-        std::fs::read(&ctx.get_abspath("workdir/streets-reference-gazdagret.lst")).unwrap(),
+        std::fs::read(ctx.get_abspath("workdir/streets-reference-gazdagret.lst")).unwrap(),
     )
     .unwrap();
 
@@ -3039,7 +3037,7 @@ fn test_relation_normalize_invalids() {
     let relation = relations.get_relation("gazdagret").unwrap();
 
     let ret = relation
-        .normalize_invalids("Tűzkő utca", &vec!["5".to_string()])
+        .normalize_invalids("Tűzkő utca", &["5".to_string()])
         .unwrap();
 
     // This is empty because 5 is outside 1-3.

--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -121,7 +121,7 @@ fn test_is_cache_current() {
     let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
     ctx.set_file_system(&file_system_arc);
 
-    let ret = is_cache_current(&ctx, &cache_path, &[]).unwrap();
+    let ret = is_cache_current(&ctx, cache_path, &[]).unwrap();
 
     assert_eq!(ret, false);
 }

--- a/src/cache_yamls.rs
+++ b/src/cache_yamls.rs
@@ -24,7 +24,7 @@ pub fn our_main(argv: &[String], ctx: &context::Context) -> anyhow::Result<()> {
     let entries = ctx
         .get_file_system()
         .listdir(&datadir)
-        .context(format!("failed to listdir() {}", datadir))?;
+        .context(format!("failed to listdir() {datadir}"))?;
     let mut yaml_paths: Vec<String> = Vec::new();
     for path in entries {
         if path.ends_with(".yaml") {
@@ -34,16 +34,16 @@ pub fn our_main(argv: &[String], ctx: &context::Context) -> anyhow::Result<()> {
     yaml_paths.sort();
     for yaml_path in yaml_paths {
         let cache_key = yaml_path
-            .strip_prefix(&format!("{}/", datadir))
+            .strip_prefix(&format!("{datadir}/"))
             .context("yaml outside datadir")?
             .to_string();
         let data = ctx.get_file_system().read_to_string(&yaml_path)?;
         let cache_value = serde_yaml::from_str::<serde_json::Value>(&data)
-            .context(format!("serde_yaml::from_str() failed for {}", yaml_path))?;
+            .context(format!("serde_yaml::from_str() failed for {yaml_path}"))?;
         cache.insert(cache_key, cache_value);
     }
 
-    let cache_path = format!("{}/yamls.cache", datadir);
+    let cache_path = format!("{datadir}/yamls.cache");
     {
         let write_stream = ctx.get_file_system().open_write(&cache_path)?;
         let mut guard = write_stream.borrow_mut();
@@ -52,22 +52,22 @@ pub fn our_main(argv: &[String], ctx: &context::Context) -> anyhow::Result<()> {
     }
 
     let workdir = ctx.get_abspath(&argv[2]);
-    let yaml_path = format!("{}/relations.yaml", datadir);
+    let yaml_path = format!("{datadir}/relations.yaml");
     let mut relation_ids: Vec<u64> = Vec::new();
     let data = ctx.get_file_system().read_to_string(&yaml_path)?;
     let relations: areas::RelationsDict = serde_yaml::from_str(&data)
-        .context(format!("serde_yaml::from_str() failed for {}", yaml_path))?;
+        .context(format!("serde_yaml::from_str() failed for {yaml_path}"))?;
     for (_key, value) in relations {
         relation_ids.push(value.osmrelation.context("no osmrelation")?);
     }
     relation_ids.sort_unstable();
     relation_ids.dedup();
-    let statsdir = format!("{}/stats", workdir);
+    let statsdir = format!("{workdir}/stats");
     std::fs::create_dir_all(&statsdir)?;
     {
         let write_stream = ctx
             .get_file_system()
-            .open_write(&format!("{}/relations.json", statsdir))?;
+            .open_write(&format!("{statsdir}/relations.json"))?;
         let mut guard = write_stream.borrow_mut();
         let write = guard.deref_mut();
         serde_json::to_writer(write, &relation_ids)?;
@@ -81,7 +81,7 @@ pub fn main(argv: &[String], stream: &mut dyn Write, ctx: &context::Context) -> 
     match our_main(argv, ctx) {
         Ok(_) => 0,
         Err(err) => {
-            stream.write_all(format!("{:?}\n", err).as_bytes()).unwrap();
+            stream.write_all(format!("{err:?}\n").as_bytes()).unwrap();
             1
         }
     }

--- a/src/cache_yamls/tests.rs
+++ b/src/cache_yamls/tests.rs
@@ -74,8 +74,8 @@ fn test_main() {
     let mut guard = stats_value.borrow_mut();
     assert_eq!(guard.seek(SeekFrom::Current(0)).unwrap() > 0, true);
     guard.seek(SeekFrom::Start(0)).unwrap();
-    let mut read = guard.deref_mut();
-    let relation_ids: serde_json::Value = serde_json::from_reader(&mut read).unwrap();
+    let read = guard.deref_mut();
+    let relation_ids: serde_json::Value = serde_json::from_reader(read).unwrap();
     let relation_ids: Vec<_> = relation_ids
         .as_array()
         .unwrap()

--- a/src/context.rs
+++ b/src/context.rs
@@ -229,13 +229,13 @@ impl Context {
     pub fn new(prefix: &str) -> anyhow::Result<Self> {
         let current_dir = std::env::current_dir()?;
         let current_dir_str = current_dir.to_str().context("current_dir() failed")?;
-        let root = format!("{}/{}", current_dir_str, prefix);
+        let root = format!("{current_dir_str}/{prefix}");
         let network = Arc::new(StdNetwork {});
         let time = Arc::new(StdTime {});
         let subprocess = Arc::new(StdSubprocess {});
         let unit = Arc::new(StdUnit {});
         let file_system: Arc<dyn FileSystem> = Arc::new(StdFileSystem {});
-        let ini = Ini::new(&file_system, &format!("{}/wsgi.ini", root), &root)?;
+        let ini = Ini::new(&file_system, &format!("{root}/wsgi.ini"), &root)?;
         Ok(Context {
             root,
             ini,

--- a/src/context/system.rs
+++ b/src/context/system.rs
@@ -43,7 +43,7 @@ impl FileSystem for StdFileSystem {
     fn open_read(&self, path: &str) -> anyhow::Result<Rc<RefCell<dyn Read>>> {
         let ret: Rc<RefCell<dyn Read>> = Rc::new(RefCell::new(
             std::fs::File::open(path)
-                .with_context(|| format!("failed to open {} for reading", path))?,
+                .with_context(|| format!("failed to open {path} for reading"))?,
         ));
         Ok(ret)
     }
@@ -57,7 +57,7 @@ impl FileSystem for StdFileSystem {
 
         let ret: Rc<RefCell<dyn Write>> = Rc::new(RefCell::new(
             std::fs::File::create(path)
-                .with_context(|| format!("failed to open {} for writing", path))?,
+                .with_context(|| format!("failed to open {path} for writing"))?,
         ));
         Ok(ret)
     }

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -132,7 +132,7 @@ impl FileSystem for TestFileSystem {
         }
 
         let metadata =
-            std::fs::metadata(path).context(format!("metadata() failed for '{}'", path))?;
+            std::fs::metadata(path).context(format!("metadata() failed for '{path}'"))?;
         Ok(time::OffsetDateTime::try_from(metadata.modified()?)?)
     }
 
@@ -147,7 +147,7 @@ impl FileSystem for TestFileSystem {
             return Ok(ret);
         }
         let ret: Rc<RefCell<dyn Read>> = Rc::new(RefCell::new(
-            std::fs::File::open(path).context(format!("failed to open '{}'", path))?,
+            std::fs::File::open(path).context(format!("failed to open '{path}'"))?,
         ));
         Ok(ret)
     }
@@ -166,7 +166,7 @@ impl FileSystem for TestFileSystem {
             hide_paths.remove(position);
         }
 
-        if let Some(ref value) = self.mtimes.get(path) {
+        if let Some(value) = self.mtimes.get(path) {
             let mut guard = value.borrow_mut();
             *guard = time::OffsetDateTime::now_utc();
         }
@@ -182,13 +182,14 @@ impl FileSystem for TestFileSystem {
             return Err(anyhow::anyhow!("unlink: {}: no such file", path));
         }
 
-        Ok(hide_paths.push(path.to_string()))
+        hide_paths.push(path.to_string());
+        Ok(())
     }
 
     fn listdir(&self, path: &str) -> anyhow::Result<Vec<String>> {
         let mut contents: Vec<String> = Vec::new();
         for file in self.files.iter() {
-            if self.hide_paths.borrow().contains(&file.0) {
+            if self.hide_paths.borrow().contains(file.0) {
                 continue;
             }
 

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -36,7 +36,7 @@ fn overpass_sleep(ctx: &context::Context) {
         if sleep == 0 {
             break;
         }
-        info!("overpass_sleep: waiting for {} seconds", sleep);
+        info!("overpass_sleep: waiting for {sleep} seconds");
         ctx.get_time().sleep(sleep as u64);
     }
 }
@@ -62,11 +62,11 @@ fn update_osm_streets(
         {
             continue;
         }
-        info!("update_osm_streets: start: {}", relation_name);
+        info!("update_osm_streets: start: {relation_name}");
         let mut retry = 0;
         while should_retry(retry) {
             if retry > 0 {
-                info!("update_osm_streets: try #{}", retry);
+                info!("update_osm_streets: try #{retry}");
             }
             retry += 1;
             overpass_sleep(ctx);
@@ -74,7 +74,7 @@ fn update_osm_streets(
             let buf = match overpass_query::overpass_query(ctx, query) {
                 Ok(value) => value,
                 Err(err) => {
-                    info!("update_osm_streets: http error: {:?}", err);
+                    info!("update_osm_streets: http error: {err:?}");
                     continue;
                 }
             };
@@ -84,7 +84,7 @@ fn update_osm_streets(
             }
             break;
         }
-        info!("update_osm_streets: end: {}", relation_name);
+        info!("update_osm_streets: end: {relation_name}");
     }
 
     Ok(())
@@ -105,11 +105,11 @@ fn update_osm_housenumbers(
         {
             continue;
         }
-        info!("update_osm_housenumbers: start: {}", relation_name);
+        info!("update_osm_housenumbers: start: {relation_name}");
         let mut retry = 0;
         while should_retry(retry) {
             if retry > 0 {
-                info!("update_osm_housenumbers: try #{}", retry);
+                info!("update_osm_housenumbers: try #{retry}");
             }
             retry += 1;
             overpass_sleep(ctx);
@@ -117,7 +117,7 @@ fn update_osm_housenumbers(
             let buf = match overpass_query::overpass_query(ctx, query) {
                 Ok(value) => value,
                 Err(err) => {
-                    info!("update_osm_housenumbers: http error: {:?}", err);
+                    info!("update_osm_housenumbers: http error: {err:?}");
                     continue;
                 }
             };
@@ -127,7 +127,7 @@ fn update_osm_housenumbers(
             }
             break;
         }
-        info!("update_osm_housenumbers: end: {}", relation_name);
+        info!("update_osm_housenumbers: end: {relation_name}");
     }
 
     Ok(())
@@ -154,12 +154,12 @@ fn update_ref_housenumbers(
             continue;
         }
 
-        info!("update_ref_housenumbers: start: {}", relation_name);
+        info!("update_ref_housenumbers: start: {relation_name}");
         if let Err(err) = relation.write_ref_housenumbers(&references) {
-            info!("update_osm_housenumbers: failed: {:?}", err);
+            info!("update_osm_housenumbers: failed: {err:?}");
             continue;
         }
-        info!("update_ref_housenumbers: end: {}", relation_name);
+        info!("update_ref_housenumbers: end: {relation_name}");
     }
 
     Ok(())
@@ -186,9 +186,9 @@ fn update_ref_streets(
             continue;
         }
 
-        info!("update_ref_streets: start: {}", relation_name);
+        info!("update_ref_streets: start: {relation_name}");
         relation.write_ref_streets(&reference)?;
-        info!("update_ref_streets: end: {}", relation_name);
+        info!("update_ref_streets: end: {relation_name}");
     }
 
     Ok(())
@@ -326,13 +326,13 @@ fn write_zip_count_path(
 /// Counts the # of all house numbers as of today.
 fn update_stats_count(ctx: &context::Context, today: &str) -> anyhow::Result<()> {
     let statedir = ctx.get_abspath("workdir/stats");
-    let csv_path = format!("{}/{}.csv", statedir, today);
+    let csv_path = format!("{statedir}/{today}.csv");
     if !ctx.get_file_system().path_exists(&csv_path) {
         return Ok(());
     }
-    let count_path = format!("{}/{}.count", statedir, today);
-    let city_count_path = format!("{}/{}.citycount", statedir, today);
-    let zip_count_path = format!("{}/{}.zipcount", statedir, today);
+    let count_path = format!("{statedir}/{today}.count");
+    let city_count_path = format!("{statedir}/{today}.citycount");
+    let zip_count_path = format!("{statedir}/{today}.zipcount");
     let mut house_numbers: HashSet<String> = HashSet::new();
     let mut cities: HashMap<String, HashSet<String>> = HashMap::new();
     let mut zips: HashMap<String, HashSet<String>> = HashMap::new();
@@ -386,12 +386,12 @@ fn update_stats_count(ctx: &context::Context, today: &str) -> anyhow::Result<()>
 /// Counts the top housenumber editors as of today.
 fn update_stats_topusers(ctx: &context::Context, today: &str) -> anyhow::Result<()> {
     let statedir = ctx.get_abspath("workdir/stats");
-    let csv_path = format!("{}/{}.csv", statedir, today);
+    let csv_path = format!("{statedir}/{today}.csv");
     if !ctx.get_file_system().path_exists(&csv_path) {
         return Ok(());
     }
-    let topusers_path = format!("{}/{}.topusers", statedir, today);
-    let usercount_path = format!("{}/{}.usercount", statedir, today);
+    let topusers_path = format!("{statedir}/{today}.topusers");
+    let usercount_path = format!("{statedir}/{today}.usercount");
     let mut users: HashMap<String, u64> = HashMap::new();
     {
         let stream = ctx.get_file_system().open_read(&csv_path)?;
@@ -450,8 +450,8 @@ fn update_stats_refcount(ctx: &context::Context, state_dir: &str) -> anyhow::Res
         }
     }
 
-    let string = format!("{}\n", count);
-    let path = format!("{}/ref.count", state_dir);
+    let string = format!("{count}\n");
+    let path = format!("{state_dir}/ref.count");
     ctx.get_file_system().write_from_string(&string, &path)
 }
 
@@ -466,21 +466,21 @@ fn update_stats(ctx: &context::Context, overpass: bool) -> anyhow::Result<()> {
     let now = ctx.get_time().now();
     let format = time::format_description::parse("[year]-[month]-[day]")?;
     let today = now.format(&format)?;
-    let csv_path = format!("{}/{}.csv", statedir, today);
+    let csv_path = format!("{statedir}/{today}.csv");
 
     if overpass {
         info!("update_stats: talking to overpass");
         let mut retry = 0;
         while should_retry(retry) {
             if retry > 0 {
-                info!("update_stats: try #{}", retry);
+                info!("update_stats: try #{retry}");
             }
             retry += 1;
             overpass_sleep(ctx);
             let response = match overpass_query::overpass_query(ctx, query.clone()) {
                 Ok(value) => value,
                 Err(err) => {
-                    info!("update_stats: http error: {}", err);
+                    info!("update_stats: http error: {err}");
                     continue;
                 }
             };
@@ -507,7 +507,7 @@ fn update_stats(ctx: &context::Context, overpass: bool) -> anyhow::Result<()> {
 
         if last_modified.whole_seconds() >= 24_i64 * 3600_i64 * 7_i64 {
             ctx.get_file_system().unlink(&file_name)?;
-            info!("update_stats: removed old {}", file_name);
+            info!("update_stats: removed old {file_name}");
         }
     }
 
@@ -542,13 +542,13 @@ fn our_main_inner(
     }
 
     let pid = std::process::id();
-    let stream = std::fs::File::open(format!("/proc/{}/status", pid))?;
+    let stream = std::fs::File::open(format!("/proc/{pid}/status"))?;
     let reader = std::io::BufReader::new(stream);
     for line in reader.lines() {
         let line = line?.to_string();
         if line.starts_with("VmPeak:") {
             let vm_peak = line.trim();
-            info!("our_main: {}", vm_peak);
+            info!("our_main: {vm_peak}");
             break;
         }
     }
@@ -611,8 +611,8 @@ pub fn our_main(
     let seconds = duration.whole_seconds() % 60;
     let minutes = duration.whole_minutes() % 60;
     let hours = duration.whole_hours();
-    let duration = format!("{}:{:0>2}:{:0>2}", hours, minutes, seconds);
-    info!("main: finished in {}", duration);
+    let duration = format!("{hours}:{minutes:0>2}:{seconds:0>2}");
+    info!("main: finished in {duration}");
 
     Ok(())
 }
@@ -622,7 +622,7 @@ pub fn main(argv: &[String], stream: &mut dyn Write, ctx: &context::Context) -> 
     match our_main(argv, stream, ctx) {
         Ok(_) => 0,
         Err(err) => {
-            error!("main: unhandled error: {:?}", err);
+            error!("main: unhandled error: {err:?}");
             1
         }
     }

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -775,13 +775,10 @@ fn test_update_stats() {
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
     let path = ctx.get_abspath("workdir/stats/2020-05-10.csv");
-    mtimes.insert(
-        path.to_string(),
-        Rc::new(RefCell::new(ctx.get_time().now())),
-    );
+    mtimes.insert(path, Rc::new(RefCell::new(ctx.get_time().now())));
     let path = ctx.get_abspath("workdir/stats/old.csv");
     mtimes.insert(
-        path.to_string(),
+        path,
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
@@ -791,7 +788,7 @@ fn test_update_stats() {
     let now = ctx.get_time().now();
     let format = time::format_description::parse("[year]-[month]-[day]").unwrap();
     let today = now.format(&format).unwrap();
-    let path = ctx.get_abspath(&format!("workdir/stats/{}.csv", today));
+    let path = ctx.get_abspath(&format!("workdir/stats/{today}.csv"));
 
     update_stats(&ctx, /*overpass=*/ true).unwrap();
 
@@ -1026,7 +1023,7 @@ fn test_our_main() {
     let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
     let path = ctx.get_abspath("workdir/cache-gazdagret.json");
     mtimes.insert(
-        path.to_string(),
+        path,
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
@@ -1126,10 +1123,7 @@ fn test_our_main_stats() {
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
     let path = ctx.get_abspath("workdir/stats/2020-05-10.csv");
-    mtimes.insert(
-        path.to_string(),
-        Rc::new(RefCell::new(ctx.get_time().now())),
-    );
+    mtimes.insert(path, Rc::new(RefCell::new(ctx.get_time().now())));
     file_system.set_mtimes(&mtimes);
     let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
     ctx.set_file_system(&file_system_arc);

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -22,10 +22,7 @@ pub fn set_language(ctx: &context::Context, language: &str) {
     // Not using ctx.get_abspath() here, tests/ doesn't have its own dummy translations.
     let current_dir = std::env::current_dir().expect("current_dir() failed");
     let current_dir_str = current_dir.to_str().expect("PathBuf::to_str() failed");
-    let path = format!(
-        "{}/locale/{}/LC_MESSAGES/osm-gimmisn.mo",
-        current_dir_str, language
-    );
+    let path = format!("{current_dir_str}/locale/{language}/LC_MESSAGES/osm-gimmisn.mo");
 
     if ctx.get_file_system().path_exists(&path) {
         // The file exists, so this should not fail.

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,12 +36,11 @@ fn rouille_main(_: &[String], stream: &mut dyn Write, ctx: &osm_gimmisn::context
     let prefix = ctx.get_ini().get_uri_prefix();
     writeln!(
         stream,
-        "Starting the server at <http://127.0.0.1:{}{}/>.",
-        port, prefix
+        "Starting the server at <http://127.0.0.1:{port}{prefix}/>."
     )
     .unwrap();
     osm_gimmisn::context::system::get_tz_offset();
-    rouille::start_server_with_pool(format!("127.0.0.1:{}", port), None, move |request| {
+    rouille::start_server_with_pool(format!("127.0.0.1:{port}"), None, move |request| {
         rouille_app(request)
     });
 }
@@ -115,7 +114,7 @@ fn main() {
     let argv: Vec<String> = args.iter().take(2).cloned().collect();
     let matches = app
         .subcommands(subcommands)
-        .try_get_matches_from(&argv)
+        .try_get_matches_from(argv)
         .unwrap_or_else(|e| e.exit());
     args.remove(1);
     let handler: &Handler = HANDLERS.get(matches.subcommand().unwrap().0).unwrap();

--- a/src/missing_housenumbers.rs
+++ b/src/missing_housenumbers.rs
@@ -41,7 +41,7 @@ pub fn our_main(
             .as_bytes(),
         )?;
         // only_in_reference items.
-        stream.write_all(format!("{:?}\n", range_strings).as_bytes())?;
+        stream.write_all(format!("{range_strings:?}\n").as_bytes())?;
     }
 
     ctx.get_unit().make_error()
@@ -52,7 +52,7 @@ pub fn main(argv: &[String], stream: &mut dyn Write, ctx: &context::Context) -> 
     match our_main(argv, stream, ctx) {
         Ok(_) => 0,
         Err(err) => {
-            stream.write_all(format!("{:?}\n", err).as_bytes()).unwrap();
+            stream.write_all(format!("{err:?}\n").as_bytes()).unwrap();
             1
         }
     }

--- a/src/missing_housenumbers/tests.rs
+++ b/src/missing_housenumbers/tests.rs
@@ -13,7 +13,6 @@
 use super::*;
 use std::io::Read;
 use std::io::Seek;
-use std::io::SeekFrom;
 use std::sync::Arc;
 
 /// Tests main().
@@ -26,7 +25,7 @@ fn test_main() {
     let ret = main(&argv, &mut buf, &mut ctx);
 
     assert_eq!(ret, 0);
-    buf.seek(SeekFrom::Start(0)).unwrap();
+    buf.rewind().unwrap();
     let mut actual: Vec<u8> = Vec::new();
     buf.read_to_end(&mut actual).unwrap();
     assert_eq!(

--- a/src/parse_access_log.rs
+++ b/src/parse_access_log.rs
@@ -177,7 +177,7 @@ fn check_top_edited_relations(
 ) -> anyhow::Result<()> {
     let workdir = ctx.get_ini().get_workdir();
     // List of 'city name' <-> '# of new house numbers' pairs.
-    let topcities = stats::get_topcities(ctx, &format!("{}/stats", workdir))?;
+    let topcities = stats::get_topcities(ctx, &format!("{workdir}/stats"))?;
     let topcities: Vec<_> = topcities
         .iter()
         .map(|city| (unidecode::unidecode(&city.0), city.1))
@@ -227,29 +227,21 @@ pub fn our_main(
             if actual {
                 if !is_relation_recently_added(ctx, &relation_create_dates, &relation_name) {
                     stdout.write_all(
-                        format!("data/relation-{}.yaml: set inactive: true\n", relation_name)
+                        format!("data/relation-{relation_name}.yaml: set inactive: true\n")
                             .as_bytes(),
                     )?;
                     removals += 1;
                 }
             } else {
                 stdout.write_all(
-                    format!(
-                        "data/relation-{}.yaml: set inactive: false\n",
-                        relation_name
-                    )
-                    .as_bytes(),
+                    format!("data/relation-{relation_name}.yaml: set inactive: false\n").as_bytes(),
                 )?;
                 additions += 1;
             }
         }
     }
     stdout.write_all(
-        format!(
-            "Suggested {} removals and {} additions.\n",
-            removals, additions
-        )
-        .as_bytes(),
+        format!("Suggested {removals} removals and {additions} additions.\n").as_bytes(),
     )?;
 
     ctx.get_unit().make_error()
@@ -260,7 +252,7 @@ pub fn main(argv: &[String], stream: &mut dyn Write, ctx: &context::Context) -> 
     match our_main(argv, stream, ctx) {
         Ok(_) => 0,
         Err(err) => {
-            stream.write_all(format!("{:?}\n", err).as_bytes()).unwrap();
+            stream.write_all(format!("{err:?}\n").as_bytes()).unwrap();
             1
         }
     }

--- a/src/parse_access_log/tests.rs
+++ b/src/parse_access_log/tests.rs
@@ -14,7 +14,6 @@ use super::*;
 
 use std::io::Read;
 use std::io::Seek;
-use std::io::SeekFrom;
 use std::sync::Arc;
 
 use context::FileSystem as _;
@@ -117,7 +116,7 @@ fn test_main() {
     let mut ctx = context::tests::make_test_context().unwrap();
     let relations_path = ctx.get_abspath("data/relations.yaml");
     // 2020-05-09, so this will be recent
-    let expected_args = format!("git blame --line-porcelain {}", relations_path);
+    let expected_args = format!("git blame --line-porcelain {relations_path}");
     let expected_out = "\n\
 author-time 1588975200\n\
 \tujbuda:\n"
@@ -156,7 +155,7 @@ author-time 1588975200\n\
     let ret = main(&argv, &mut buf, &ctx);
 
     assert_eq!(ret, 0);
-    buf.seek(SeekFrom::Start(0)).unwrap();
+    buf.rewind().unwrap();
     let mut actual: Vec<u8> = Vec::new();
     buf.read_to_end(&mut actual).unwrap();
     let actual = String::from_utf8(actual).unwrap();

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -11,7 +11,7 @@
 //! The ranges module contains functionality related to the Ranges class.
 
 /// A range object represents an odd or even range of integer numbers.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct Range {
     start: i64,
     end: i64,

--- a/src/ranges/tests.rs
+++ b/src/ranges/tests.rs
@@ -14,7 +14,7 @@ use super::*;
 
 /// Factory for Range without specifying interpolation.
 fn make_range(start: i64, end: i64) -> Range {
-    Range::new(start, end, "".into())
+    Range::new(start, end, "")
 }
 
 /// Range: Tests an odd range with an even number.
@@ -65,7 +65,7 @@ fn test_range_interpolation_all() {
 fn test_range_traits() {
     let range = make_range(1, 3);
     assert_eq!(
-        format!("{:?}", range),
+        format!("{range:?}"),
         "Range { start: 1, end: 3, is_odd: Some(true) }"
     );
     let range2 = range.clone();
@@ -105,5 +105,5 @@ fn test_ranges_none() {
 fn test_ranges_traits() {
     let ranges = Ranges::new(vec![make_range(0, 0), make_range(1, 1)]);
     let expected = "Ranges { items: [Range { start: 0, end: 0, is_odd: Some(false) }, Range { start: 1, end: 1, is_odd: Some(true) }] }";
-    assert_eq!(format!("{:?}", ranges), expected);
+    assert_eq!(format!("{ranges:?}"), expected);
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -32,7 +32,7 @@ fn handle_progress(
     let mut ret = serde_json::json!({});
     let num_ref: f64 = ctx
         .get_file_system()
-        .read_to_string(&format!("{}/ref.count", src_root))
+        .read_to_string(&format!("{src_root}/ref.count"))
         .context("failed to read ref.count")?
         .trim()
         .parse()
@@ -43,7 +43,7 @@ fn handle_progress(
         now.format(&format)?
     };
     let mut num_osm = 0_f64;
-    let count_path = format!("{}/{}.count", src_root, today);
+    let count_path = format!("{src_root}/{today}.count");
     if ctx.get_file_system().path_exists(&count_path) {
         num_osm = ctx
             .get_file_system()
@@ -91,7 +91,7 @@ fn handle_capital_progress(
     let format = time::format_description::parse("[year]-[month]-[day]")?;
     let today = now.format(&format)?;
     let mut osm_count = 0;
-    let osm_path = format!("{}/{}.citycount", src_root, today);
+    let osm_path = format!("{src_root}/{today}.citycount");
     if ctx.get_file_system().path_exists(&osm_path) {
         let stream = ctx.get_file_system().open_read(&osm_path)?;
         let mut guard = stream.borrow_mut();
@@ -137,7 +137,7 @@ fn handle_topusers(
         now.format(&format)?
     };
     let mut ret: Vec<(String, String)> = Vec::new();
-    let topusers_path = format!("{}/{}.topusers", src_root, today);
+    let topusers_path = format!("{src_root}/{today}.topusers");
     if ctx.get_file_system().path_exists(&topusers_path) {
         let stream = ctx.get_file_system().open_read(&topusers_path)?;
         let mut guard = stream.borrow_mut();
@@ -172,12 +172,9 @@ pub fn get_topcities(ctx: &context::Context, src_root: &str) -> anyhow::Result<V
     let mut old_counts: HashMap<String, i64> = HashMap::new();
     let mut counts: Vec<(String, i64)> = Vec::new();
 
-    let old_count_path = format!("{}/{}.citycount", src_root, old_day);
+    let old_count_path = format!("{src_root}/{old_day}.citycount");
     if !ctx.get_file_system().path_exists(&old_count_path) {
-        info!(
-            "get_topcities: empty result: no such path: {}",
-            old_count_path
-        );
+        info!("get_topcities: empty result: no such path: {old_count_path}");
         return Ok(vec![]);
     }
     let stream = ctx.get_file_system().open_read(&old_count_path)?;
@@ -192,7 +189,7 @@ pub fn get_topcities(ctx: &context::Context, src_root: &str) -> anyhow::Result<V
         old_counts.insert(city.into(), count);
     }
 
-    let new_count_path = format!("{}/{}.citycount", src_root, new_day);
+    let new_count_path = format!("{src_root}/{new_day}.citycount");
     if !ctx.get_file_system().path_exists(&new_count_path) {
         return Ok(vec![]);
     }
@@ -243,7 +240,7 @@ fn handle_user_total(
     for day_offset in (0..=day_range).rev() {
         let day_delta = now - time::Duration::days(day_offset);
         let day = day_delta.format(&ymd)?;
-        let count_path = format!("{}/{}.usercount", src_root, day);
+        let count_path = format!("{src_root}/{day}.usercount");
         if !ctx.get_file_system().path_exists(&count_path) {
             break;
         }
@@ -276,7 +273,7 @@ fn handle_daily_new(
     for day_offset in (0..=day_range).rev() {
         let day_delta = now - time::Duration::days(day_offset);
         let day = day_delta.format(&ymd)?;
-        let count_path = format!("{}/{}.count", src_root, day);
+        let count_path = format!("{src_root}/{day}.count");
         if !ctx.get_file_system().path_exists(&count_path) {
             break;
         }
@@ -326,7 +323,7 @@ fn handle_monthly_new(
         let month_delta = get_previous_month(&ctx.get_time().now(), month_offset)?;
         // Get the first day of each month.
         let month = month_delta.replace_day(1).unwrap().format(&ym)?;
-        let count_path = format!("{}/{}-01.count", src_root, month);
+        let count_path = format!("{src_root}/{month}-01.count");
         if !ctx.get_file_system().path_exists(&count_path) {
             break;
         }
@@ -346,7 +343,7 @@ fn handle_monthly_new(
     let now = ctx.get_time().now();
     let ymd = time::format_description::parse("[year]-[month]-[day]")?;
     let mut month = now.format(&ymd)?;
-    let count_path = format!("{}/{}.count", src_root, month);
+    let count_path = format!("{src_root}/{month}.count");
     if ctx.get_file_system().path_exists(&count_path) {
         let count: i64 = ctx
             .get_file_system()
@@ -377,7 +374,7 @@ fn handle_daily_total(
     for day_offset in (0..=day_range).rev() {
         let day_delta = now - time::Duration::days(day_offset);
         let day = day_delta.format(&ymd)?;
-        let count_path = format!("{}/{}.count", src_root, day);
+        let count_path = format!("{src_root}/{day}.count");
         if !ctx.get_file_system().path_exists(&count_path) {
             break;
         }
@@ -412,7 +409,7 @@ fn handle_monthly_total(
         // Get the first day of each past month.
         let mut month = month_delta.replace_day(1)?.format(&ym)?;
         let prev_month = prev_month_delta.replace_day(1).unwrap().format(&ym)?;
-        let mut count_path = format!("{}/{}-01.count", src_root, month);
+        let mut count_path = format!("{src_root}/{month}-01.count");
         if !ctx.get_file_system().path_exists(&count_path) {
             break;
         }
@@ -426,7 +423,7 @@ fn handle_monthly_total(
         if month_offset == 0 {
             // Current month: show today's count as well.
             month = month_delta.format(&ymd)?;
-            count_path = format!("{}/{}.count", src_root, month);
+            count_path = format!("{src_root}/{month}.count");
             let count: i64 = ctx
                 .get_file_system()
                 .read_to_string(&count_path)?

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -367,7 +367,7 @@ fn test_get_topcities_test_old_missing() {
     let mut ctx = context::tests::make_test_context().unwrap();
     let mut file_system = context::tests::TestFileSystem::new();
     let src_root = ctx.get_abspath("workdir/stats");
-    file_system.set_hide_paths(&vec![format!("{}/2020-04-10.citycount", src_root)]);
+    file_system.set_hide_paths(&vec![format!("{src_root}/2020-04-10.citycount")]);
     let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
     ctx.set_file_system(&file_system_arc);
     let ret = get_topcities(&ctx, &src_root).unwrap();
@@ -380,7 +380,7 @@ fn test_get_topcities_test_new_missing() {
     let mut ctx = context::tests::make_test_context().unwrap();
     let mut file_system = context::tests::TestFileSystem::new();
     let src_root = ctx.get_abspath("workdir/stats");
-    file_system.set_hide_paths(&vec![format!("{}/2020-05-10.citycount", src_root)]);
+    file_system.set_hide_paths(&vec![format!("{src_root}/2020-05-10.citycount")]);
     let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
     ctx.set_file_system(&file_system_arc);
     let ret = get_topcities(&ctx, &src_root).unwrap();

--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -60,14 +60,14 @@ pub fn our_main(
 
         let mut dests: Vec<String> = Vec::new();
         for path in paths {
-            let url = format!("{}{}", url, path);
-            let dest = ctx.get_abspath(&format!("refdir/{}", path));
+            let url = format!("{url}{path}");
+            let dest = ctx.get_abspath(&format!("refdir/{path}"));
             dests.push(dest.clone());
             if ctx.get_file_system().path_exists(&dest) {
                 continue;
             }
 
-            stream.write_all(format!("sync-ref: downloading '{}'...\n", url).as_bytes())?;
+            stream.write_all(format!("sync-ref: downloading '{url}'...\n").as_bytes())?;
             let buf = ctx.get_network().urlopen(&url, "")?;
             ctx.get_file_system().write_from_string(&buf, &dest)?;
         }
@@ -76,7 +76,7 @@ pub fn our_main(
                 continue;
             }
             let relpath = path.strip_prefix(&ctx.get_abspath("")).unwrap();
-            stream.write_all(format!("sync-ref: removing '{}'...\n", relpath).as_bytes())?;
+            stream.write_all(format!("sync-ref: removing '{relpath}'...\n").as_bytes())?;
             ctx.get_file_system().unlink(&path)?;
         }
 
@@ -156,13 +156,9 @@ pub fn our_main(
     // Write config.
     ctx.get_file_system()
         .write_from_string(&config.join("\n"), &config_file)?;
-    let max = files.iter().map(|(_k, v)| v).max().context("empty files")?;
+    let max = files.values().max().context("empty files")?;
     stream.write_all(
-        format!(
-            "Now you can run: git commit -m 'Update reference to {}'\n",
-            max
-        )
-        .as_bytes(),
+        format!("Now you can run: git commit -m 'Update reference to {max}'\n").as_bytes(),
     )?;
     Ok(())
 }
@@ -173,7 +169,7 @@ pub fn main(args: &[String], stream: &mut dyn Write, ctx: &context::Context) -> 
     match our_main(args, stream, ctx) {
         Ok(_) => 0,
         Err(err) => {
-            stream.write_all(format!("{:?}\n", err).as_bytes()).unwrap();
+            stream.write_all(format!("{err:?}\n").as_bytes()).unwrap();
             1
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -598,7 +598,7 @@ pub fn build_street_reference_cache(
 
 /// Gets the filename of the (house number) reference cache file.
 fn get_reference_cache_path(local: &str, refcounty: &str) -> String {
-    format!("{}-{}-v1.cache", local, refcounty)
+    format!("{local}-{refcounty}-v1.cache")
 }
 
 /// Two strings: first is a range, second is an optional comment.
@@ -651,7 +651,7 @@ pub fn build_reference_cache(
     }
 
     let mut read = std::io::BufReader::new(
-        std::fs::File::open(local).context(format!("failed to open {}", local))?,
+        std::fs::File::open(local).context(format!("failed to open {local}"))?,
     );
     let mut csv_reader = make_csv_reader(&mut read);
     for result in csv_reader.deserialize() {
@@ -921,7 +921,7 @@ pub fn tsv_to_list(csv_read: &mut CsvRead<'_>) -> anyhow::Result<Vec<Vec<yattag:
             if let Ok(osm_id) = cells[0].get_value().parse::<u64>() {
                 let osm_type = cells[columns["@type"]].get_value();
                 let doc = yattag::Doc::new();
-                let href = format!("https://www.openstreetmap.org/{}/{}", osm_type, osm_id);
+                let href = format!("https://www.openstreetmap.org/{osm_type}/{osm_id}");
                 {
                     let a = doc.tag("a", &[("href", href.as_str()), ("target", "_blank")]);
                     a.text(&osm_id.to_string());

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -12,7 +12,6 @@
 
 use super::*;
 use std::io::Seek;
-use std::io::SeekFrom;
 use std::io::Write;
 use std::sync::Arc;
 
@@ -24,10 +23,7 @@ fn street_list(streets: &[&str]) -> Vec<Street> {
 /// Tests get_only_in_first().
 #[test]
 fn test_only_in_first() {
-    let ret = get_only_in_first(
-        &street_list(&vec!["1", "2", "3"]),
-        &street_list(&vec!["3", "4"]),
-    );
+    let ret = get_only_in_first(&street_list(&["1", "2", "3"]), &street_list(&["3", "4"]));
     let names: Vec<_> = ret.iter().map(|i| i.get_osm_name()).collect();
     assert_eq!(names, vec!["1", "2"]);
 }
@@ -36,8 +32,8 @@ fn test_only_in_first() {
 #[test]
 fn test_get_in_both() {
     let ret = get_in_both(
-        &street_list(&vec!["1", "2", "3"]),
-        &street_list(&vec!["2", "3", "4"]),
+        &street_list(&["1", "2", "3"]),
+        &street_list(&["2", "3", "4"]),
     );
     let names: Vec<_> = ret.iter().map(|i| i.get_osm_name()).collect();
     assert_eq!(names, vec!["2", "3"]);
@@ -425,7 +421,7 @@ fn test_gen_link() {
 fn test_process_template() {
     let template = "aaa @RELATION@ bbb @AREA@ ccc";
     let expected = "aaa 42 bbb 3600000042 ccc";
-    let actual = process_template(&template, 42);
+    let actual = process_template(template, 42);
     assert_eq!(actual, expected);
 }
 
@@ -710,7 +706,7 @@ fn test_get_street_from_housenumber_addr_place() {
 fn test_get_street_from_housenumber_missing_column() {
     let mut cursor = std::io::Cursor::new(Vec::new());
     cursor.write_all(b"@id\n42\n").unwrap();
-    cursor.seek(SeekFrom::Start(0)).unwrap();
+    cursor.rewind().unwrap();
     let mut csv_reader = make_csv_reader(&mut cursor);
     assert_eq!(get_street_from_housenumber(&mut csv_reader).is_err(), true);
 }
@@ -831,7 +827,7 @@ fn test_get_valid_settlements_error() {
 fn test_house_number_range_debug() {
     let range = HouseNumberRange::new("1", "");
 
-    let ret = format!("{:?}", range);
+    let ret = format!("{range:?}");
 
     assert_eq!(ret.starts_with("HouseNumberRange"), true);
 }
@@ -841,7 +837,7 @@ fn test_house_number_range_debug() {
 fn test_street_debug() {
     let street = Street::from_string("mystreet");
 
-    let ret = format!("{:?}", street);
+    let ret = format!("{street:?}");
 
     assert_eq!(ret.starts_with("Street"), true);
 }
@@ -851,7 +847,7 @@ fn test_street_debug() {
 fn test_house_number_debug() {
     let street = HouseNumber::new("1", "1-3", "");
 
-    let ret = format!("{:?}", street);
+    let ret = format!("{street:?}");
 
     assert_eq!(ret.starts_with("HouseNumber"), true);
 }
@@ -866,7 +862,7 @@ fn test_numbered_street_debug() {
         house_numbers,
     };
 
-    let ret = format!("{:?}", numbered_street);
+    let ret = format!("{numbered_street:?}");
 
     assert_eq!(ret.starts_with("NumberedStreet"), true);
 }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -27,8 +27,7 @@ fn validate_range_missing_keys(
         Ok(value) => value,
         Err(_) => {
             errors.push(format!(
-                "expected value type for '{}.start' is a digit str",
-                parent
+                "expected value type for '{parent}.start' is a digit str"
             ));
             return Ok(());
         }
@@ -37,18 +36,17 @@ fn validate_range_missing_keys(
         Ok(value) => value,
         Err(_) => {
             errors.push(format!(
-                "expected value type for '{}.end' is a digit str",
-                parent
+                "expected value type for '{parent}.end' is a digit str"
             ));
             return Ok(());
         }
     };
     if start > end {
-        errors.push(format!("expected end >= start for '{}'", parent));
+        errors.push(format!("expected end >= start for '{parent}'"));
     }
 
     if filter_data.interpolation.is_none() && start % 2 != end % 2 {
-        errors.push(format!("expected start % 2 == end % 2 for '{}'", parent))
+        errors.push(format!("expected start % 2 == end % 2 for '{parent}'"))
     }
 
     Ok(())
@@ -75,7 +73,7 @@ fn validate_ranges(
     for (index, range_data) in ranges.iter().enumerate() {
         validate_range(
             errors,
-            &format!("{}[{}]", parent, index),
+            &format!("{parent}[{index}]"),
             range_data,
             filter_data,
         )?;
@@ -110,8 +108,7 @@ fn validate_filter_invalid_valid(
             continue;
         }
         errors.push(format!(
-            "expected format for '{}[{}]' is '42', '42a' or '42/1'",
-            parent, index
+            "expected format for '{parent}[{index}]' is '42', '42a' or '42/1'"
         ));
     }
 
@@ -124,9 +121,9 @@ fn validate_filter(
     parent: &str,
     filter_data: &areas::RelationFiltersDict,
 ) -> anyhow::Result<()> {
-    let context = format!("{}.", parent);
+    let context = format!("{parent}.");
     if let Some(ref ranges) = filter_data.ranges {
-        validate_ranges(errors, &format!("{}ranges", context), ranges, filter_data)?;
+        validate_ranges(errors, &format!("{context}ranges"), ranges, filter_data)?;
     }
 
     if let Some(ref invalid) = filter_data.invalid {
@@ -145,9 +142,9 @@ fn validate_filters(
     parent: &str,
     filters: &HashMap<String, areas::RelationFiltersDict>,
 ) -> anyhow::Result<()> {
-    let context = format!("{}.", parent);
+    let context = format!("{parent}.");
     for (key, value) in filters {
-        validate_filter(errors, &format!("{}{}", context, key), value)?;
+        validate_filter(errors, &format!("{context}{key}"), value)?;
     }
 
     Ok(())
@@ -159,22 +156,16 @@ fn validate_refstreets(
     parent: &str,
     refstreets: &HashMap<String, String>,
 ) -> anyhow::Result<()> {
-    let context = format!("{}.", parent);
+    let context = format!("{parent}.");
     for (key, value) in refstreets {
         if value.parse::<i64>().is_ok() {
-            errors.push(format!(
-                "expected value type for '{}{}' is str",
-                context, key
-            ));
+            errors.push(format!("expected value type for '{context}{key}' is str"));
         }
         if key.contains('\'') || key.contains('"') {
-            errors.push(format!("expected no quotes in '{}{}'", context, key));
+            errors.push(format!("expected no quotes in '{context}{key}'"));
         }
         if value.contains('\'') || value.contains('"') {
-            errors.push(format!(
-                "expected no quotes in value of '{}{}'",
-                context, key
-            ));
+            errors.push(format!("expected no quotes in value of '{context}{key}'"));
         }
     }
     let mut reverse: Vec<_> = refstreets
@@ -185,8 +176,7 @@ fn validate_refstreets(
     reverse.dedup();
     if refstreets.keys().len() != reverse.len() {
         errors.push(format!(
-            "osm and ref streets are not a 1:1 mapping in '{}'",
-            parent
+            "osm and ref streets are not a 1:1 mapping in '{parent}'"
         ));
     }
 
@@ -202,8 +192,7 @@ fn validate_street_filters(
     for (index, street_filter) in street_filters.iter().enumerate() {
         if street_filter.parse::<i64>().is_ok() {
             errors.push(format!(
-                "expected value type for '{}[{}]' is str",
-                parent, index
+                "expected value type for '{parent}[{index}]' is str"
             ));
         }
     }
@@ -219,18 +208,18 @@ fn validate_relation(
 ) -> anyhow::Result<()> {
     let mut context: String = "".into();
     if !parent.is_empty() {
-        context = format!("{}.", parent);
+        context = format!("{parent}.");
 
         // Just to be consistent, we require these keys in relations.yaml for now, even if code would
         // handle having them there or in relation-foo.yaml as well.
         if relation.osmrelation.is_none() {
-            errors.push(format!("missing key '{}osmrelation'", context));
+            errors.push(format!("missing key '{context}osmrelation'"));
         }
         if relation.refcounty.is_none() {
-            errors.push(format!("missing key '{}refcounty'", context));
+            errors.push(format!("missing key '{context}refcounty'"));
         }
         if relation.refsettlement.is_none() {
-            errors.push(format!("missing key '{}refsettlement'", context));
+            errors.push(format!("missing key '{context}refsettlement'"));
         }
     }
 
@@ -249,18 +238,14 @@ fn validate_relation(
     }
     if let Some(ref source) = relation.source {
         if source.parse::<i64>().is_ok() {
-            errors.push(format!(
-                "expected value type for '{}source' is str",
-                context
-            ));
+            errors.push(format!("expected value type for '{context}source' is str"));
         }
     }
     if let Some(ref aliases) = relation.alias {
         for (index, alias) in aliases.iter().enumerate() {
             if alias.parse::<i64>().is_ok() {
                 errors.push(format!(
-                    "expected value type for '{}alias[{}]' is str",
-                    context, index
+                    "expected value type for '{context}alias[{index}]' is str"
                 ));
             }
         }
@@ -286,7 +271,7 @@ pub fn main(argv: &[String], stream: &mut dyn Write, ctx: &context::Context) -> 
     match our_main(argv, stream, ctx) {
         Ok(_) => 0,
         Err(err) => {
-            stream.write_all(format!("{:?}\n", err).as_bytes()).unwrap();
+            stream.write_all(format!("{err:?}\n").as_bytes()).unwrap();
             1
         }
     }
@@ -313,13 +298,13 @@ pub fn our_main(
         validate_relations(&mut errors, &relations_dict)?;
     } else {
         let relation_dict: areas::RelationDict =
-            serde_yaml::from_str(&data).context(format!("failed to validate {}", yaml_path))?;
+            serde_yaml::from_str(&data).context(format!("failed to validate {yaml_path}"))?;
         let parent = "";
         validate_relation(&mut errors, parent, &relation_dict)?;
     }
     if !errors.is_empty() {
         for error in errors {
-            stream.write_all(format!("{}\n", error).as_bytes())?;
+            stream.write_all(format!("{error}\n").as_bytes())?;
         }
         return Err(anyhow::anyhow!("failed to validate {}", yaml_path));
     }

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -82,10 +82,7 @@ fn fill_header_function(
                     "a",
                     &[(
                         "href",
-                        &format!(
-                            "{}/street-housenumbers/{}/update-result",
-                            prefix, relation_name
-                        ),
+                        &format!("{prefix}/street-housenumbers/{relation_name}/update-result"),
                     )],
                 );
                 a.text(&tr("Update from OSM"));
@@ -101,10 +98,7 @@ fn fill_header_function(
                     "a",
                     &[(
                         "href",
-                        &format!(
-                            "{}/missing-housenumbers/{}/update-result",
-                            prefix, relation_name
-                        ),
+                        &format!("{prefix}/missing-housenumbers/{relation_name}/update-result"),
                     )],
                 );
                 a.text(&tr("Update from reference"));
@@ -122,7 +116,7 @@ fn fill_header_function(
                     "a",
                     &[(
                         "href",
-                        &format!("{}/streets/{}/update-result", prefix, relation_name),
+                        &format!("{prefix}/streets/{relation_name}/update-result"),
                     )],
                 );
                 a.text(&tr("Update from OSM"));
@@ -138,7 +132,7 @@ fn fill_header_function(
                     "a",
                     &[(
                         "href",
-                        &format!("{}/missing-streets/{}/update-result", prefix, relation_name),
+                        &format!("{prefix}/missing-streets/{relation_name}/update-result"),
                     )],
                 );
                 a.text(&tr("Update from reference"));
@@ -154,10 +148,7 @@ fn fill_header_function(
                     "a",
                     &[(
                         "href",
-                        &format!(
-                            "{}/street-housenumbers/{}/update-result",
-                            prefix, relation_name
-                        ),
+                        &format!("{prefix}/street-housenumbers/{relation_name}/update-result"),
                     )],
                 );
                 a.text(&tr("Call Overpass to update"));
@@ -170,10 +161,7 @@ fn fill_header_function(
                 "a",
                 &[(
                     "href",
-                    &format!(
-                        "{}/street-housenumbers/{}/view-query",
-                        prefix, relation_name
-                    ),
+                    &format!("{prefix}/street-housenumbers/{relation_name}/view-query"),
                 )],
             );
             a.text(&tr("View query"));
@@ -188,7 +176,7 @@ fn fill_header_function(
                     "a",
                     &[(
                         "href",
-                        &format!("{}/streets/{}/update-result", prefix, relation_name),
+                        &format!("{prefix}/streets/{relation_name}/update-result"),
                     )],
                 );
                 a.text(&tr("Call Overpass to update"));
@@ -201,7 +189,7 @@ fn fill_header_function(
                 "a",
                 &[(
                     "href",
-                    &format!("{}/streets/{}/view-query", prefix, relation_name),
+                    &format!("{prefix}/streets/{relation_name}/view-query"),
                 )],
             );
             a.text(&tr("View query"));
@@ -228,10 +216,7 @@ fn fill_missing_header_items(
                 "a",
                 &[(
                     "href",
-                    &format!(
-                        "{}/missing-housenumbers/{}/view-result",
-                        prefix, relation_name
-                    ),
+                    &format!("{prefix}/missing-housenumbers/{relation_name}/view-result"),
                 )],
             );
             a.text(&tr("Missing house numbers"));
@@ -245,10 +230,7 @@ fn fill_missing_header_items(
                     "a",
                     &[(
                         "href",
-                        &format!(
-                            "{}/additional-housenumbers/{}/view-result",
-                            prefix, relation_name
-                        ),
+                        &format!("{prefix}/additional-housenumbers/{relation_name}/view-result"),
                     )],
                 );
                 a.text(&tr("Additional house numbers"));
@@ -263,7 +245,7 @@ fn fill_missing_header_items(
                 "a",
                 &[(
                     "href",
-                    &format!("{}/missing-streets/{}/view-result", prefix, relation_name),
+                    &format!("{prefix}/missing-streets/{relation_name}/view-result"),
                 )],
             );
             a.text(&tr("Missing streets"));
@@ -275,10 +257,7 @@ fn fill_missing_header_items(
                 "a",
                 &[(
                     "href",
-                    &format!(
-                        "{}/additional-streets/{}/view-result",
-                        prefix, relation_name
-                    ),
+                    &format!("{prefix}/additional-streets/{relation_name}/view-result"),
                 )],
             );
             a.text(&tr("Additional streets"));
@@ -304,10 +283,7 @@ fn fill_existing_header_items(
                 "a",
                 &[(
                     "href",
-                    &format!(
-                        "{}/street-housenumbers/{}/view-result",
-                        prefix, relation_name
-                    ),
+                    &format!("{prefix}/street-housenumbers/{relation_name}/view-result"),
                 )],
             );
             a.text(&tr("Existing house numbers"));
@@ -321,7 +297,7 @@ fn fill_existing_header_items(
             "a",
             &[(
                 "href",
-                &format!("{}/streets/{}/view-result", prefix, relation_name),
+                &format!("{prefix}/streets/{relation_name}/view-result"),
             )],
         );
         a.text(&tr("Existing streets"));
@@ -410,7 +386,7 @@ pub fn get_toolbar(
                 "a",
                 &[(
                     "href",
-                    &format!("https://www.openstreetmap.org/relation/{}", relation_osmid),
+                    &format!("https://www.openstreetmap.org/relation/{relation_osmid}"),
                 )],
             );
             a.text(&tr("Area boundary"))
@@ -466,13 +442,13 @@ pub fn handle_static(
     if request_uri.ends_with(".js") {
         let content_type = "application/x-javascript; charset=utf-8";
         let (content, extra_headers) =
-            get_content_with_meta(ctx, &ctx.get_abspath(&format!("target/browser/{}", path)))?;
+            get_content_with_meta(ctx, &ctx.get_abspath(&format!("target/browser/{path}")))?;
         return Ok((content, content_type.into(), extra_headers));
     }
     if request_uri.ends_with(".css") {
         let content_type = "text/css; charset=utf-8";
         let (content, extra_headers) =
-            get_content_with_meta(ctx, &ctx.get_abspath(&format!("target/browser/{}", path)))
+            get_content_with_meta(ctx, &ctx.get_abspath(&format!("target/browser/{path}")))
                 .context("get_content_with_meta() failed")?;
         return Ok((content, content_type.into(), extra_headers));
     }
@@ -584,18 +560,18 @@ fn handle_stats_cityprogress(
     let mut read = guard.deref_mut();
     let mut csv_read = util::CsvRead::new(&mut read);
     for result in csv_read.records() {
-        let row = result.context(format!("failed to read row in {}", path))?;
+        let row = result.context(format!("failed to read row in {path}"))?;
         let city = row.get(0).unwrap();
         let count: u64 = row.get(1).unwrap().parse()?;
         osm_citycounts.insert(city.into(), count);
     }
     let ref_cities: Vec<_> = ref_citycounts
-        .iter()
-        .map(|(k, _v)| util::Street::from_string(k))
+        .keys()
+        .map(|k| util::Street::from_string(k))
         .collect();
     let osm_cities: Vec<_> = osm_citycounts
-        .iter()
-        .map(|(k, _v)| util::Street::from_string(k))
+        .keys()
+        .map(|k| util::Street::from_string(k))
         .collect();
     let in_both = util::get_in_both(&ref_cities, &osm_cities);
     let mut cities: Vec<_> = in_both.iter().map(|i| i.get_osm_name()).collect();
@@ -689,18 +665,18 @@ fn handle_stats_zipprogress(
     let mut read = guard.deref_mut();
     let mut csv_read = util::CsvRead::new(&mut read);
     for result in csv_read.records() {
-        let row = result.context(format!("failed to read row in {}", path))?;
+        let row = result.context(format!("failed to read row in {path}"))?;
         let zip = row.get(0).unwrap();
         let count: u64 = row.get(1).unwrap().parse()?;
         osm_zipcounts.insert(zip.into(), count);
     }
     let ref_zips: Vec<_> = ref_zipcounts
-        .iter()
-        .map(|(k, _v)| util::Street::from_string(k))
+        .keys()
+        .map(|k| util::Street::from_string(k))
         .collect();
     let osm_zips: Vec<_> = osm_zipcounts
-        .iter()
-        .map(|(k, _v)| util::Street::from_string(k))
+        .keys()
+        .map(|k| util::Street::from_string(k))
         .collect();
     let in_both = util::get_in_both(&ref_zips, &osm_zips);
     let mut zips: Vec<_> = in_both.iter().map(|i| i.get_osm_name()).collect();
@@ -786,7 +762,7 @@ fn handle_invalid_refstreets(
                     "a",
                     &[(
                         "href",
-                        &format!("{}/streets/{}/view-result", prefix, relation_name),
+                        &format!("{prefix}/streets/{relation_name}/view-result"),
                     )],
                 );
                 a.text(&relation_name);
@@ -928,7 +904,7 @@ pub fn handle_stats(
                     "a",
                     &[(
                         "href",
-                        &format!("{}/housenumber-stats/hungary/cityprogress", prefix),
+                        &format!("{prefix}/housenumber-stats/hungary/cityprogress"),
                     )],
                 );
                 a.text(title);
@@ -939,7 +915,7 @@ pub fn handle_stats(
                     "a",
                     &[(
                         "href",
-                        &format!("{}/housenumber-stats/hungary/zipprogress", prefix),
+                        &format!("{prefix}/housenumber-stats/hungary/zipprogress"),
                     )],
                 );
                 a.text(title);
@@ -950,13 +926,13 @@ pub fn handle_stats(
                     "a",
                     &[(
                         "href",
-                        &format!("{}/housenumber-stats/hungary/invalid-relations", prefix),
+                        &format!("{prefix}/housenumber-stats/hungary/invalid-relations"),
                     )],
                 );
                 a.text(title);
                 continue;
             }
-            let a = li.tag("a", &[("href", &format!("#_{}", identifier))]);
+            let a = li.tag("a", &[("href", &format!("#_{identifier}"))]);
             a.text(title);
         }
     }
@@ -970,7 +946,7 @@ pub fn handle_stats(
             continue;
         }
         {
-            let h2 = doc.tag("h2", &[("id", &format!("_{}", identifier))]);
+            let h2 = doc.tag("h2", &[("id", &format!("_{identifier}"))]);
             h2.text(title);
         }
 
@@ -1008,17 +984,17 @@ pub fn get_request_uri(
     let prefix = ctx.get_ini().get_uri_prefix();
     if !request_uri.is_empty() {
         // Compatibility.
-        if request_uri.starts_with(&format!("{}/suspicious-streets/", prefix)) {
+        if request_uri.starts_with(&format!("{prefix}/suspicious-streets/")) {
             request_uri = request_uri.replace("suspicious-streets", "missing-housenumbers");
-        } else if request_uri.starts_with(&format!("{}/suspicious-relations/", prefix)) {
+        } else if request_uri.starts_with(&format!("{prefix}/suspicious-relations/")) {
             request_uri = request_uri.replace("suspicious-relations", "missing-streets");
         }
 
         // Performance: don't bother with relation aliases for non-relation requests.
-        if !request_uri.starts_with(&format!("{}/streets/", prefix))
-            && !request_uri.starts_with(&format!("{}/missing-streets/", prefix))
-            && !request_uri.starts_with(&format!("{}/street-housenumbers/", prefix))
-            && !request_uri.starts_with(&format!("{}/missing-housenumbers/", prefix))
+        if !request_uri.starts_with(&format!("{prefix}/streets/"))
+            && !request_uri.starts_with(&format!("{prefix}/missing-streets/"))
+            && !request_uri.starts_with(&format!("{prefix}/street-housenumbers/"))
+            && !request_uri.starts_with(&format!("{prefix}/missing-housenumbers/"))
         {
             return Ok(request_uri);
         }
@@ -1044,10 +1020,10 @@ pub fn check_existing_relation(
 ) -> anyhow::Result<yattag::Doc> {
     let doc = yattag::Doc::new();
     let prefix = ctx.get_ini().get_uri_prefix();
-    if !request_uri.starts_with(&format!("{}/streets/", prefix))
-        && !request_uri.starts_with(&format!("{}/missing-streets/", prefix))
-        && !request_uri.starts_with(&format!("{}/street-housenumbers/", prefix))
-        && !request_uri.starts_with(&format!("{}/missing-housenumbers/", prefix))
+    if !request_uri.starts_with(&format!("{prefix}/streets/"))
+        && !request_uri.starts_with(&format!("{prefix}/missing-streets/"))
+        && !request_uri.starts_with(&format!("{prefix}/street-housenumbers/"))
+        && !request_uri.starts_with(&format!("{prefix}/missing-housenumbers/"))
     {
         return Ok(doc);
     }
@@ -1069,7 +1045,7 @@ pub fn check_existing_relation(
 /// Handles the no-osm-streets error on a page using JS.
 pub fn handle_no_osm_streets(prefix: &str, relation_name: &str) -> yattag::Doc {
     let doc = yattag::Doc::new();
-    let link = format!("{}/streets/{}/uppdate-result", prefix, relation_name);
+    let link = format!("{prefix}/streets/{relation_name}/uppdate-result");
     {
         let div = doc.tag("div", &[("id", "no-osm-streets")]);
         let a = div.tag("a", &[("href", &link)]);
@@ -1089,10 +1065,7 @@ pub fn handle_no_osm_streets(prefix: &str, relation_name: &str) -> yattag::Doc {
 /// Handles the no-osm-housenumbers error on a page using JS.
 pub fn handle_no_osm_housenumbers(prefix: &str, relation_name: &str) -> yattag::Doc {
     let doc = yattag::Doc::new();
-    let link = format!(
-        "{}/street-housenumbers/{}/uppdate-result",
-        prefix, relation_name
-    );
+    let link = format!("{prefix}/street-housenumbers/{relation_name}/uppdate-result");
     {
         let div = doc.tag("div", &[("id", "no-osm-housenumbers")]);
         let a = div.tag("a", &[("href", &link)]);
@@ -1113,10 +1086,7 @@ pub fn handle_no_osm_housenumbers(prefix: &str, relation_name: &str) -> yattag::
 /// Handles the no-ref-housenumbers error on a page using JS.
 pub fn handle_no_ref_housenumbers(prefix: &str, relation_name: &str) -> yattag::Doc {
     let doc = yattag::Doc::new();
-    let link = format!(
-        "{}/missing-housenumbers/{}/uppdate-result",
-        prefix, relation_name
-    );
+    let link = format!("{prefix}/missing-housenumbers/{relation_name}/uppdate-result");
     {
         let div = doc.tag("div", &[("id", "no-ref-housenumbers")]);
         let a = div.tag("a", &[("href", &link)]);
@@ -1137,7 +1107,7 @@ pub fn handle_no_ref_housenumbers(prefix: &str, relation_name: &str) -> yattag::
 /// Handles the no-ref-streets error on a page using JS.
 pub fn handle_no_ref_streets(prefix: &str, relation_name: &str) -> yattag::Doc {
     let doc = yattag::Doc::new();
-    let link = format!("{}/missing-streets/{}/update-result", prefix, relation_name);
+    let link = format!("{prefix}/missing-streets/{relation_name}/update-result");
     {
         let div = doc.tag("div", &[("id", "no-ref-streets")]);
         let a = div.tag("a", &[("href", &link)]);

--- a/src/webframe/tests.rs
+++ b/src/webframe/tests.rs
@@ -31,7 +31,7 @@ fn test_handle_static() {
     let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
     let path = ctx.get_abspath("target/browser/osm.min.css");
     mtimes.insert(
-        path.to_string(),
+        path,
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_files(&files);
@@ -41,7 +41,7 @@ fn test_handle_static() {
 
     let prefix = ctx.get_ini().get_uri_prefix();
     let (content, content_type, extra_headers) =
-        handle_static(&ctx, &format!("{}/static/osm.min.css", prefix)).unwrap();
+        handle_static(&ctx, &format!("{prefix}/static/osm.min.css")).unwrap();
 
     assert_eq!(content.is_empty(), false);
     assert_eq!(content_type, "text/css; charset=utf-8");
@@ -55,7 +55,7 @@ fn test_handle_static_generated_javascript() {
     let ctx = context::tests::make_test_context().unwrap();
     let prefix = ctx.get_ini().get_uri_prefix();
     let (content, content_type, extra_headers) =
-        handle_static(&ctx, &format!("{}/static/bundle.js", prefix)).unwrap();
+        handle_static(&ctx, &format!("{prefix}/static/bundle.js")).unwrap();
     assert_eq!("// bundle.js\n".as_bytes(), content);
     assert_eq!(content_type, "application/x-javascript; charset=utf-8");
     assert_eq!(extra_headers.len(), 1);
@@ -68,7 +68,7 @@ fn test_handle_static_json() {
     let ctx = context::tests::make_test_context().unwrap();
     let prefix = ctx.get_ini().get_uri_prefix();
     let (content, content_type, extra_headers) =
-        handle_static(&ctx, &format!("{}/static/stats-empty.json", prefix)).unwrap();
+        handle_static(&ctx, &format!("{prefix}/static/stats-empty.json")).unwrap();
     assert_eq!(content.starts_with(b"{"), true);
     assert_eq!(content_type, "application/json; charset=utf-8");
     assert_eq!(extra_headers.len(), 1);
@@ -90,7 +90,7 @@ fn test_handle_static_ico() {
     let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
     let path = ctx.get_abspath("favicon.ico");
     mtimes.insert(
-        path.to_string(),
+        path,
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_files(&files);
@@ -121,7 +121,7 @@ fn test_handle_static_svg() {
     let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
     let path = ctx.get_abspath("favicon.svg");
     mtimes.insert(
-        path.to_string(),
+        path,
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_files(&files);
@@ -143,7 +143,7 @@ fn test_handle_static_else() {
     let ctx = context::tests::make_test_context().unwrap();
     let prefix = ctx.get_ini().get_uri_prefix();
     let (content, content_type, extra_headers) =
-        handle_static(&ctx, &format!("{}/static/test.xyz", prefix)).unwrap();
+        handle_static(&ctx, &format!("{prefix}/static/test.xyz")).unwrap();
     assert_eq!(content.is_empty(), true);
     assert_eq!(content_type.is_empty(), true);
     // No last modified non-existing file.
@@ -180,7 +180,7 @@ fn test_handle_error() {
     let unit = context::tests::TestUnit::new();
     let err = unit.make_error();
 
-    let response = handle_error(&request, &format!("{:?}", err));
+    let response = handle_error(&request, &format!("{err:?}"));
     let mut data = Vec::new();
     let (mut reader, _size) = response.data.into_reader_and_size();
     reader.read_to_end(&mut data).unwrap();

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -71,10 +71,7 @@ fn handle_streets(
                 if streets != "only" {
                     doc.text(&tr("Update successful: "));
                     let prefix = ctx.get_ini().get_uri_prefix();
-                    let link = format!(
-                        "{}/missing-housenumbers/{}/view-result",
-                        prefix, relation_name
-                    );
+                    let link = format!("{prefix}/missing-housenumbers/{relation_name}/view-result");
                     doc.append_value(
                         util::gen_link(&link, &tr("View missing house numbers")).get_value(),
                     );
@@ -143,10 +140,7 @@ fn handle_street_housenumbers(
             Ok(buf) => {
                 relation.get_files().write_osm_housenumbers(ctx, &buf)?;
                 doc.text(&tr("Update successful: "));
-                let link = format!(
-                    "{}/missing-housenumbers/{}/view-result",
-                    prefix, relation_name
-                );
+                let link = format!("{prefix}/missing-housenumbers/{relation_name}/view-result");
                 doc.append_value(
                     util::gen_link(&link, &tr("View missing house numbers")).get_value(),
                 );
@@ -245,10 +239,7 @@ fn missing_housenumbers_view_res_html(
                 "a",
                 &[(
                     "href",
-                    &format!(
-                        "{}/missing-housenumbers/{}/view-turbo",
-                        prefix, relation_name
-                    ),
+                    &format!("{prefix}/missing-housenumbers/{relation_name}/view-turbo"),
                 )],
             );
             a.text(&tr("Overpass turbo query for the below streets"));
@@ -259,10 +250,7 @@ fn missing_housenumbers_view_res_html(
                 "a",
                 &[(
                     "href",
-                    &format!(
-                        "{}/missing-housenumbers/{}/view-result.txt",
-                        prefix, relation_name
-                    ),
+                    &format!("{prefix}/missing-housenumbers/{relation_name}/view-result.txt"),
                 )],
             );
             a.text(&tr("Plain text format"));
@@ -273,10 +261,7 @@ fn missing_housenumbers_view_res_html(
                 "a",
                 &[(
                     "href",
-                    &format!(
-                        "{}/missing-housenumbers/{}/view-result.chkl",
-                        prefix, relation_name
-                    ),
+                    &format!("{prefix}/missing-housenumbers/{relation_name}/view-result.chkl"),
                 )],
             );
             a.text(&tr("Checklist format"));
@@ -381,7 +366,7 @@ fn missing_streets_view_result(
                 "a",
                 &[(
                     "href",
-                    &format!("{}/missing-streets/{}/view-turbo", prefix, relation_name),
+                    &format!("{prefix}/missing-streets/{relation_name}/view-turbo"),
                 )],
             );
             a.text(&tr(
@@ -394,10 +379,7 @@ fn missing_streets_view_result(
                 "a",
                 &[(
                     "href",
-                    &format!(
-                        "{}/missing-streets/{}/view-result.txt",
-                        prefix, relation_name
-                    ),
+                    &format!("{prefix}/missing-streets/{relation_name}/view-result.txt"),
                 )],
             );
             a.text(&tr("Plain text format"));
@@ -408,10 +390,7 @@ fn missing_streets_view_result(
                 "a",
                 &[(
                     "href",
-                    &format!(
-                        "{}/missing-streets/{}/view-result.chkl",
-                        prefix, relation_name
-                    ),
+                    &format!("{prefix}/missing-streets/{relation_name}/view-result.chkl"),
                 )],
             );
             a.text(&tr("Checklist format"));
@@ -593,9 +572,9 @@ fn missing_streets_view_txt(
         let mut lines: Vec<String> = Vec::new();
         for street in todo_streets {
             if chkl {
-                lines.push(format!("[ ] {}\n", street));
+                lines.push(format!("[ ] {street}\n"));
             } else {
-                lines.push(format!("{}\n", street));
+                lines.push(format!("{street}\n"));
             }
         }
         output = lines.join("");
@@ -615,10 +594,7 @@ fn missing_housenumbers_update(
     let doc = yattag::Doc::new();
     doc.text(&tr("Update successful: "));
     let prefix = ctx.get_ini().get_uri_prefix();
-    let link = format!(
-        "{}/missing-housenumbers/{}/view-result",
-        prefix, relation_name
-    );
+    let link = format!("{prefix}/missing-housenumbers/{relation_name}/view-result");
     doc.append_value(util::gen_link(&link, &tr("View missing house numbers")).get_value());
     Ok(doc)
 }
@@ -1168,7 +1144,7 @@ fn handle_main_filters_refcounty(
             "a",
             &[(
                 "href",
-                &format!("{}/filter-for/refcounty/{}/whole-county", prefix, refcounty),
+                &format!("{prefix}/filter-for/refcounty/{refcounty}/whole-county"),
             )],
         );
         a.text(&name);
@@ -1182,8 +1158,7 @@ fn handle_main_filters_refcounty(
                 let name_doc = yattag::Doc::new();
                 {
                     let href = format!(
-                        "{}/filter-for/refcounty/{}/refsettlement/{}",
-                        prefix, refcounty, refsettlement_id
+                        "{prefix}/filter-for/refcounty/{refcounty}/refsettlement/{refsettlement_id}"
                     );
                     let a = name_doc.tag("a", &[("href", &href)]);
                     a.text(&name);
@@ -1222,10 +1197,7 @@ fn handle_main_filters(
     doc = yattag::Doc::new();
     let prefix = ctx.get_ini().get_uri_prefix();
     {
-        let a = doc.tag(
-            "a",
-            &[("href", &format!("{}/filter-for/everything", prefix))],
-        );
+        let a = doc.tag("a", &[("href", &format!("{prefix}/filter-for/everything"))]);
         a.text(&tr("Show complete areas"));
     }
     items.push(doc);
@@ -1440,7 +1412,7 @@ fn write_html_head(ctx: &context::Context, doc: &yattag::Tag, title: &str) -> an
             ("rel", "icon"),
             ("type", "image/vnd.microsoft.icon"),
             ("sizes", "16x12"),
-            ("href", &format!("{}/favicon.ico", prefix)),
+            ("href", &format!("{prefix}/favicon.ico")),
         ],
     );
     head.stag(
@@ -1449,7 +1421,7 @@ fn write_html_head(ctx: &context::Context, doc: &yattag::Tag, title: &str) -> an
             ("rel", "icon"),
             ("type", "image/svg+xml"),
             ("sizes", "any"),
-            ("href", &format!("{}/favicon.svg", prefix)),
+            ("href", &format!("{prefix}/favicon.svg")),
         ],
     );
 
@@ -1475,7 +1447,7 @@ fn write_html_head(ctx: &context::Context, doc: &yattag::Tag, title: &str) -> an
         "script",
         &[
             ("defer", ""),
-            ("src", &format!("{}/static/bundle.js", prefix)),
+            ("src", &format!("{prefix}/static/bundle.js")),
         ],
     );
     drop(script);
@@ -1497,24 +1469,24 @@ fn our_application_txt(
         chkl = last == &"chkl";
     }
     let data: Vec<u8>;
-    if request_uri.starts_with(&format!("{}/missing-streets/", prefix)) {
+    if request_uri.starts_with(&format!("{prefix}/missing-streets/")) {
         let (output, relation_name) = missing_streets_view_txt(ctx, relations, request_uri, chkl)?;
         if chkl {
             content_type = "application/octet-stream";
             headers.push((
                 "Content-Disposition".into(),
-                format!(r#"attachment;filename="{}.txt""#, relation_name).into(),
+                format!(r#"attachment;filename="{relation_name}.txt""#).into(),
             ));
         }
         data = output.as_bytes().to_vec();
-    } else if request_uri.starts_with(&format!("{}/additional-streets/", prefix)) {
+    } else if request_uri.starts_with(&format!("{prefix}/additional-streets/")) {
         let (output, relation_name) =
             wsgi_additional::additional_streets_view_txt(ctx, relations, request_uri, chkl)?;
         if chkl {
             content_type = "application/octet-stream";
             headers.push((
                 "Content-Disposition".into(),
-                format!(r#"attachment;filename="{}.txt""#, relation_name).into(),
+                format!(r#"attachment;filename="{relation_name}.txt""#).into(),
             ));
         }
         data = output.as_bytes().to_vec();
@@ -1526,7 +1498,7 @@ fn our_application_txt(
             content_type = "application/octet-stream";
             headers.push((
                 "Content-Disposition".into(),
-                format!(r#"attachment;filename="{}.txt""#, relation_name).into(),
+                format!(r#"attachment;filename="{relation_name}.txt""#).into(),
             ));
             data = output.as_bytes().to_vec();
         } else if request_uri.ends_with("robots.txt") {
@@ -1568,7 +1540,7 @@ lazy_static! {
 fn get_handler(ctx: &context::Context, request_uri: &str) -> anyhow::Result<Option<Handler>> {
     let prefix = ctx.get_ini().get_uri_prefix();
     for (key, value) in HANDLERS.iter() {
-        if request_uri.starts_with(&format!("{}{}", prefix, key)) {
+        if request_uri.starts_with(&format!("{prefix}{key}")) {
             return Ok(Some(*value));
         }
     }
@@ -1606,7 +1578,7 @@ fn our_application(
         ));
     }
 
-    if request_uri.starts_with(&format!("{}/static/", prefix))
+    if request_uri.starts_with(&format!("{prefix}/static/"))
         || request_uri.ends_with("favicon.ico")
         || request_uri.ends_with("favicon.svg")
     {
@@ -1636,7 +1608,7 @@ fn our_application(
                 .context("handler() failed")?
                 .get_value();
             body.append_value(value);
-        } else if request_uri.starts_with(&format!("{}/webhooks/github", prefix)) {
+        } else if request_uri.starts_with(&format!("{prefix}/webhooks/github")) {
             body.append_value(webframe::handle_github_webhook(request, ctx)?.get_value());
         } else {
             let doc =
@@ -1658,7 +1630,7 @@ pub fn application(request: &rouille::Request, ctx: &context::Context) -> rouill
     match our_application(request, ctx).context("our_application() failed") {
         // Compress.
         Ok(value) => rouille::content_encoding::apply(request, value),
-        Err(err) => webframe::handle_error(request, &format!("{:?}", err)),
+        Err(err) => webframe::handle_error(request, &format!("{err:?}")),
     }
 }
 

--- a/src/wsgi_additional.rs
+++ b/src/wsgi_additional.rs
@@ -125,10 +125,7 @@ pub fn additional_streets_view_result(
                     "a",
                     &[(
                         "href",
-                        &format!(
-                            "{}/additional-streets/{}/view-result.txt",
-                            prefix, relation_name
-                        ),
+                        &format!("{prefix}/additional-streets/{relation_name}/view-result.txt"),
                     )],
                 );
                 a.text(&tr("Plain text format"));
@@ -139,10 +136,7 @@ pub fn additional_streets_view_result(
                     "a",
                     &[(
                         "href",
-                        &format!(
-                            "{}/additional-streets/{}/view-result.chkl",
-                            prefix, relation_name
-                        ),
+                        &format!("{prefix}/additional-streets/{relation_name}/view-result.chkl"),
                     )],
                 );
                 a.text(&tr("Checklist format"));
@@ -153,7 +147,7 @@ pub fn additional_streets_view_result(
                     "a",
                     &[(
                         "href",
-                        &format!("{}/additional-streets/{}/view-turbo", prefix, relation_name),
+                        &format!("{prefix}/additional-streets/{relation_name}/view-turbo"),
                     )],
                 );
                 a.text(&tr("Overpass turbo query for the below streets"));

--- a/src/wsgi_json/tests.rs
+++ b/src/wsgi_json/tests.rs
@@ -289,7 +289,7 @@ fn test_missing_housenumbers_view_result_json() {
     let mut file_system = context::tests::TestFileSystem::new();
     let json_cache = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
-        &test_wsgi.get_ctx(),
+        test_wsgi.get_ctx(),
         &[("workdir/cache-budafok.json", &json_cache)],
     );
     file_system.set_files(&files);


### PR DESCRIPTION
More readable, similar to C++'s "foo " << bar << " baz".

Change-Id: I7d8ad6a21ec8462e4c1336859ec1779b1bfe0f32
