### PR TITLE
sync-ref: ignore files without dates

### DIFF
--- a/src/fixtures/network/sync-ref.html
+++ b/src/fixtures/network/sync-ref.html
@@ -12,5 +12,6 @@
       <a href="irsz_count_20221001.tsv">irsz_count_20221001.tsv</a> 01-Oct-2022 09:59   31K  
       <a href="utcak_20221016.tsv">utcak_20221016.tsv</a>      16-Oct-2022 18:22  2.8M  
       <a href="varosok_count_20221001.tsv">varosok_count_202210..&gt;</a> 01-Oct-2022 09:59   49K  
+      <a href="telepulesek.tsv">telepulesek.tsv</a>         19-Apr-2023 08:28   94K
 <hr></pre>
 </body></html>

--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -142,6 +142,9 @@ pub fn our_main(
         };
         let tokens: Vec<&str> = href.split('_').collect();
         let file: String = tokens[0..tokens.len() - 1].join("_");
+        if file.is_empty() {
+            continue;
+        }
         let href_date: u64 = tokens[tokens.len() - 1].parse()?;
         files
             .entry(file)


### PR DESCRIPTION
We assumed that the filename always have a date, but this may not be
true. Just ignore those files.

Change-Id: I96ae446e913e3e0665eaaf39fa78628c02d49395
