### PR TITLE
stats, daily csv: include id and type of found objects

### DIFF
--- a/data/street-housenumbers-hungary.overpassql
+++ b/data/street-housenumbers-hungary.overpassql
@@ -1,4 +1,4 @@
-[out:csv("addr:postcode","addr:city", "addr:street", "addr:housenumber", ::user)] [timeout:425];
+[out:csv("addr:postcode","addr:city", "addr:street", "addr:housenumber", ::user, ::id, ::type)] [timeout:425];
 area(3600021335)->.searchArea;
 (
   node["addr:housenumber"](area.searchArea);


### PR DESCRIPTION
I want to flag invalid addr:city values, but it's more helpful when a
link can be provided for the problematic osm object, which requires
asking for the type + id.

Change-Id: I82b7f63c3754a7cdf70b26701dcd5b1edee5cb6b
