### PR TITLE
areas: avoid clone() in Relation::new()

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -37,7 +37,7 @@ fn is_cache_current(
 }
 
 /// Decides if we have an up to date json cache entry or not.
-fn is_missing_housenumbers_json_cached(relation: &mut areas::Relation) -> anyhow::Result<bool> {
+fn is_missing_housenumbers_json_cached(relation: &mut areas::Relation<'_>) -> anyhow::Result<bool> {
     let cache_path = relation.get_files().get_housenumbers_jsoncache_path();
     let datadir = relation.get_ctx().get_abspath("data");
     let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
@@ -51,7 +51,7 @@ fn is_missing_housenumbers_json_cached(relation: &mut areas::Relation) -> anyhow
 }
 
 /// Gets the cached json of the missing housenumbers for a relation.
-pub fn get_missing_housenumbers_json(relation: &mut areas::Relation) -> anyhow::Result<String> {
+pub fn get_missing_housenumbers_json(relation: &mut areas::Relation<'_>) -> anyhow::Result<String> {
     let output: String;
     let jsoncache_path = relation.get_files().get_housenumbers_jsoncache_path();
     if is_missing_housenumbers_json_cached(relation)? {
@@ -73,7 +73,9 @@ pub fn get_missing_housenumbers_json(relation: &mut areas::Relation) -> anyhow::
 }
 
 /// Decides if we have an up to date additional json cache entry or not.
-fn is_additional_housenumbers_json_cached(relation: &mut areas::Relation) -> anyhow::Result<bool> {
+fn is_additional_housenumbers_json_cached(
+    relation: &mut areas::Relation<'_>,
+) -> anyhow::Result<bool> {
     let cache_path = relation
         .get_files()
         .get_additional_housenumbers_jsoncache_path();
@@ -89,7 +91,9 @@ fn is_additional_housenumbers_json_cached(relation: &mut areas::Relation) -> any
 }
 
 /// Gets the cached json of the additional housenumbers for a relation.
-pub fn get_additional_housenumbers_json(relation: &mut areas::Relation) -> anyhow::Result<String> {
+pub fn get_additional_housenumbers_json(
+    relation: &mut areas::Relation<'_>,
+) -> anyhow::Result<String> {
     let output: String;
     let jsoncache_path = relation
         .get_files()

--- a/src/context.rs
+++ b/src/context.rs
@@ -154,14 +154,14 @@ pub trait Unit {
 pub use system::StdUnit;
 
 /// The root of the workdir/wsgi.ini config file.
-#[derive(Clone, Default, serde::Deserialize)]
+#[derive(Default, serde::Deserialize)]
 pub struct IniConfig {
     /// The wsgi section in the config file.
     pub wsgi: WsgiConfig,
 }
 
 /// The wsgi section in the config file.
-#[derive(Clone, Default, serde::Deserialize)]
+#[derive(Default, serde::Deserialize)]
 pub struct WsgiConfig {
     /// Space-separated list of housenumber references.
     pub reference_housenumbers: String,
@@ -178,7 +178,6 @@ pub struct WsgiConfig {
 }
 
 /// Configuration file reader.
-#[derive(Clone)]
 pub struct Ini {
     config: IniConfig,
     root: String,
@@ -264,7 +263,6 @@ impl Ini {
 }
 
 /// Context owns global state which is set up once and then read everywhere.
-#[derive(Clone)]
 pub struct Context {
     root: String,
     ini: Ini,

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -36,8 +36,6 @@ pub fn make_test_context() -> anyhow::Result<Context> {
     let database = TestDatabase {};
     let database_rc: Rc<dyn Database> = Rc::new(database);
     ctx.set_database(&database_rc);
-    // Create the shared db before cloning the context, so we can assert the result.
-    ctx.get_database_connection().unwrap();
 
     Ok(ctx)
 }

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -35,7 +35,7 @@ fn get_last_modified(ctx: &context::Context, path: &str) -> anyhow::Result<Strin
 /// Gets the update date of streets for a relation.
 fn get_streets_last_modified(
     ctx: &context::Context,
-    relation: &areas::Relation,
+    relation: &areas::Relation<'_>,
 ) -> anyhow::Result<String> {
     get_last_modified(ctx, &relation.get_files().get_osm_streets_path())
 }
@@ -99,7 +99,7 @@ fn handle_streets(
 /// Gets the update date of house numbers for a relation.
 fn get_housenumbers_last_modified(
     ctx: &context::Context,
-    relation: &areas::Relation,
+    relation: &areas::Relation<'_>,
 ) -> anyhow::Result<String> {
     get_last_modified(ctx, &relation.get_files().get_osm_housenumbers_path())
 }
@@ -197,7 +197,7 @@ fn missing_housenumbers_view_turbo(
 /// The actual HTML part of missing_housenumbers_view_res().
 fn missing_housenumbers_view_res_html(
     ctx: &context::Context,
-    relation: &mut areas::Relation,
+    relation: &mut areas::Relation<'_>,
 ) -> anyhow::Result<yattag::Doc> {
     let doc = yattag::Doc::new();
     let (todo_street_count, todo_count, done_count, percent, table) = relation
@@ -706,7 +706,7 @@ fn missing_streets_view_turbo(
 /// Gets the update date for missing/additional streets.
 fn relation_streets_get_last_modified(
     ctx: &context::Context,
-    relation: &areas::Relation,
+    relation: &areas::Relation<'_>,
 ) -> anyhow::Result<String> {
     let t_ref = util::get_mtime(ctx, &relation.get_files().get_ref_streets_path());
     let t_osm = util::get_mtime(ctx, &relation.get_files().get_osm_streets_path());
@@ -804,7 +804,7 @@ fn handle_additional_streets(
 /// Gets the update date for missing/additional housenumbers.
 fn relation_housenumbers_get_last_modified(
     ctx: &context::Context,
-    relation: &areas::Relation,
+    relation: &areas::Relation<'_>,
 ) -> anyhow::Result<String> {
     let t_ref = util::get_mtime(ctx, &relation.get_files().get_ref_housenumbers_path());
     let t_osm = util::get_mtime(ctx, &relation.get_files().get_osm_housenumbers_path());
@@ -850,7 +850,7 @@ fn handle_additional_housenumbers(
 /// Handles the house number percent part of the main page.
 fn handle_main_housenr_percent(
     ctx: &context::Context,
-    relation: &areas::Relation,
+    relation: &areas::Relation<'_>,
 ) -> anyhow::Result<(yattag::Doc, f64)> {
     let prefix = ctx.get_ini().get_uri_prefix();
     let url = format!(
@@ -890,7 +890,7 @@ fn handle_main_housenr_percent(
 /// Handles the street percent part of the main page.
 fn handle_main_street_percent(
     ctx: &context::Context,
-    relation: &areas::Relation,
+    relation: &areas::Relation<'_>,
 ) -> anyhow::Result<(yattag::Doc, f64)> {
     let prefix = ctx.get_ini().get_uri_prefix();
     let url = format!(
@@ -935,7 +935,7 @@ fn handle_main_street_percent(
 /// Handles the street additional count part of the main page.
 fn handle_main_street_additional_count(
     ctx: &context::Context,
-    relation: &areas::Relation,
+    relation: &areas::Relation<'_>,
 ) -> anyhow::Result<yattag::Doc> {
     let prefix = ctx.get_ini().get_uri_prefix();
     let url = format!(
@@ -993,7 +993,7 @@ fn get_housenr_additional_count(
 /// Handles the housenumber additional count part of the main page.
 pub fn handle_main_housenr_additional_count(
     ctx: &context::Context,
-    relation: &areas::Relation,
+    relation: &areas::Relation<'_>,
 ) -> anyhow::Result<yattag::Doc> {
     if !relation.get_config().should_check_additional_housenumbers() {
         return Ok(yattag::Doc::new());
@@ -1030,16 +1030,16 @@ pub fn handle_main_housenr_additional_count(
 }
 
 /// Does not filter out anything.
-fn filter_for_everything(_complete: bool, _relation: &areas::Relation) -> bool {
+fn filter_for_everything(_complete: bool, _relation: &areas::Relation<'_>) -> bool {
     true
 }
 
 /// Filters out complete items.
-fn filter_for_incomplete(complete: bool, _relation: &areas::Relation) -> bool {
+fn filter_for_incomplete(complete: bool, _relation: &areas::Relation<'_>) -> bool {
     !complete
 }
 
-type RelationFilter = dyn Fn(bool, &areas::Relation) -> bool;
+type RelationFilter = dyn Fn(bool, &areas::Relation<'_>) -> bool;
 
 /// Creates a function that filters for a single refcounty.
 fn create_filter_for_refcounty(refcounty_filter: &str) -> Box<RelationFilter> {

--- a/src/wsgi_additional.rs
+++ b/src/wsgi_additional.rs
@@ -218,7 +218,7 @@ pub fn additional_streets_view_turbo(
 
 /// The actual HTML part of additional_housenumbers_view_result().
 fn additional_housenumbers_view_result_html(
-    relation: &mut areas::Relation,
+    relation: &mut areas::Relation<'_>,
 ) -> anyhow::Result<yattag::Doc> {
     let doc = yattag::Doc::new();
     let (todo_street_count, todo_count, table) = relation.write_additional_housenumbers()?;

--- a/src/wsgi_additional/tests.rs
+++ b/src/wsgi_additional/tests.rs
@@ -171,15 +171,13 @@ fn test_handle_main_housenr_additional_count() {
 #[test]
 fn test_handle_main_housenr_additional_count_no_count_file() {
     let mut ctx = context::tests::make_test_context().unwrap();
-    let mut relations = areas::Relations::new(&ctx).unwrap();
-    let relation = relations.get_relation("budafok").unwrap();
-    let hide_path = relation
-        .get_files()
-        .get_housenumbers_additional_count_path();
     let mut file_system = context::tests::TestFileSystem::new();
+    let hide_path = ctx.get_abspath("workdir/budafok-additional-housenumbers.count");
     file_system.set_hide_paths(&[hide_path]);
     let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
     ctx.set_file_system(&file_system_rc);
+    let mut relations = areas::Relations::new(&ctx).unwrap();
+    let relation = relations.get_relation("budafok").unwrap();
 
     let actual = wsgi::handle_main_housenr_additional_count(&ctx, &relation).unwrap();
 


### PR DESCRIPTION
Gets rid of that DB hack at the end of make_test_context().

Change-Id: I7183e44edfc1c698cc4d479cabc0dd0a6fc028a5
