### PR TITLE
tools, container: import initial support

### DIFF
--- a/tools/container/Containerfile
+++ b/tools/container/Containerfile
@@ -1,0 +1,20 @@
+FROM fedora:37
+
+RUN dnf install -y \
+    cargo \
+    clang-devel \
+    gettext \
+    git \
+    libicu-devel \
+    llvm-devel \
+    make \
+    npm \
+    openssl-devel
+
+RUN git -C /opt clone https://github.com/vmiklos/osm-gimmisn
+
+RUN make -C /opt/osm-gimmisn
+
+COPY /init.sh /
+
+CMD ["/init.sh"]

--- a/tools/container/build.sh
+++ b/tools/container/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
+#
+
+podman build -f Containerfile -t osm-gimmisn
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/tools/container/init.sh
+++ b/tools/container/init.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
+#
+
+cd /opt/osm-gimmisn
+
+# TODO doc: podman exec -t -i osm-gimmisn bash -c 'cd /opt/osm-gimmisn && target/release/osm-gimmisn sync-ref --mode download --url https://www.example.com/osm/data/'
+# TODO doc: podman exec -t -i osm-gimmisn bash -c 'cd /opt/osm-gimmisn && git pull -r && make data/yamls.cache'
+
+target/release/osm-gimmisn rouille --host 0.0.0.0
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab:

--- a/tools/container/run.sh
+++ b/tools/container/run.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
+#
+
+REF_URL="$1"
+
+mkdir -p workdir
+podman run \
+    --env "REF_URL=$REF_URL" \
+    --hostname osm-gimmisn \
+    --interactive \
+    --name osm-gimmisn \
+    --publish 8000:8000 \
+    --rm \
+    --tty \
+    --volume $PWD/workdir:/opt/osm-gimmisn/workdir \
+    localhost/osm-gimmisn:latest
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab:


### PR DESCRIPTION
Docs still needs writing, but in short:

- build.sh can build a container if you want to run osm-gimmisn on some
  hosting platform that only allows containers, not VMs

  - Containerfile is used by build.sh

- run.sh can run the container, in a rootless mode

  - the container will invoke init.sh as its first / only process

Change-Id: Ic0b467b88d950cc2dd4c9e1116349d6aebd1fff3
