### PR TITLE
No need to hold FileSystem by Arc

### DIFF
--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -14,7 +14,6 @@ use super::*;
 use std::io::Seek;
 use std::io::SeekFrom;
 use std::io::Write;
-use std::sync::Arc;
 
 /// Tests normalize().
 #[test]
@@ -1867,8 +1866,8 @@ fn test_relation_write_missing_housenumbers() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = Relations::new(&ctx).unwrap();
     let relation_name = "gazdagret";
     let mut relation = relations.get_relation(relation_name).unwrap();
@@ -1918,8 +1917,8 @@ fn test_relation_write_missing_housenumbers_empty() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = Relations::new(&ctx).unwrap();
     let relation_name = "empty";
     let mut relation = relations.get_relation(relation_name).unwrap();
@@ -1953,8 +1952,8 @@ fn test_relation_write_missing_housenumbers_interpolation_all() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = Relations::new(&ctx).unwrap();
     let relation_name = "budafok";
     let mut relation = relations.get_relation(relation_name).unwrap();
@@ -1999,8 +1998,8 @@ fn test_relation_write_missing_housenumbers_sorting() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = Relations::new(&ctx).unwrap();
     let relation_name = "gh414";
     let mut relation = relations.get_relation(relation_name).unwrap();

--- a/src/cache/tests.rs
+++ b/src/cache/tests.rs
@@ -15,7 +15,6 @@ use context::FileSystem;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::Arc;
 
 /// Tests get_missing_housenumbers_json(): the cached case.
 ///
