### PR TITLE
areas: track osm housenumber coverages in sql instead of separate files

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -55,11 +55,6 @@ impl RelationFiles {
         )
     }
 
-    /// Builds the file name of the house number percent file of a relation.
-    pub fn get_housenumbers_percent_path(&self) -> String {
-        format!("{}/{}.percent", self.workdir, self.name)
-    }
-
     /// Builds the file name of the house number json cache file of a relation.
     pub fn get_housenumbers_jsoncache_path(&self) -> String {
         format!("{}/cache-{}.json", self.workdir, self.name)

--- a/src/context.rs
+++ b/src/context.rs
@@ -95,6 +95,14 @@ pub trait Database {
                 on ref_streets (county_code, settlement_code)",
             [],
         )?;
+        conn.execute(
+            "create table if not exists osm_housenumber_coverages (
+                 relation_name text primary key not null,
+                 coverage text not null,
+                 last_modified text not null
+             )",
+            [],
+        )?;
         Ok(conn)
     }
 }

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -36,6 +36,8 @@ pub fn make_test_context() -> anyhow::Result<Context> {
     let database = TestDatabase {};
     let database_rc: Rc<dyn Database> = Rc::new(database);
     ctx.set_database(&database_rc);
+    // Create the shared db before cloning the context, so we can assert the result.
+    ctx.get_database_connection().unwrap();
 
     Ok(ctx)
 }

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -196,7 +196,6 @@ fn update_ref_streets(
 
 /// Update the relation's house number coverage stats.
 fn update_missing_housenumbers(
-    ctx: &context::Context,
     relations: &mut areas::Relations,
     update: bool,
 ) -> anyhow::Result<()> {
@@ -208,11 +207,7 @@ fn update_missing_housenumbers(
         let mut relation = relations
             .get_relation(&relation_name)
             .context("get_relation() failed")?;
-        if !update
-            && ctx
-                .get_file_system()
-                .path_exists(&relation.get_files().get_housenumbers_percent_path())
-        {
+        if !update && relation.has_osm_housenumber_coverage()? {
             continue;
         }
         let streets = relation.get_config().should_check_missing_streets();
@@ -522,7 +517,7 @@ fn our_main_inner(
         update_ref_streets(ctx, relations, update)?;
         update_ref_housenumbers(ctx, relations, update)?;
         update_missing_streets(ctx, relations, update)?;
-        update_missing_housenumbers(ctx, relations, update)?;
+        update_missing_housenumbers(relations, update)?;
         update_additional_streets(ctx, relations, update)?;
     }
 

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -859,20 +859,14 @@ fn handle_main_housenr_percent(
         relation.get_name()
     );
     let mut percent: Option<f64> = None;
-    let files = relation.get_files();
-    if ctx
-        .get_file_system()
-        .path_exists(&files.get_housenumbers_percent_path())
-    {
-        let string = ctx
-            .get_file_system()
-            .read_to_string(&files.get_housenumbers_percent_path())?;
+    if relation.has_osm_housenumber_coverage()? {
+        let string = relation.get_osm_housenumber_coverage()?;
         percent = Some(string.parse::<f64>().context("parse to f64 failed")?);
     }
 
     let doc = yattag::Doc::new();
     if let Some(percent) = percent {
-        let date = get_last_modified(ctx, &files.get_housenumbers_percent_path())?;
+        let date = webframe::format_timestamp(&relation.get_osm_housenumber_coverage_mtime()?)?;
         let strong = doc.tag("strong", &[]);
         let a = strong.tag(
             "a",


### PR DESCRIPTION
It's less code.

Change-Id: Idc9ec08eaf8e7db51548064b2c0dd16baf3f5c1e
