### PR TITLE
sync-ref: differentiate between "ext with no comment" vs "not ext"

### DIFF
--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -58,7 +58,7 @@ fn create_index(
                 let row: util::RefHouseNumber = result?;
                 tx.execute(
                         "insert into ref_housenumbers (county_code, settlement_code, street, housenumber, comment) values (?1, ?2, ?3, ?4, ?5)",
-                        [row.county, row.settlement, row.street, row.alt_housenumber.unwrap(), row.comment.unwrap_or("".into())],
+                        [row.county, row.settlement, row.street, row.alt_housenumber.unwrap(), row.comment.unwrap_or(" ".into())],
                     )?;
             }
             tx.commit()?;


### PR DESCRIPTION
- no comment at all: comes from the main housenumbers ref source

- " " comment: comes from ext, but no comment

Change-Id: Iab24a1b9f551f5b6b98a812638fe32ed56807f4c
