### PR TITLE
webframe: fix /housenumber-stats/hungary/zipprogress

### DIFF
--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -669,7 +669,12 @@ fn handle_stats_zipprogress(
     let mut guard = csv_stream.borrow_mut();
     let mut read = guard.deref_mut();
     let mut csv_read = util::CsvRead::new(&mut read);
+    let mut first = true;
     for result in csv_read.records() {
+        if first {
+            first = false;
+            continue;
+        }
         let row = result.context(format!("failed to read row in {path}"))?;
         let zip = row.get(0).unwrap();
         let count: u64 = row.get(1).unwrap().parse()?;
@@ -795,7 +800,8 @@ pub fn handle_stats(
     }
 
     if request_uri.ends_with("/zipprogress") {
-        return handle_stats_zipprogress(ctx, relations);
+        return handle_stats_zipprogress(ctx, relations)
+            .context("handle_stats_zipprogress() failed");
     }
 
     if request_uri.ends_with("/invalid-relations") {

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -1907,7 +1907,7 @@ fn test_handle_stats_zipprogress_well_formed() {
     let zips_value = context::tests::TestFileSystem::make_file();
     zips_value
         .borrow_mut()
-        .write_all(b"1111\t10\n1121\t20\n")
+        .write_all(b"VAROS\tCNT\n1111\t10\n1121\t20\n")
         .unwrap();
     let files = context::tests::TestFileSystem::make_files(
         &test_wsgi.ctx,


### PR DESCRIPTION
Now that .zipcount has a header, need to ignore that till the data is
parsed with util::CsvRead.

Change-Id: I8b2d4b2cc989b573c39417ef8c31c8d35125617d
