### PR TITLE
rouille: add new --host parameter

### DIFF
--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+- rouille: new `--host` parameter to specify the bind address
+
 ## 7.5
 
 - New `/missing-housenumbers/.../view-result.json` endpoint, exposing the missing-housenumbers


### PR DESCRIPTION
127.0.0.1 is a fine default when HTTPS is provided by a reverse proxy on
the same host, but if running inside a container, this won't be
reachable from the outside. E.g. 0.0.0.0 is a better choice in that
case.

Change-Id: I835e8382292e5d459e7a65978c07530dc0d19523
