### PR TITLE
context: take network by value in set_network()

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -263,8 +263,8 @@ impl Context {
     }
 
     /// Sets the network implementation.
-    pub fn set_network(&mut self, network: &Arc<dyn Network>) {
-        self.network = network.clone();
+    pub fn set_network(&mut self, network: Arc<dyn Network>) {
+        self.network = network;
     }
 
     /// Gets the time implementation.

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -29,7 +29,7 @@ pub fn make_test_context() -> anyhow::Result<Context> {
     ctx.set_time(&time_arc);
     let network = TestNetwork::new(&[]);
     let network_arc: Arc<dyn Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
     let subprocess = TestSubprocess::new(&HashMap::new());
     let subprocess_arc: Arc<dyn Subprocess> = Arc::new(subprocess);
     ctx.set_subprocess(&subprocess_arc);

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -29,7 +29,7 @@ fn test_overpass_sleep_no_sleep() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
 
     overpass_sleep(&ctx);
 
@@ -59,7 +59,7 @@ fn test_overpass_sleep_need_sleep() {
     ];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
 
     overpass_sleep(&ctx);
 
@@ -484,7 +484,7 @@ fn test_update_osm_housenumbers() {
     ];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let path = ctx.get_abspath("workdir/street-housenumbers-gazdagret.csv");
     let expected = std::fs::read_to_string(&path).unwrap();
@@ -518,7 +518,7 @@ fn test_update_osm_housenumbers_http_error() {
     ];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let path = ctx.get_abspath("workdir/street-housenumbers-gazdagret.csv");
     let expected = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
@@ -572,7 +572,7 @@ fn test_update_osm_housenumbers_xml_as_csv() {
     ];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let path = ctx.get_abspath("workdir/street-housenumbers-gazdagret.csv");
     let expected = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
@@ -599,7 +599,7 @@ fn test_update_osm_streets() {
     ];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
@@ -667,7 +667,7 @@ fn test_update_osm_streets_http_error() {
     ];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let path = ctx.get_abspath("workdir/streets-gazdagret.csv");
     let expected = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
@@ -720,7 +720,7 @@ fn test_update_osm_streets_xml_as_csv() {
     ];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let path = ctx.get_abspath("workdir/streets-gazdagret.csv");
     let expected = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
@@ -749,7 +749,7 @@ fn test_update_stats() {
     ];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
 
     let citycount_value = context::tests::TestFileSystem::make_file();
     let zipcount_value = context::tests::TestFileSystem::make_file();
@@ -836,7 +836,7 @@ fn test_update_stats_http_error() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
 
     let citycount_value = context::tests::TestFileSystem::make_file();
     let count_value = context::tests::TestFileSystem::make_file();
@@ -891,7 +891,7 @@ fn test_update_stats_no_overpass() {
     ];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
 
     let citycount_value = context::tests::TestFileSystem::make_file();
     let zipcount_value = context::tests::TestFileSystem::make_file();
@@ -964,7 +964,7 @@ fn test_our_main() {
     ];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
@@ -1116,7 +1116,7 @@ fn test_our_main_stats() {
     ];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
     let mut file_system = context::tests::TestFileSystem::new();
     let stats_value = context::tests::TestFileSystem::make_file();
     let overpass_template = context::tests::TestFileSystem::make_file();

--- a/src/overpass_query/tests.rs
+++ b/src/overpass_query/tests.rs
@@ -24,7 +24,7 @@ fn test_overpass_query_need_sleep() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
 
     assert_eq!(overpass_query_need_sleep(&ctx), 0);
 }
@@ -40,7 +40,7 @@ fn test_overpass_query_need_sleep_wait() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
 
     assert_eq!(overpass_query_need_sleep(&ctx), 12);
 }
@@ -56,7 +56,7 @@ fn test_overpass_query_need_sleep_wait_negative() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
 
     assert_eq!(overpass_query_need_sleep(&ctx), 1);
 }