@@ -54,8 +53,8 @@ fn test_get_missing_housenumbers_json() {
         Rc::new(RefCell::new(time::OffsetDateTime::now_utc())),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let mut relation = relations.get_relation("gazdagret").unwrap();
 
@@ -101,8 +100,8 @@ fn test_get_additional_housenumbers_json() {
         Rc::new(RefCell::new(time::OffsetDateTime::now_utc())),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let mut relation = relations.get_relation("gazdagret").unwrap();
 
@@ -118,8 +117,8 @@ fn test_is_cache_current() {
     let mut file_system = context::tests::TestFileSystem::new();
     let cache_path = "workdir/gazdagret.json.cache";
     file_system.set_hide_paths(&[cache_path.to_string()]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     let ret = is_cache_current(&ctx, cache_path, &[]).unwrap();
 

--- a/src/cache_yamls/tests.rs
+++ b/src/cache_yamls/tests.rs
@@ -13,6 +13,7 @@
 use super::*;
 use std::io::Seek;
 use std::io::SeekFrom;
+use std::rc::Rc;
 use std::sync::Arc;
 
 /// Tests main().
@@ -58,8 +59,8 @@ fn test_main() {
         ],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     let ret = main(&argv, &mut buf, &ctx);
 
@@ -107,8 +108,8 @@ fn test_main_error() {
         ],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     let ret = main(&argv, &mut buf, &ctx);
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -177,7 +177,7 @@ pub struct Ini {
 
 impl Ini {
     fn new(
-        file_system: &Arc<dyn FileSystem>,
+        file_system: &Rc<dyn FileSystem>,
         config_path: &str,
         root: &str,
     ) -> anyhow::Result<Self> {
@@ -263,7 +263,7 @@ pub struct Context {
     time: Arc<dyn Time>,
     subprocess: Arc<dyn Subprocess>,
     unit: Arc<dyn Unit>,
-    file_system: Arc<dyn FileSystem>,
+    file_system: Rc<dyn FileSystem>,
     database: Arc<dyn Database>,
 }
 
@@ -277,7 +277,7 @@ impl Context {
         let time = Arc::new(StdTime {});
         let subprocess = Arc::new(StdSubprocess {});
         let unit = Arc::new(StdUnit {});
-        let file_system: Arc<dyn FileSystem> = Arc::new(StdFileSystem {});
+        let file_system: Rc<dyn FileSystem> = Rc::new(StdFileSystem {});
         let database: Arc<dyn Database> = Arc::new(StdDatabase {});
         let ini = Ini::new(&file_system, &format!("{root}/workdir/wsgi.ini"), &root)?;
         Ok(Context {
@@ -343,12 +343,12 @@ impl Context {
     }
 
     /// Gets the file system implementation.
-    pub fn get_file_system(&self) -> &Arc<dyn FileSystem> {
+    pub fn get_file_system(&self) -> &Rc<dyn FileSystem> {
         &self.file_system
     }
 
     /// Sets the file system implementation.
-    pub fn set_file_system(&mut self, file_system: &Arc<dyn FileSystem>) {
+    pub fn set_file_system(&mut self, file_system: &Rc<dyn FileSystem>) {
         self.file_system = file_system.clone();
     }
 

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -22,8 +22,8 @@ pub fn make_test_context() -> anyhow::Result<Context> {
     let mut ctx = Context::new("tests")?;
 
     let file_system = TestFileSystem::new();
-    let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let time = TestTime::new(2020, 5, 10);
     let time_arc: Arc<dyn Time> = Arc::new(time);
     ctx.set_time(&time_arc);
@@ -68,11 +68,11 @@ impl TestFileSystem {
     /// Shorthand for new() + set_files() + cast to trait.
     pub fn from_files(
         files: &HashMap<String, Rc<RefCell<std::io::Cursor<Vec<u8>>>>>,
-    ) -> Arc<dyn FileSystem> {
+    ) -> Rc<dyn FileSystem> {
         let mut file_system = TestFileSystem::new();
         file_system.set_files(files);
-        let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
-        file_system_arc
+        let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
+        file_system_rc
     }
 
     pub fn make_file() -> Rc<RefCell<std::io::Cursor<Vec<u8>>>> {
@@ -417,10 +417,10 @@ fn test_ini_new() {
     file_system
         .write_from_string("[wsgi]\n=", &ctx.get_abspath("workdir/wsgi.ini"))
         .unwrap();
-    let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
+    let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
 
     let ret = Ini::new(
-        &file_system_arc,
+        &file_system_rc,
         &ctx.get_abspath("workdir/wsgi.ini"),
         "tests",
     );
@@ -434,9 +434,9 @@ fn test_ini_new_no_config() {
     let ctx = make_test_context().unwrap();
     let mut file_system = TestFileSystem::new();
     file_system.set_hide_paths(&[ctx.get_abspath("workdir/wsgi.ini")]);
-    let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
+    let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
 
-    let ret = Ini::new(&file_system_arc, &ctx.get_abspath("workdir/wsgi.ini"), "");
+    let ret = Ini::new(&file_system_rc, &ctx.get_abspath("workdir/wsgi.ini"), "");
 
     assert_eq!(ret.is_err(), false);
 }

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -121,8 +121,8 @@ fn test_update_ref_housenumbers() {
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
 
     update_ref_housenumbers(&ctx, &mut relations, /*update=*/ true).unwrap();
@@ -191,8 +191,8 @@ fn test_update_ref_streets() {
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
 
     update_ref_streets(&ctx, &mut relations, /*update=*/ true).unwrap();
@@ -272,20 +272,20 @@ fn test_update_missing_housenumbers() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     // Only one housenumber and it's missing.
     let expected: String = "0.00".into();
 
     update_missing_housenumbers(&ctx, &mut relations, /*update=*/ true).unwrap();
 
-    let expected_mtime = file_system_arc.getmtime(&path1).unwrap();
+    let expected_mtime = file_system_rc.getmtime(&path1).unwrap();
     assert!(expected_mtime > time::OffsetDateTime::UNIX_EPOCH);
 
     update_missing_housenumbers(&ctx, &mut relations, /*update=*/ false).unwrap();
 
-    let actual_mtime = file_system_arc.getmtime(&path1).unwrap();
+    let actual_mtime = file_system_rc.getmtime(&path1).unwrap();
     assert_eq!(actual_mtime, expected_mtime);
     let actual = context::tests::TestFileSystem::get_content(&count_file1);
     assert_eq!(actual, expected);
@@ -337,8 +337,8 @@ fn test_update_missing_streets() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let expected: String = "50.00".into();
 
@@ -405,16 +405,16 @@ fn test_update_additional_streets() {
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let expected: String = "1".into();
     update_additional_streets(&ctx, &mut relations, /*update=*/ true).unwrap();
-    let mtime = file_system_arc.getmtime(&path1).unwrap();
+    let mtime = file_system_rc.getmtime(&path1).unwrap();
 
     update_additional_streets(&ctx, &mut relations, /*update=*/ false).unwrap();
 
-    assert_eq!(file_system_arc.getmtime(&path1).unwrap(), mtime);
+    assert_eq!(file_system_rc.getmtime(&path1).unwrap(), mtime);
     let actual = context::tests::TestFileSystem::get_content(&count_file1);
     assert_eq!(actual, expected);
     // Make sure street stat is not created for the streets=no case.
@@ -619,8 +619,8 @@ fn test_update_osm_streets() {
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
 
     update_osm_streets(&ctx, &mut relations, /*update=*/ true).unwrap();
@@ -779,8 +779,8 @@ fn test_update_stats() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     let now = ctx.get_time().now();
     let format = time::format_description::parse("[year]-[month]-[day]").unwrap();
@@ -1021,8 +1021,8 @@ fn test_our_main() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
 
     our_main_inner(
@@ -1122,8 +1122,8 @@ fn test_our_main_stats() {
     let path = ctx.get_abspath("workdir/stats/2020-05-10.csv");
     mtimes.insert(path, Rc::new(RefCell::new(ctx.get_time().now())));
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
 
     our_main_inner(
@@ -1159,8 +1159,8 @@ fn test_main() {
         ],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let argv = vec![
         "".to_string(),
         "--mode".to_string(),
@@ -1205,8 +1205,8 @@ fn test_main_error() {
     file_system
         .write_from_string("300", &ctx.get_abspath("workdir/stats/ref.count"))
         .unwrap();
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let argv = vec![
         "".to_string(),
         "--mode".to_string(),
@@ -1249,8 +1249,8 @@ fn test_update_stats_count() {
         ],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     update_stats_count(&ctx, "2020-05-10").unwrap();
 
@@ -1282,8 +1282,8 @@ fn test_update_stats_count_no_csv() {
     );
     file_system.set_files(&files);
     file_system.set_hide_paths(&[ctx.get_abspath("workdir/stats/2020-05-10.csv")]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     update_stats_count(&ctx, "2020-05-10").unwrap();
 
@@ -1321,8 +1321,8 @@ fn test_update_stats_count_xml_as_csv() {
         ],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     update_stats_count(&ctx, "2020-05-10").unwrap();
 
@@ -1359,8 +1359,8 @@ fn test_update_stats_topusers() {
         ],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     update_stats_topusers(&ctx, "2020-05-10").unwrap();
 
@@ -1391,8 +1391,8 @@ fn test_update_stats_topusers_no_csv() {
     );
     file_system.set_files(&files);
     file_system.set_hide_paths(&[ctx.get_abspath("workdir/stats/2020-05-10.csv")]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     update_stats_topusers(&ctx, "2020-05-10").unwrap();
 
@@ -1417,7 +1417,7 @@ fn test_write_city_count_path() {
     let abspath = ctx.get_abspath(relpath);
     let files = context::tests::TestFileSystem::make_files(&ctx, &[(relpath, &file)]);
     file_system.set_files(&files);
-    let file_system: Arc<dyn context::FileSystem> = Arc::new(file_system);
+    let file_system: Rc<dyn context::FileSystem> = Rc::new(file_system);
     ctx.set_file_system(&file_system);
     let city1: HashSet<String> = ["mystreet 1".to_string(), "mystreet 2".to_string()].into();
     let city2: HashSet<String> = ["mystreet 1".to_string(), "mystreet 2".to_string()].into();
@@ -1444,7 +1444,7 @@ fn test_write_zip_count_path() {
     let abspath = ctx.get_abspath(relpath);
     let files = context::tests::TestFileSystem::make_files(&ctx, &[(relpath, &file)]);
     file_system.set_files(&files);
-    let file_system: Arc<dyn context::FileSystem> = Arc::new(file_system);
+    let file_system: Rc<dyn context::FileSystem> = Rc::new(file_system);
     ctx.set_file_system(&file_system);
     let zip1: HashSet<String> = ["mystreet 1".to_string(), "mystreet 2".to_string()].into();
     let zip2: HashSet<String> = ["mystreet 1".to_string(), "mystreet 2".to_string()].into();
@@ -1493,8 +1493,8 @@ fn test_update_ref_housenumbers_xml_as_csv() {
         ],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
 
     // When updating ref housenumbers:

--- a/src/parse_access_log/tests.rs
+++ b/src/parse_access_log/tests.rs
@@ -14,6 +14,7 @@ use super::*;
 
 use std::io::Read;
 use std::io::Seek;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use context::FileSystem as _;
@@ -98,8 +99,8 @@ fn test_is_complete_relation_complete() {
     file_system
         .write_from_string("100.00", &ctx.get_abspath("workdir/gazdagret.percent"))
         .unwrap();
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
 
     let ret = is_complete_relation(&ctx, &mut relations, "gazdagret").unwrap();

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -12,6 +12,7 @@
 
 use super::*;
 use std::io::Write;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::context::FileSystem as _;
@@ -34,8 +35,8 @@ fn test_handle_progress() {
     file_system
         .write_from_string("300", &ctx.get_abspath("workdir/stats/ref.count"))
         .unwrap();
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
@@ -78,7 +79,7 @@ budapest_11	11
             &ctx.get_abspath("workdir/stats/2020-05-10.citycount"),
         )
         .unwrap();
-    let file_system: Arc<dyn context::FileSystem> = Arc::new(file_system);
+    let file_system: Rc<dyn context::FileSystem> = Rc::new(file_system);
     ctx.set_file_system(&file_system);
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
@@ -109,8 +110,8 @@ fn test_handle_progress_old_time() {
     file_system
         .write_from_string("42", &ctx.get_abspath("workdir/stats/ref.count"))
         .unwrap();
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     let src_root = ctx.get_abspath("workdir/stats");
     let mut j = serde_json::json!({});
@@ -286,8 +287,8 @@ fn test_handle_monthly_new_incomplete_last_month() {
     let hide_path = ctx.get_abspath("workdir/stats/2020-05-10.count");
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_hide_paths(&[hide_path]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     handle_monthly_new(&ctx, &src_root, &mut j, /*month_range=*/ 12).unwrap();
     let monthly = &j.as_object().unwrap()["monthly"].as_array().unwrap();

--- a/src/sync_ref/tests.rs
+++ b/src/sync_ref/tests.rs
@@ -12,6 +12,7 @@
 
 use super::*;
 use std::ops::DerefMut as _;
+use std::rc::Rc;
 use std::sync::Arc;
 
 /// Tests main().
@@ -99,8 +100,8 @@ reference_zipcounts = 'workdir/refs/irsz_count_20200717.tsv'
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
     file_system.set_hide_paths(&[ctx.get_abspath("workdir/refs/irsz_count_20200717.tsv")]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let routes = vec![context::tests::URLRoute::new(
         /*url=*/ "https://www.example.com/osm/data/irsz_count_20200717.tsv",
         /*data_path=*/ "",

--- a/src/webframe/tests.rs
+++ b/src/webframe/tests.rs
@@ -13,7 +13,6 @@
 use super::*;
 use crate::context::Unit;
 use std::io::Write;
-use std::sync::Arc;
 
 /// Tests handle_static().
 #[test]
@@ -36,8 +35,8 @@ fn test_handle_static() {
     );
     file_system.set_files(&files);
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     let prefix = ctx.get_ini().get_uri_prefix();
     let (content, content_type, extra_headers) =
@@ -95,8 +94,8 @@ fn test_handle_static_ico() {
     );
     file_system.set_files(&files);
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     let (content, content_type, extra_headers) = handle_static(&ctx, "/favicon.ico").unwrap();
 
@@ -126,8 +125,8 @@ fn test_handle_static_svg() {
     );
     file_system.set_files(&files);
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     let (content, content_type, extra_headers) = handle_static(&ctx, "/favicon.svg").unwrap();
 

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -402,8 +402,8 @@ fn test_missing_housenumbers_well_formed() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/missing-housenumbers/gazdagret/view-result");
 
@@ -458,8 +458,8 @@ fn test_missing_housenumbers_compat() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/suspicious-streets/gazdagret/view-result");
 
@@ -510,8 +510,8 @@ fn test_missing_housenumbers_compat_relation() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/suspicious-streets/budapest_22/view-result");
 
@@ -541,8 +541,8 @@ fn test_missing_housenumbers_no_osm_streets() {
         &[("data/yamls.cache", &yamls_cache_value)],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/missing-housenumbers/gazdagret/view-result");
 
@@ -572,8 +572,8 @@ fn test_missing_housenumbers_no_osm_housenumbers() {
         &[("data/yamls.cache", &yamls_cache_value)],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/missing-housenumbers/gazdagret/view-result");
 
@@ -603,8 +603,8 @@ fn test_missing_housenumbers_no_ref_housenumbers_well_formed() {
         &[("data/yamls.cache", &yamls_cache_value)],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/missing-housenumbers/gazdagret/view-result");
 
@@ -629,8 +629,8 @@ fn test_missing_housenumbers_view_result_txt() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let result = test_wsgi.get_txt_for_path("/missing-housenumbers/budafok/view-result.txt");
 
@@ -676,8 +676,8 @@ fn test_missing_housenumbers_view_result_txt_even_odd() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let result = test_wsgi.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.txt");
 
@@ -840,8 +840,8 @@ fn test_missing_housenumbers_view_result_chkl_no_osm_streets() {
     let hide_path = relation.get_files().get_osm_streets_path();
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_hide_paths(&[hide_path]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
     let result = test_wsgi.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl");
     assert_eq!(result, "No existing streets");
 }
@@ -855,8 +855,8 @@ fn test_missing_housenumbers_view_result_chkl_no_osm_housenumbers() {
     let hide_path = relation.get_files().get_osm_housenumbers_path();
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_hide_paths(&[hide_path]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
     let result = test_wsgi.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl");
     assert_eq!(result, "No existing house numbers");
 }
@@ -870,8 +870,8 @@ fn test_missing_housenumbers_view_result_chkl_no_ref_housenumbers() {
     let hide_path = relation.get_files().get_ref_housenumbers_path();
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_hide_paths(&[hide_path]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
     let result = test_wsgi.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl");
     assert_eq!(result, "No reference house numbers");
 }
@@ -885,8 +885,8 @@ fn test_missing_housenumbers_view_result_txt_no_osm_streets() {
     let hide_path = relation.get_files().get_osm_streets_path();
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_hide_paths(&[hide_path]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
     let result = test_wsgi.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.txt");
     assert_eq!(result, "No existing streets");
 }
@@ -900,8 +900,8 @@ fn test_missing_housenumbers_view_result_txt_no_osm_housenumbers() {
     let hide_path = relation.get_files().get_osm_housenumbers_path();
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_hide_paths(&[hide_path]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
     let result = test_wsgi.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.txt");
     assert_eq!(result, "No existing house numbers");
 }
@@ -915,8 +915,8 @@ fn test_missing_housenumbers_view_result_txt_no_ref_housenumbers() {
     let hide_path = relation.get_files().get_ref_housenumbers_path();
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_hide_paths(&[hide_path]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
     let result = test_wsgi.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.txt");
     assert_eq!(result, "No reference house numbers");
 }
@@ -1190,8 +1190,8 @@ fn test_housenumbers_no_osm_streets_well_formed() {
         &[("data/yamls.cache", &yamls_cache_value)],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
     let root = test_wsgi.get_dom_for_path("/street-housenumbers/gazdagret/view-result");
     let results = TestWsgi::find_all(&root, "body/div[@id='no-osm-housenumbers']");
     assert_eq!(results.len(), 1);
@@ -1292,8 +1292,8 @@ fn test_missing_streets_no_osm_streets_well_formed() {
         &[("data/yamls.cache", &yamls_cache_value)],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/missing-streets/gazdagret/view-result");
 
@@ -1323,8 +1323,8 @@ fn test_missing_streets_no_ref_streets_well_formed() {
         &[("data/yamls.cache", &yamls_cache_value)],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/missing-streets/gazdagret/view-result");
 
@@ -1400,8 +1400,8 @@ fn test_missing_streets_view_result_txt_no_osm_streets() {
     let hide_path = relation.get_files().get_osm_streets_path();
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_hide_paths(&[hide_path]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let result = test_wsgi.get_txt_for_path("/missing-streets/gazdagret/view-result.txt");
 
@@ -1417,8 +1417,8 @@ fn test_missing_streets_view_result_txt_no_ref_streets() {
     let hide_path = relation.get_files().get_ref_streets_path();
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_hide_paths(&[hide_path]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let result = test_wsgi.get_txt_for_path("/missing-streets/gazdagret/view-result.txt");
 
@@ -1732,8 +1732,8 @@ fn test_application_error() {
     let files =
         context::tests::TestFileSystem::make_files(&ctx, &[("target/browser/osm.min.css", &css)]);
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let bytes: Vec<u8> = Vec::new();
 
     let abspath: String = "/".into();
@@ -1833,8 +1833,8 @@ fn test_static_css() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let result = test_wsgi.get_css_for_path("/static/osm.min.css");
 
@@ -1856,8 +1856,8 @@ fn test_static_text() {
         &[("data/robots.txt", &txt_value)],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let result = test_wsgi.get_txt_for_path("/robots.txt");
 
@@ -1961,8 +1961,8 @@ fn test_handle_invalid_refstreets_no_osm_sreets() {
     file_system.set_files(&files);
     let hide_path = test_wsgi.ctx.get_abspath("workdir/streets-gazdagret.csv");
     file_system.set_hide_paths(&[hide_path]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.ctx.set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/housenumber-stats/hungary/invalid-relations");
 
@@ -1991,7 +1991,7 @@ fn test_handle_invalid_refstreets_no_invalids() {
     );
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
-    let file_system: Arc<dyn context::FileSystem> = Arc::new(file_system);
+    let file_system: Rc<dyn context::FileSystem> = Rc::new(file_system);
     test_wsgi.ctx.set_file_system(&file_system);
 
     let root = test_wsgi.get_dom_for_path("/housenumber-stats/hungary/invalid-relations");
@@ -2190,8 +2190,8 @@ fn test_handle_main_housenr_percent() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let relation = relations.get_relation("gazdagret").unwrap();
 
@@ -2235,8 +2235,8 @@ fn test_handle_main_street_percent() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let relation = relations.get_relation("gazdagret").unwrap();
 
@@ -2280,8 +2280,8 @@ fn test_handle_main_street_additional_count() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let relation = relations.get_relation("gazdagret").unwrap();
 

--- a/src/wsgi_additional/tests.rs
+++ b/src/wsgi_additional/tests.rs
@@ -15,7 +15,6 @@ use std::collections::HashMap;
 use std::io::Seek;
 use std::io::SeekFrom;
 use std::rc::Rc;
-use std::sync::Arc;
 
 use crate::areas;
 use crate::context;
@@ -89,8 +88,8 @@ fn test_streets_view_result_txt_no_osm_streets() {
     let hide_path = relation.get_files().get_osm_streets_path();
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_hide_paths(&[hide_path]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.get_ctx().set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.get_ctx().set_file_system(&file_system_rc);
 
     let result = test_wsgi.get_txt_for_path("/additional-streets/gazdagret/view-result.txt");
 
@@ -106,8 +105,8 @@ fn test_streets_view_result_txt_no_ref_streets() {
     let hide_path = relation.get_files().get_ref_streets_path();
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_hide_paths(&[hide_path]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.get_ctx().set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.get_ctx().set_file_system(&file_system_rc);
 
     let result = test_wsgi.get_txt_for_path("/additional-streets/gazdagret/view-result.txt");
 
@@ -179,8 +178,8 @@ fn test_handle_main_housenr_additional_count_no_count_file() {
         .get_housenumbers_additional_count_path();
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_hide_paths(&[hide_path]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    ctx.set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
 
     let actual = wsgi::handle_main_housenr_additional_count(&ctx, &relation).unwrap();
 
@@ -223,8 +222,8 @@ fn test_additional_housenumbers_well_formed() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.get_ctx().set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.get_ctx().set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/additional-housenumbers/gazdagret/view-result");
 
@@ -254,8 +253,8 @@ fn test_additional_housenumbers_no_osm_streets_well_formed() {
         &[("data/yamls.cache", &yamls_cache_value)],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.get_ctx().set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.get_ctx().set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/additional-housenumbers/gazdagret/view-result");
 
@@ -285,8 +284,8 @@ fn test_additional_housenumbers_no_osm_housenumbers_well_formed() {
     );
     file_system.set_files(&files);
     file_system.set_hide_paths(&[hide_path]);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.get_ctx().set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.get_ctx().set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/additional-housenumbers/gazdagret/view-result");
 
@@ -316,8 +315,8 @@ fn test_additional_housenumbers_no_ref_housenumbers_well_formed() {
         &[("data/yamls.cache", &yamls_cache_value)],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.get_ctx().set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.get_ctx().set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/additional-housenumbers/gazdagret/view-result");
 
@@ -421,8 +420,8 @@ fn test_streets_no_osm_streets_well_formed() {
         &[("data/yamls.cache", &yamls_cache_value)],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.get_ctx().set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.get_ctx().set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/additional-streets/gazdagret/view-result");
 
@@ -452,8 +451,8 @@ fn test_streets_no_ref_streets_well_formed() {
         &[("data/yamls.cache", &yamls_cache_value)],
     );
     file_system.set_files(&files);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.get_ctx().set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.get_ctx().set_file_system(&file_system_rc);
 
     let root = test_wsgi.get_dom_for_path("/additional-streets/gazdagret/view-result");
 

--- a/src/wsgi_json/tests.rs
+++ b/src/wsgi_json/tests.rs
@@ -295,8 +295,8 @@ fn test_missing_housenumbers_view_result_json() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.get_ctx().set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.get_ctx().set_file_system(&file_system_rc);
 
     let result = test_wsgi.get_json_for_path("/missing-housenumbers/budafok/view-result.json");
 
@@ -339,8 +339,8 @@ fn test_additional_housenumbers_view_result_json() {
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);
-    let file_system_arc: Arc<dyn context::FileSystem> = Arc::new(file_system);
-    test_wsgi.get_ctx().set_file_system(&file_system_arc);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.get_ctx().set_file_system(&file_system_rc);
 
     let result = test_wsgi.get_json_for_path("/additional-housenumbers/budafok/view-result.json");
 


### PR DESCRIPTION
A simple Rc is enough, since all code runs on a single thread. This was
a leftover from Python porting.

Change-Id: I9a227fc9aaec4ce021e78afd52fb4971d2f5c4c3
