### PR TITLE
stats: zipprogress: separate header for city and zip count

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -386,6 +386,17 @@ pub struct CityCount {
     pub count: u64,
 }
 
+/// One row in workdir/refs/zip_count_<DATE>.tsv.
+#[derive(serde::Deserialize)]
+pub struct ZipCount {
+    /// Zip code.
+    #[serde(rename = "IRSZ")]
+    pub city: String,
+    /// Reference count of all housenumbers.
+    #[serde(rename = "CNT")]
+    pub count: u64,
+}
+
 /// Creates a new typed CSV reader.
 pub fn make_csv_reader(read: &mut dyn Read) -> csv::Reader<&mut dyn Read> {
     let reader = csv::ReaderBuilder::new()

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -663,7 +663,7 @@ fn handle_stats_zipprogress(
     let mut read = guard.deref_mut();
     let mut csv_reader = util::make_csv_reader(&mut read);
     for result in csv_reader.deserialize() {
-        let row: util::CityCount = result?;
+        let row: util::ZipCount = result.context(format!("failed to read row in {path}"))?;
         osm_zipcounts.insert(row.city, row.count);
     }
     let ref_zips: Vec<_> = ref_zipcounts

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -1907,7 +1907,7 @@ fn test_handle_stats_zipprogress_well_formed() {
     let zips_value = context::tests::TestFileSystem::make_file();
     zips_value
         .borrow_mut()
-        .write_all(b"VAROS\tCNT\n1111\t10\n1121\t20\n")
+        .write_all(b"IRSZ\tCNT\n1111\t10\n1121\t20\n")
         .unwrap();
     let files = context::tests::TestFileSystem::make_files(
         &test_wsgi.ctx,


### PR DESCRIPTION
We already wrote a different header, adjust the reading side, so
/housenumber-stats/hungary/zipprogress doesn't fail.

Change-Id: I0baee22df4f720a9e384242eb71475ea3c78fe29
