### PR TITLE
areas: track osm street coverages in sql instead of separate files

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -65,11 +65,6 @@ impl RelationFiles {
         format!("{}/additional-cache-{}.json", self.workdir, self.name)
     }
 
-    /// Builds the file name of the street percent file of a relation.
-    pub fn get_streets_percent_path(&self) -> String {
-        format!("{}/{}-streets.percent", self.workdir, self.name)
-    }
-
     /// Builds the file name of the street additional count file of a relation.
     pub fn get_streets_additional_count_path(&self) -> String {
         format!("{}/{}-additional-streets.count", self.workdir, self.name)

--- a/src/context.rs
+++ b/src/context.rs
@@ -103,6 +103,14 @@ pub trait Database {
              )",
             [],
         )?;
+        conn.execute(
+            "create table if not exists osm_street_coverages (
+                 relation_name text primary key not null,
+                 coverage text not null,
+                 last_modified text not null
+             )",
+            [],
+        )?;
         Ok(conn)
     }
 }

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -226,18 +226,13 @@ fn update_missing_housenumbers(
 
 /// Update the relation's street coverage stats.
 fn update_missing_streets(
-    ctx: &context::Context,
     relations: &mut areas::Relations<'_>,
     update: bool,
 ) -> anyhow::Result<()> {
     info!("update_missing_streets: start");
     for relation_name in relations.get_active_names()? {
         let relation = relations.get_relation(&relation_name)?;
-        if !update
-            && ctx
-                .get_file_system()
-                .path_exists(&relation.get_files().get_streets_percent_path())
-        {
+        if !update && relation.has_osm_street_coverage()? {
             continue;
         }
         let streets = relation.get_config().should_check_missing_streets();
@@ -516,7 +511,7 @@ fn our_main_inner(
         update_osm_housenumbers(ctx, relations, update)?;
         update_ref_streets(ctx, relations, update)?;
         update_ref_housenumbers(ctx, relations, update)?;
-        update_missing_streets(ctx, relations, update)?;
+        update_missing_streets(relations, update)?;
         update_missing_housenumbers(relations, update)?;
         update_additional_streets(ctx, relations, update)?;
     }

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -309,44 +309,32 @@ fn test_update_missing_streets() {
         },
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
-    let count_file1 = context::tests::TestFileSystem::make_file();
-    let count_file2 = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
-        &[
-            ("data/yamls.cache", &yamls_cache_value),
-            ("workdir/gazdagret-streets.percent", &count_file1),
-            ("workdir/gellerthegy-streets.percent", &count_file2),
-        ],
+        &[("data/yamls.cache", &yamls_cache_value)],
     );
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
-    let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
-    let path1 = ctx.get_abspath("workdir/gazdagret-streets.percent");
-    mtimes.insert(
-        path1.to_string(),
-        Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
-    );
-    file_system.set_mtimes(&mtimes);
     let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
     ctx.set_file_system(&file_system_rc);
     let mut relations = areas::Relations::new(&ctx).unwrap();
     let expected: String = "50.00".into();
+    let relation = relations.get_relation("gazdagret").unwrap();
 
-    update_missing_streets(&ctx, &mut relations, /*update=*/ true).unwrap();
+    update_missing_streets(&mut relations, /*update=*/ true).unwrap();
 
-    let expected_mtime = ctx.get_file_system().getmtime(&path1).unwrap();
+    let expected_mtime = relation.get_osm_street_coverage_mtime().unwrap();
     assert!(expected_mtime > time::OffsetDateTime::UNIX_EPOCH);
 
-    update_missing_streets(&ctx, &mut relations, /*update=*/ false).unwrap();
+    update_missing_streets(&mut relations, /*update=*/ false).unwrap();
 
-    let actual_mtime = ctx.get_file_system().getmtime(&path1).unwrap();
+    let actual_mtime = relation.get_osm_street_coverage_mtime().unwrap();
     assert_eq!(actual_mtime, expected_mtime);
-    let actual = context::tests::TestFileSystem::get_content(&count_file1);
+    let actual = relation.get_osm_street_coverage().unwrap();
     assert_eq!(actual, expected);
     // Make sure street stat is not created for the streets=no case.
-    let mut guard = count_file2.borrow_mut();
-    assert_eq!(guard.seek(SeekFrom::Current(0)).unwrap() > 0, false);
+    let relation2 = relations.get_relation("ujbuda").unwrap();
+    assert_eq!(relation2.has_osm_street_coverage().unwrap(), false);
 }
 
 /// Tests update_additional_streets().
@@ -958,7 +946,6 @@ fn test_our_main() {
     let osm_housenumbers_value = context::tests::TestFileSystem::make_file();
     let ref_streets_value = context::tests::TestFileSystem::make_file();
     let ref_housenumbers_value = context::tests::TestFileSystem::make_file();
-    let missing_streets_value = context::tests::TestFileSystem::make_file();
     let additional_streets_value = context::tests::TestFileSystem::make_file();
     let missing_housenumbers_json = context::tests::TestFileSystem::make_file();
     let template_value = context::tests::TestFileSystem::make_file();
@@ -988,7 +975,6 @@ fn test_our_main() {
                 "workdir/street-housenumbers-reference-gazdagret.lst",
                 &ref_housenumbers_value,
             ),
-            ("workdir/gazdagret-streets.percent", &missing_streets_value),
             (
                 "workdir/gazdagret-additional-streets.count",
                 &additional_streets_value,
@@ -1045,10 +1031,7 @@ fn test_our_main() {
         assert_eq!(guard.seek(SeekFrom::Current(0)).unwrap() > 0, true);
     }
     // update_missing_streets() is called.
-    {
-        let mut guard = missing_streets_value.borrow_mut();
-        assert_eq!(guard.seek(SeekFrom::Current(0)).unwrap() > 0, true);
-    }
+    assert_eq!(relation.has_osm_street_coverage().unwrap(), true);
     // update_missing_housenumbers() is called.
     assert_eq!(relation.has_osm_housenumber_coverage().unwrap(), true);
     // update_additional_streets() is called.

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -899,19 +899,14 @@ fn handle_main_street_percent(
         relation.get_name()
     );
     let mut percent: Option<f64> = None;
-    if ctx
-        .get_file_system()
-        .path_exists(&relation.get_files().get_streets_percent_path())
-    {
-        let string = ctx
-            .get_file_system()
-            .read_to_string(&relation.get_files().get_streets_percent_path())?;
+    if relation.has_osm_street_coverage()? {
+        let string = relation.get_osm_street_coverage()?;
         percent = Some(string.parse::<f64>().context("parse to f64 failed")?);
     }
 
     let doc = yattag::Doc::new();
     if let Some(percent) = percent {
-        let date = get_last_modified(ctx, &relation.get_files().get_streets_percent_path())?;
+        let date = webframe::format_timestamp(&relation.get_osm_street_coverage_mtime()?)?;
         let strong = doc.tag("strong", &[]);
         let a = strong.tag(
             "a",


### PR DESCRIPTION
It's less code.

Change-Id: I3f5ec263f5e7a85654b14e4b57922921f68da5fa
