### PR TITLE
Switch to SPDX-style license identifiers

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/browser/main.ts
+++ b/src/browser/main.ts
@@ -1,7 +1,7 @@
 /*
- * Copyright 2020 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2020 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 import * as config from './config';

--- a/src/browser/stats.ts
+++ b/src/browser/stats.ts
@@ -1,7 +1,7 @@
 /*
- * Copyright 2020 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2020 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 import {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/cache_yamls.rs
+++ b/src/cache_yamls.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/cache_yamls/tests.rs
+++ b/src/cache_yamls/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/context/system.rs
+++ b/src/context/system.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/i18n/tests.rs
+++ b/src/i18n/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/missing_housenumbers.rs
+++ b/src/missing_housenumbers.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/missing_housenumbers/tests.rs
+++ b/src/missing_housenumbers/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/overpass_query.rs
+++ b/src/overpass_query.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/overpass_query/tests.rs
+++ b/src/overpass_query/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/parse_access_log.rs
+++ b/src/parse_access_log.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/parse_access_log/tests.rs
+++ b/src/parse_access_log/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/ranges/tests.rs
+++ b/src/ranges/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/sync_ref/tests.rs
+++ b/src/sync_ref/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/webframe/tests.rs
+++ b/src/webframe/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/wsgi_additional.rs
+++ b/src/wsgi_additional.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/wsgi_additional/tests.rs
+++ b/src/wsgi_additional/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/wsgi_json.rs
+++ b/src/wsgi_json.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/wsgi_json/tests.rs
+++ b/src/wsgi_json/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/yattag.rs
+++ b/src/yattag.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2021 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2021 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/src/yattag/tests.rs
+++ b/src/yattag/tests.rs
@@ -1,7 +1,7 @@
 /*
- * Copyright 2022 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2022 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #![deny(warnings)]

--- a/tools/ci-build.sh
+++ b/tools/ci-build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -ex
 #
-# Copyright 2020 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2020 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 #
 
 #

--- a/tools/dump-deps.sh
+++ b/tools/dump-deps.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Copyright 2021 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2021 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 #
 
 #

--- a/tools/issue.sh
+++ b/tools/issue.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Copyright 2021 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2021 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 #
 
 #

--- a/tools/read-only.sh
+++ b/tools/read-only.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Copyright 2021 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2021 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 #
 
 # Allows running the tests in a read-only source root (at least the tests/ subfolder).

--- a/tools/sync-state.sh
+++ b/tools/sync-state.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
-# Copyright 2020 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2020 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 #
 
 #


### PR DESCRIPTION
Less boilerplate.

Change-Id: I6f6358f864457e9b94827a3fa2de3f14e21c671b
