### PR TITLE
Extract the sql module from context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ RS_OBJECTS = \
 	src/parse_access_log/tests.rs \
 	src/ranges.rs \
 	src/ranges/tests.rs \
+	src/sql.rs \
 	src/stats.rs \
 	src/stats/tests.rs \
 	src/sync_ref.rs \

--- a/src/context.rs
+++ b/src/context.rs
@@ -20,6 +20,8 @@ use std::path::Path;
 use std::rc::Rc;
 use std::time::Duration;
 
+use crate::sql;
+
 /// File system interface.
 pub trait FileSystem {
     /// Test whether a path exists.
@@ -67,70 +69,7 @@ pub trait Database {
     /// Opens and initializes a new database connection.
     fn create(&self) -> anyhow::Result<rusqlite::Connection> {
         let conn = self.open()?;
-        conn.execute(
-            "create table if not exists ref_housenumbers (
-                 county_code text not null,
-                 settlement_code text not null,
-                 street text not null,
-                 housenumber text not null,
-                 comment text not null
-             )",
-            [],
-        )?;
-        conn.execute(
-            "create index if not exists idx_ref_housenumbers
-                on ref_housenumbers (county_code, settlement_code, street)",
-            [],
-        )?;
-        conn.execute(
-            "create table if not exists ref_streets (
-                 county_code text not null,
-                 settlement_code text not null,
-                 street text not null
-             )",
-            [],
-        )?;
-        conn.execute(
-            "create index if not exists idx_ref_streets
-                on ref_streets (county_code, settlement_code)",
-            [],
-        )?;
-        conn.execute(
-            "create table if not exists osm_housenumber_coverages (
-                 relation_name text primary key not null,
-                 coverage text not null,
-                 last_modified text not null
-             )",
-            [],
-        )?;
-        conn.execute(
-            "create table if not exists osm_street_coverages (
-                 relation_name text primary key not null,
-                 coverage text not null,
-                 last_modified text not null
-             )",
-            [],
-        )?;
-        conn.execute(
-            "create table if not exists stats_invalid_addr_cities (
-                 osm_id text not null,
-                 osm_type text not null,
-                 postcode text not null,
-                 city text not null,
-                 street text not null,
-                 housenumber text not null,
-                 user text not null
-             )",
-            [],
-        )?;
-        conn.execute(
-            "create table if not exists mtimes (
-                 page text primary key not null,
-                 last_modified text not null
-             )",
-            [],
-        )?;
-        conn.execute("pragma user_version = 1", [])?;
+        sql::init(&conn)?;
         Ok(conn)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod missing_housenumbers;
 mod overpass_query;
 pub mod parse_access_log;
 mod ranges;
+mod sql;
 mod stats;
 pub mod sync_ref;
 pub mod util;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#![deny(warnings)]
+#![warn(clippy::all)]
+#![warn(missing_docs)]
+
+//! Database schema creation / migration.
+
+pub fn init(conn: &rusqlite::Connection) -> anyhow::Result<()> {
+    conn.execute(
+        "create table if not exists ref_housenumbers (
+            county_code text not null,
+            settlement_code text not null,
+            street text not null,
+            housenumber text not null,
+            comment text not null
+         )",
+        [],
+    )?;
+    conn.execute(
+        "create index if not exists idx_ref_housenumbers
+            on ref_housenumbers (county_code, settlement_code, street)",
+        [],
+    )?;
+    conn.execute(
+        "create table if not exists ref_streets (
+            county_code text not null,
+            settlement_code text not null,
+            street text not null
+         )",
+        [],
+    )?;
+    conn.execute(
+        "create index if not exists idx_ref_streets
+            on ref_streets (county_code, settlement_code)",
+        [],
+    )?;
+    conn.execute(
+        "create table if not exists osm_housenumber_coverages (
+            relation_name text primary key not null,
+            coverage text not null,
+            last_modified text not null
+         )",
+        [],
+    )?;
+    conn.execute(
+        "create table if not exists osm_street_coverages (
+             relation_name text primary key not null,
+             coverage text not null,
+             last_modified text not null
+         )",
+        [],
+    )?;
+    conn.execute(
+        "create table if not exists stats_invalid_addr_cities (
+            osm_id text not null,
+            osm_type text not null,
+            postcode text not null,
+            city text not null,
+            street text not null,
+            housenumber text not null,
+            user text not null
+        )",
+        [],
+    )?;
+    conn.execute(
+        "create table if not exists mtimes (
+            page text primary key not null,
+            last_modified text not null
+        )",
+        [],
+    )?;
+    conn.execute("pragma user_version = 1", [])?;
+    Ok(())
+}


### PR DESCRIPTION
Mostly because soon we'll need some DB schema migration and context is
not meant to contain much logic, apart from abstracting away
time/network/sql/etc.

Change-Id: I455087f0a153c2247b57c79e2e66241e1583d4e7