@@ -72,7 +72,7 @@ fn test_overpass_query() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
     let query = ctx
         .get_file_system()
         .read_to_string("src/fixtures/network/overpass-happy.overpassql")

--- a/src/sync_ref/tests.rs
+++ b/src/sync_ref/tests.rs
@@ -31,7 +31,7 @@ fn test_main() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
     let wsgi_ini_template = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
@@ -108,7 +108,7 @@ reference_zipcounts = 'workdir/refs/irsz_count_20200717.tsv'
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
 
     let ret = main(&argv, &mut buf, &mut ctx);
 

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -354,7 +354,7 @@ fn test_handle_overpass_error_no_sleep() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
     let doc = handle_overpass_error(&ctx, error);
     let expected = r#"<div id="overpass-error">Overpass error: HTTP Error 404: no such file</div>"#;
     assert_eq!(doc.get_value(), expected);
@@ -372,7 +372,7 @@ fn test_handle_overpass_error_need_sleep() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    ctx.set_network(&network_arc);
+    ctx.set_network(network_arc);
     let doc = handle_overpass_error(&ctx, error);
     let expected = r#"<div id="overpass-error">Overpass error: HTTP Error 404: no such file<br />Note: wait for 12 seconds</div>"#;
     assert_eq!(doc.get_value(), expected);

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -243,7 +243,7 @@ fn test_handle_streets_update_result_well_formed() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    test_wsgi.ctx.set_network(&network_arc);
+    test_wsgi.ctx.set_network(network_arc);
     let streets_value = context::tests::TestFileSystem::make_file();
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
@@ -288,7 +288,7 @@ fn test_handle_streets_update_result_error_well_formed() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    test_wsgi.ctx.set_network(&network_arc);
+    test_wsgi.ctx.set_network(network_arc);
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
@@ -330,7 +330,7 @@ fn test_handle_streets_update_result_missing_streets_well_formed() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    test_wsgi.ctx.set_network(&network_arc);
+    test_wsgi.ctx.set_network(network_arc);
     let streets_value = context::tests::TestFileSystem::make_file();
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
@@ -1097,7 +1097,7 @@ fn test_housenumbers_update_result_well_formed() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    test_wsgi.ctx.set_network(&network_arc);
+    test_wsgi.ctx.set_network(network_arc);
     let streets_value = context::tests::TestFileSystem::make_file();
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
@@ -1145,7 +1145,7 @@ fn test_housenumbers_update_result_error_well_formed() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    test_wsgi.ctx.set_network(&network_arc);
+    test_wsgi.ctx.set_network(network_arc);
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {

--- a/src/wsgi_json/tests.rs
+++ b/src/wsgi_json/tests.rs
@@ -34,7 +34,7 @@ fn test_json_streets_update_result() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    test_wsgi.get_ctx().set_network(&network_arc);
+    test_wsgi.get_ctx().set_network(network_arc);
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "myrelation": {
@@ -80,7 +80,7 @@ fn test_json_streets_update_result_error() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    test_wsgi.get_ctx().set_network(&network_arc);
+    test_wsgi.get_ctx().set_network(network_arc);
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "myrelation": {
@@ -121,7 +121,7 @@ fn test_json_housenumbers_update_result() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    test_wsgi.get_ctx().set_network(&network_arc);
+    test_wsgi.get_ctx().set_network(network_arc);
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
@@ -174,7 +174,7 @@ fn test_json_housenumbers_update_result_error() {
     )];
     let network = context::tests::TestNetwork::new(&routes);
     let network_arc: Arc<dyn context::Network> = Arc::new(network);
-    test_wsgi.get_ctx().set_network(&network_arc);
+    test_wsgi.get_ctx().set_network(network_arc);
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {


### PR DESCRIPTION
Avoids a clone() and we don't need the network after setting it on the
caller side.

Change-Id: Id8f44b83b89285c7df2cb7afe1e7a2a31df0d9bd
