### PR TITLE
context: introduce a Database interface

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -58,6 +58,14 @@ pub trait FileSystem {
 
 pub use system::StdFileSystem;
 
+/// Database interface.
+pub trait Database {
+    /// Opens the connection().
+    fn open(&self) -> anyhow::Result<rusqlite::Connection>;
+}
+
+pub use system::StdDatabase;
+
 /// Network interface.
 pub trait Network {
     /// Opens an URL. Empty data means HTTP GET, otherwise it means a HTTP POST.
@@ -222,6 +230,7 @@ pub struct Context {
     subprocess: Arc<dyn Subprocess>,
     unit: Arc<dyn Unit>,
     file_system: Arc<dyn FileSystem>,
+    database: Arc<dyn Database>,
 }
 
 impl Context {
@@ -235,6 +244,7 @@ impl Context {
         let subprocess = Arc::new(StdSubprocess {});
         let unit = Arc::new(StdUnit {});
         let file_system: Arc<dyn FileSystem> = Arc::new(StdFileSystem {});
+        let database: Arc<dyn Database> = Arc::new(StdDatabase {});
         let ini = Ini::new(&file_system, &format!("{root}/workdir/wsgi.ini"), &root)?;
         Ok(Context {
             root,
@@ -244,6 +254,7 @@ impl Context {
             subprocess,
             unit,
             file_system,
+            database,
         })
     }
 
@@ -305,6 +316,16 @@ impl Context {
     /// Sets the file system implementation.
     pub fn set_file_system(&mut self, file_system: &Arc<dyn FileSystem>) {
         self.file_system = file_system.clone();
+    }
+
+    /// Gets the database implementation.
+    pub fn get_database(&self) -> &Arc<dyn Database> {
+        &self.database
+    }
+
+    /// Sets the database implementation.
+    pub fn set_database(&mut self, database: &Arc<dyn Database>) {
+        self.database = database.clone();
     }
 }
 

--- a/src/context/system.rs
+++ b/src/context/system.rs
@@ -25,6 +25,15 @@ pub fn get_tz_offset() -> time::UtcOffset {
     *TZ_OFFSET
 }
 
+/// Database implementation, backed by sqlite on the filesystem.
+pub struct StdDatabase {}
+
+impl Database for StdDatabase {
+    fn open(&self) -> anyhow::Result<rusqlite::Connection> {
+        Ok(rusqlite::Connection::open("workdir/state.db")?)
+    }
+}
+
 /// File system implementation, backed by the Rust stdlib.
 pub struct StdFileSystem {}
 

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -33,8 +33,20 @@ pub fn make_test_context() -> anyhow::Result<Context> {
     let subprocess = TestSubprocess::new(&HashMap::new());
     let subprocess_arc: Arc<dyn Subprocess> = Arc::new(subprocess);
     ctx.set_subprocess(&subprocess_arc);
+    let database = TestDatabase {};
+    let database_arc: Arc<dyn Database> = Arc::new(database);
+    ctx.set_database(&database_arc);
 
     Ok(ctx)
+}
+
+/// Database implementation, for test purposes.
+pub struct TestDatabase {}
+
+impl Database for TestDatabase {
+    fn open(&self) -> anyhow::Result<rusqlite::Connection> {
+        Ok(rusqlite::Connection::open(":memory:")?)
+    }
 }
 
 /// File system implementation, for test purposes.

--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -22,8 +22,7 @@ fn create_index(
     ctx: &context::Context,
     paths: &[String],
 ) -> anyhow::Result<()> {
-    let db_path = ctx.get_abspath("workdir/state.db");
-    let mut conn = rusqlite::Connection::open(db_path)?;
+    let mut conn = ctx.get_database().open()?;
     conn.execute(
         "create table if not exists ref_housenumbers (
              county_code text not null,


### PR DESCRIPTION
This way the test db is kept in-memory, and no tests/workdir/state.db is
created.

Change-Id: I67eb3ebd37232080dfacc153b4a4d286934a0e00
