### PR TITLE
context: lazy-create a shared database connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,7 @@ dependencies = [
  "isahc",
  "lazy_static",
  "log",
+ "once_cell",
  "regex",
  "rouille",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ toml = "0.7.3"
 unidecode = "0.3.0"
 url = "2.3.1"
 rusqlite = "0.29.0"
+once_cell = "1.17.1"
 
 [dev-dependencies]
 flate2 = "1.0.25"

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -574,7 +574,7 @@ impl Relation {
     /// Gets known streets (not their coordinates) from a reference site, based on relation names
     /// from OSM.
     pub fn write_ref_streets(&self, reference: &str) -> anyhow::Result<()> {
-        let mut conn = self.ctx.get_database().create()?;
+        let mut conn = self.ctx.get_database_connection()?;
         util::build_street_reference_index(&self.ctx, &mut conn, reference)?;
 
         let mut lst: Vec<String> = Vec::new();
@@ -615,7 +615,7 @@ impl Relation {
     /// from OSM. Uses build_reference_cache() to build an indexed reference, the result will be
     /// used by get_ref_housenumbers().
     pub fn write_ref_housenumbers(&self, references: &[String]) -> anyhow::Result<()> {
-        let mut conn = self.ctx.get_database().create()?;
+        let mut conn = self.ctx.get_database_connection()?;
         util::build_reference_index(&self.ctx, &mut conn, references)?;
 
         let streets: Vec<String> = self

--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -65,7 +65,7 @@ pub fn download(
     }
 
     stream.write_all("sync-ref: removing old index...\n".as_bytes())?;
-    let conn = ctx.get_database().create()?;
+    let conn = ctx.get_database_connection()?;
     conn.execute("delete from ref_housenumbers", [])?;
 
     ctx.get_file_system()

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -100,7 +100,7 @@ fn test_format_even_odd_html_multi_odd() {
 #[test]
 fn test_build_reference_index() {
     let ctx = context::tests::make_test_context().unwrap();
-    let mut conn = ctx.get_database().create().unwrap();
+    let mut conn = ctx.get_database_connection().unwrap();
     conn.execute("delete from ref_housenumbers", []).unwrap();
     let refpath = ctx.get_abspath("workdir/refs/hazszamok_20190511.tsv");
     build_reference_index(&ctx, &mut conn, &[refpath.clone()]).unwrap();
@@ -134,7 +134,7 @@ fn test_build_reference_index() {
 #[test]
 fn test_build_street_reference_index() {
     let ctx = context::tests::make_test_context().unwrap();
-    let mut conn = ctx.get_database().create().unwrap();
+    let mut conn = ctx.get_database_connection().unwrap();
     conn.execute("delete from ref_streets", []).unwrap();
     let refpath = ctx.get_abspath("workdir/refs/utcak_20190514.tsv");
     build_street_reference_index(&ctx, &mut conn, &refpath).unwrap();


### PR DESCRIPTION
Right now all 3 places create their own sql connections, which is not a
big problem, but in case more sql usage is introduced in the future,
then this connect / disconnect all the time is a waste.

Also, the tests use a :memory: connection, so in case you create a table
in one function and you try to select form it in an other function, it
won't work in the :memory: case to reconnect between the two functions.

Solving this is a bit tricky, since we pass around an immutable Context
and we want to lazy-create this (so the test Context can inject its
memory database), which means inferior mutability, twice.

Solve the lazy part by using OnceCell, we already indirectly depend on
the once_cell crate anyway. The remaining problem is how to have a
mutable connection (for transactions) inside an immutable &Context; that
can work if we hold the sql connection by Rc<RefCell<>>.

Change-Id: I1402a3692be7d148e65b151b957fe64044bd6fa0
