### PR TITLE
context: change overpass URI back to the primary one

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -231,7 +231,7 @@ impl Ini {
 
     /// Gets the URI of the overpass instance to be used.
     pub fn get_overpass_uri(&self) -> String {
-        self.get_with_fallback(&self.config.wsgi.overpass_uri, "https://z.overpass-api.de")
+        self.get_with_fallback(&self.config.wsgi.overpass_uri, "https://overpass-api.de")
     }
 
     /// Should the cron job update inactive relations?


### PR DESCRIPTION
'z' seems to be down for now.

Change-Id: I50e30df417c06a01def5b38abe05ce4842d6494c
