### PR TITLE
webframe: fix /housenumber-stats/hungary/cityprogress

### DIFF
--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -559,7 +559,12 @@ fn handle_stats_cityprogress(
     let mut guard = csv_stream.borrow_mut();
     let mut read = guard.deref_mut();
     let mut csv_read = util::CsvRead::new(&mut read);
+    let mut first = true;
     for result in csv_read.records() {
+        if first {
+            first = false;
+            continue;
+        }
         let row = result.context(format!("failed to read row in {path}"))?;
         let city = row.get(0).unwrap();
         let count: u64 = row.get(1).unwrap().parse()?;
@@ -785,7 +790,8 @@ pub fn handle_stats(
     request_uri: &str,
 ) -> anyhow::Result<yattag::Doc> {
     if request_uri.ends_with("/cityprogress") {
-        return handle_stats_cityprogress(ctx, relations);
+        return handle_stats_cityprogress(ctx, relations)
+            .context("handle_stats_cityprogress() failed");
     }
 
     if request_uri.ends_with("/zipprogress") {

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -1874,7 +1874,7 @@ fn test_handle_stats_cityprogress_well_formed() {
     let citycount_value = context::tests::TestFileSystem::make_file();
     citycount_value
         .borrow_mut()
-        .write_all(b"budapest_11\t11\nbudapest_12\t12\n")
+        .write_all(b"VAROS\tCNT\nbudapest_11\t11\nbudapest_12\t12\n")
         .unwrap();
     let files = context::tests::TestFileSystem::make_files(
         &test_wsgi.ctx,


### PR DESCRIPTION
Now that .citycount has a header, need to ignore that till the data is
parsed with util::CsvRead.

Change-Id: Ia6ae7d2178e4305be4d5ceed7590ffe7a5d639b4
