### PR TITLE
areas: write() on a string will never fail

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1509,8 +1509,8 @@ area(@AREA@)->.searchArea;
 "#;
     let mut query = util::process_template(header, relation.config.get_osmrelation());
     for street in streets {
-        writeln!(query, "way[\"name\"=\"{street}\"](r.searchRelation);").unwrap();
-        writeln!(query, "way[\"name\"=\"{street}\"](area.searchArea);").unwrap();
+        let _ = writeln!(query, "way[\"name\"=\"{street}\"](r.searchRelation);");
+        let _ = writeln!(query, "way[\"name\"=\"{street}\"](area.searchArea);");
     }
     query += r#");
 out body;
@@ -1537,7 +1537,7 @@ area(@AREA@)->.searchArea;
     ids.sort();
     ids.dedup();
     for (osm_type, osm_id) in ids {
-        writeln!(query, "{osm_type}({osm_id});").unwrap();
+        let _ = writeln!(query, "{osm_type}({osm_id});");
     }
     query += r#");
 out body;


### PR DESCRIPTION
So can avoid those unwrap() calls.

See
<https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string>.

Change-Id: I78a002ba38dbd1e88ab918c226a5f49ea748c217
