### PR TITLE
cron: switch to typed CSV parsing for stats-level OSM housenumbers

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -978,6 +978,27 @@ pub struct OsmHouseNumber {
     pub object_type: String,
 }
 
+/// One row in workdir/stats/<date>.csv. Keep this in sync with
+/// data/data/street-housenumbers-hungary.overpassql.
+#[derive(serde::Deserialize)]
+pub struct OsmLightHouseNumber {
+    /// Postal code.
+    #[serde(rename = "addr:postcode")]
+    pub postcode: String,
+    /// City name.
+    #[serde(rename = "addr:city")]
+    pub city: String,
+    /// Street name.
+    #[serde(rename = "addr:street")]
+    pub street: String,
+    /// House number.
+    #[serde(rename = "addr:housenumber")]
+    pub housenumber: String,
+    /// Last editor.
+    #[serde(rename = "@user")]
+    pub user: String,
+}
+
 /// Reads a house number CSV and extracts streets from rows.
 /// Returns a list of street objects, with their name, ID and type set.
 pub fn get_street_from_housenumber(


### PR DESCRIPTION
I.e. the one that is country-level, not relation-level.

Change-Id: I6df3e75d8ac233096fa1f68a10ccdba6f71ae734
