### PR TITLE
Import street reference into sql

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -584,6 +584,9 @@ impl Relation {
     /// Gets known streets (not their coordinates) from a reference site, based on relation names
     /// from OSM.
     pub fn write_ref_streets(&self, reference: &str) -> anyhow::Result<()> {
+        let mut conn = self.ctx.get_database().create()?;
+        util::build_street_reference_index(&self.ctx, &mut conn, reference)?;
+
         let memory_cache = util::build_street_reference_cache(&self.ctx, reference)
             .context("build_street_reference_cache() failed")?;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -81,6 +81,19 @@ pub trait Database {
                 on ref_housenumbers (county_code, settlement_code, street)",
             [],
         )?;
+        conn.execute(
+            "create table if not exists ref_streets (
+                 county_code text not null,
+                 settlement_code text not null,
+                 street text not null
+             )",
+            [],
+        )?;
+        conn.execute(
+            "create index if not exists idx_ref_streets
+                on ref_streets (county_code, settlement_code)",
+            [],
+        )?;
         Ok(conn)
     }
 }

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -196,6 +196,36 @@ fn test_build_reference_index() {
     }
 }
 
+/// Tests build_street_reference_index().
+#[test]
+fn test_build_street_reference_index() {
+    let ctx = context::tests::make_test_context().unwrap();
+    let mut conn = ctx.get_database().create().unwrap();
+    conn.execute("delete from ref_streets", []).unwrap();
+    let refpath = ctx.get_abspath("workdir/refs/utcak_20190514.tsv");
+    build_street_reference_index(&ctx, &mut conn, &refpath).unwrap();
+    {
+        let mut stmt = conn.prepare("select count(*) from ref_streets").unwrap();
+        let mut rows = stmt.query([]).unwrap();
+        while let Some(row) = rows.next().unwrap() {
+            let count: i64 = row.get(0).unwrap();
+            // Empty table, so changes from 0 to 6.
+            assert_eq!(count, 6);
+        }
+    }
+
+    build_street_reference_index(&ctx, &mut conn, &refpath).unwrap();
+    {
+        let mut stmt = conn.prepare("select count(*) from ref_streets").unwrap();
+        let mut rows = stmt.query([]).unwrap();
+        while let Some(row) = rows.next().unwrap() {
+            let count: i64 = row.get(0).unwrap();
+            // Early return, so doesn't change from 6 to 12.
+            assert_eq!(count, 6);
+        }
+    }
+}
+
 /// Tests split_house_number(): just numbers.
 #[test]
 fn test_split_house_number_only_number() {


### PR DESCRIPTION
So that indexed sql can be used in the future instead of the home-grown
json cache.

Change-Id: I76a6f5bdc39b592ba713d4a5b70884d5003395e9
