### PR TITLE
context: ensure tables / indexes in a created database

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -60,8 +60,29 @@ pub use system::StdFileSystem;
 
 /// Database interface.
 pub trait Database {
-    /// Opens the connection().
+    /// Opens the connection.
     fn open(&self) -> anyhow::Result<rusqlite::Connection>;
+
+    /// Opens and initializes a new database connection.
+    fn create(&self) -> anyhow::Result<rusqlite::Connection> {
+        let conn = self.open()?;
+        conn.execute(
+            "create table if not exists ref_housenumbers (
+                 county_code text not null,
+                 settlement_code text not null,
+                 street text not null,
+                 housenumber text not null,
+                 comment text not null
+             )",
+            [],
+        )?;
+        conn.execute(
+            "create index if not exists idx_ref_housenumbers
+                on ref_housenumbers (county_code, settlement_code, street)",
+            [],
+        )?;
+        Ok(conn)
+    }
 }
 
 pub use system::StdDatabase;

--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -22,22 +22,7 @@ fn create_index(
     ctx: &context::Context,
     paths: &[String],
 ) -> anyhow::Result<()> {
-    let mut conn = ctx.get_database().open()?;
-    conn.execute(
-        "create table if not exists ref_housenumbers (
-             county_code text not null,
-             settlement_code text not null,
-             street text not null,
-             housenumber text not null,
-             comment text not null
-         )",
-        [],
-    )?;
-    conn.execute(
-        "create index if not exists idx_ref_housenumbers
-            on ref_housenumbers (county_code, settlement_code, street)",
-        [],
-    )?;
+    let mut conn = ctx.get_database().create()?;
 
     conn.execute("delete from ref_housenumbers", [])?;
 


### PR DESCRIPTION
Move related code from sync_ref to context, so later areas can use it.

Change-Id: I29a3fec8b767c349f8fd82ac7d26c5091331a013
