### PR TITLE
sync-ref: fix missing invalidation of ref-streets cache

### DIFF
--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -67,6 +67,7 @@ pub fn download(
     stream.write_all("sync-ref: removing old index...\n".as_bytes())?;
     let conn = ctx.get_database_connection()?;
     conn.execute("delete from ref_housenumbers", [])?;
+    conn.execute("delete from ref_streets", [])?;
 
     ctx.get_file_system()
         .write_from_string(&config_data, &ctx.get_abspath("workdir/wsgi.ini"))?;


### PR DESCRIPTION
ref-housenumbers were already invalidated in sql, do the same for
streets.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/3028>.

Change-Id: I3259fbe32a539ebf9bcddd12be8490102a12d49f
