### PR TITLE
Update dependencies (2023-06)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,18 +341,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1f23fa97e1d1641371b51f35535cb26959b8e27ab50d167a8b996b5bada819"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdc5d93c358224b4d6867ef1356d740de2303e9892edc06c5340daeccd96bab"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
  "anstream",
  "anstyle",
@@ -363,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "codespan-reporting"
@@ -437,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
+checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
 dependencies = [
  "csv-core",
  "itoa",
@@ -550,6 +550,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "encoding"
@@ -870,10 +876,11 @@ dependencies = [
 
 [[package]]
 name = "html_parser"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec016cabcf7c9c48f9d5fdc6b03f273585bfce640a0f47a69552039e92b1959a"
+checksum = "f6f56db07b6612644f6f7719f8ef944f75fff9d6378fdf3d316fd32194184abd"
 dependencies = [
+ "doc-comment",
  "pest",
  "pest_derive",
  "serde",
@@ -1108,12 +1115,9 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "memchr"
@@ -1214,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "openssl-probe"
@@ -1243,7 +1247,7 @@ version = "7.5.0"
 dependencies = [
  "accept-language",
  "anyhow",
- "clap 4.2.5",
+ "clap 4.3.0",
  "csv",
  "flate2",
  "gettext",
@@ -1304,9 +1308,9 @@ checksum = "f658886ed52e196e850cfbbfddab9eaa7f6d90dd0929e264c31e5cec07e09e57"
 
 [[package]]
 name = "pest"
-version = "2.5.5"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1314,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.5"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac3922aac69a40733080f53c1ce7f91dcf57e1a5f6c52f421fadec7fbdc4b69"
+checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1324,22 +1328,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.5"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06646e185566b5961b4058dd107e0a7f56e77c3f484549fb119867773c0f202"
+checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.12",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.5.5"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f60b2ba541577e2a0c307c8f39d1439108120eb7903adeb6497fa880c59616"
+checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
 dependencies = [
  "once_cell",
  "pest",
@@ -1469,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1480,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rouille"
@@ -1524,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "rust_icu_common"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87aff2972ffe7a1f1ee4432375191ef3c6b19bf4e4555fe39594358f58e2197d"
+checksum = "6f9d6105fe694f4c0f9ff9a20863c47018c09456b221a0473e5359bf37017e4d"
 dependencies = [
  "anyhow",
  "rust_icu_sys",
@@ -1535,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "rust_icu_sys"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9f16b72fb360e84f90651180f0621879e5759b9ac4a762c34d782caac38898"
+checksum = "77591b9849b60c741a1ee3bad21c583c0d9409f462b89d22c5055999d0594180"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -1548,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "rust_icu_ucol"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8134af880a3c2efc3904061905ba8c02e96dfb93d8206ca127c521a3b7aaee2d"
+checksum = "dbeaa9c96f290a9ded51bda6296cc091daaaf96d2db1658e9fe530e5bf466b90"
 dependencies = [
  "anyhow",
  "log",
@@ -1563,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "rust_icu_uenum"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2772c3a67218bea2ad5c919183cbd5a2d6c2b6a45590801b9f5e563ed5e2d285"
+checksum = "38875cadabd12f7c9e1fca605a6a1faed1788e6506ae748a554b3f3a3a263f1f"
 dependencies = [
  "paste",
  "rust_icu_common",
@@ -1574,9 +1578,9 @@ dependencies = [
 
 [[package]]
 name = "rust_icu_uformattable"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f19626d0133bc604b9cf9995f4e4ba55966e0662963fbd02a2cb60dcdc9a4e"
+checksum = "e13841a11e01bb6f0ea882058ea283c7322df6c66f70aaaf2a14e401f7ae83dd"
 dependencies = [
  "anyhow",
  "log",
@@ -1588,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "rust_icu_uloc"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276efae72ddb751c3ef4f872cd40e1f184ec96623ef9c457081e262095c09908"
+checksum = "1965997300392724256e88649f741b9a498182191a9e402d2b8c494b98fa88b0"
 dependencies = [
  "anyhow",
  "log",
@@ -1603,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "rust_icu_unum"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c83b91305f52c457a6629df78caec9dff31c491695bd25fdcbc4d004ad6f0c"
+checksum = "e618d4bbd418dc31ec66d3cd7a9ed16d1149cad8b7bee33d15bda65640c46a94"
 dependencies = [
  "anyhow",
  "log",
@@ -1619,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "rust_icu_unumberformatter"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7870d3f1099a37ddce445a78172a70f0590acfdbafecbd578819d619b12a0e09"
+checksum = "ff61938627cf5383bd51124fee92f1aba2f4342791b2f242f9c161550079e00e"
 dependencies = [
  "anyhow",
  "log",
@@ -1636,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "rust_icu_ustring"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54aec55ff42f2616469d493f0a086bd4bd306dfd3bc1f1f7a6613af48aade181"
+checksum = "d292bca291f51f47a114f536a34486c507774dc1f6b02da4ec3c2c31869a9048"
 dependencies = [
  "log",
  "paste",
@@ -1695,18 +1699,18 @@ checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1726,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
  "serde",
 ]
@@ -1904,22 +1908,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -1933,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
  "libc",
@@ -1947,15 +1951,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -1989,9 +1993,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2001,18 +2005,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
  "serde",
@@ -2444,9 +2448,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,30 +7,30 @@ license = "MIT"
 [dependencies]
 accept-language = "2.0.0"
 anyhow = "1.0.71"
-clap = "4.2.5"
-csv = "1.2.1"
+clap = "4.3.0"
+csv = "1.2.2"
 gettext = "0.4.0"
 git-version = "0.3.5"
 html-escape = "0.2.13"
-html_parser = "0.6.3"
+html_parser = "0.7.0"
 isahc = "1.7.2"
 lazy_static = "1.4.0"
-log = "0.4.17"
-regex = "1.8.1"
+log = "0.4.18"
+once_cell = "1.17.2"
+regex = "1.8.3"
 rouille = "3.6.2"
-rust_icu_ucol = { version = "3.0.0", optional = true }
-rust_icu_ustring = { version = "3.0.0", optional = true }
-rust_icu_unumberformatter = { version = "3.0.0", optional = true }
-serde = { version = "1.0.160", features = ["derive"] }
+rusqlite = "0.29.0"
+rust_icu_ucol = { version = "4.0.0", optional = true }
+rust_icu_unumberformatter = { version = "4.0.0", optional = true }
+rust_icu_ustring = { version = "4.0.0", optional = true }
+serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 serde_yaml = "0.9.21"
 simplelog = "0.12.1"
-time = { version = "0.3.20", features = ["formatting", "macros", "local-offset"] }
-toml = "0.7.3"
+time = { version = "0.3.21", features = ["formatting", "macros", "local-offset"] }
+toml = "0.7.4"
 unidecode = "0.3.0"
 url = "2.3.1"
-rusqlite = "0.29.0"
-once_cell = "1.17.1"
 
 [dev-dependencies]
 flate2 = "1.0.26"

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
   "license": "MIT",
   "dependencies": {
-    "@types/node": "18.16.3",
-    "@typescript-eslint/eslint-plugin": "5.59.1",
-    "@typescript-eslint/parser": "5.59.1",
+    "@types/node": "20.2.5",
+    "@typescript-eslint/eslint-plugin": "5.59.8",
+    "@typescript-eslint/parser": "5.59.8",
     "chart.js": "4.3.0",
     "chartjs-plugin-datalabels": "2.2.0",
-    "chartjs-plugin-trendline": "2.0.1",
+    "chartjs-plugin-trendline": "2.0.3",
     "clean-css-cli": "5.6.2",
-    "eslint": "8.39.0",
+    "eslint": "8.41.0",
     "sorttable": "1.0.2",
-    "ts-loader": "9.4.2",
+    "ts-loader": "9.4.3",
     "typescript": "5.0.4",
-    "webpack": "5.81.0",
-    "webpack-cli": "5.0.2"
+    "webpack": "5.85.0",
+    "webpack-cli": "5.1.1"
   },
   "sideEffects": false,
   "repository": {

--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -105,18 +105,19 @@ pub fn our_main(
     }
 
     // Download HTML.
-    let html = ctx.get_network().urlopen(&url, "")?;
+    let mut html = ctx.get_network().urlopen(&url, "")?;
+    // Work around 'expected attribute key' failure.
+    html = html.replace(
+        r#"<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">"#,
+        r#"<!DOCTYPE html>"#,
+    );
 
     // Parse the HTML.
-    let dom = html_parser::Dom::parse(&html)?;
+    let dom = html_parser::Dom::parse(&html).context("failed to parse html")?;
     let mut dom_iter = dom.children.iter();
-    let mut root = dom_iter
+    let root = dom_iter
         .next()
         .context("failed to get first child of dom")?;
-    if root.text().is_some() {
-        // Skip a first-line comment before the real root.
-        root = dom_iter.next().unwrap();
-    }
     let root = root.into_iter();
 
     // The format is type_date.tsv, figure out the latest date for each type.

--- a/src/sync_ref/tests.rs
+++ b/src/sync_ref/tests.rs
@@ -41,6 +41,10 @@ fn test_main() {
     ctx.set_file_system(&file_system);
 
     let ret = main(&argv, &mut buf, &mut ctx);
+    println!(
+        "test_main: buf is '{}'",
+        String::from_utf8(buf.into_inner()).unwrap()
+    );
 
     assert_eq!(ret, 0);
     let actual = ctx


### PR DESCRIPTION
There is some incompatile change in the html_parser crate, the input
can't be parsed as-is. If the header is replaced with the standard html5
header, then no need to skip a first-line comment before the real root.

Change-Id: Ief20bba0e8daf9e3f5469d0c29c4c962cbc1bcdd
