### PR TITLE
stats: explicitly test what happens when old vs new citycount has growing keys

### DIFF
--- a/tests/workdir/stats/2019-07-17.citycount
+++ b/tests/workdir/stats/2019-07-17.citycount
@@ -1,2 +1,0 @@
-budapest_11	142
-budapest_12	20

--- a/tests/workdir/stats/2020-04-10.citycount
+++ b/tests/workdir/stats/2020-04-10.citycount
@@ -1,3 +1,0 @@
-budapest_01	10
-budapest_02	10
-	42


### PR DESCRIPTION
If the city is only in new, but not in old, it should be ignored. This
was hard to test when the .citycount was not populated from code.

Also remove 2019-07-17.citycount, which was not used by any tests.

Change-Id: Ic733af047e1a8ce4972e423c1544c15b0839138a
