### PR TITLE
sql: add timestamp and fixme cols for the stats_invalid_addr_cities table

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -81,8 +81,20 @@ pub fn init(conn: &rusqlite::Connection) -> anyhow::Result<()> {
         )",
             [],
         )?;
-        conn.execute("pragma user_version = 1", [])?;
     }
+    if user_version < 2 {
+        conn.execute(
+            "alter table stats_invalid_addr_cities add column
+            timestamp text not null default ''",
+            [],
+        )?;
+        conn.execute(
+            "alter table stats_invalid_addr_cities add column
+            fixme text not null default ''",
+            [],
+        )?;
+    }
+    conn.execute("pragma user_version = 2", [])?;
     Ok(())
 }
 


### PR DESCRIPTION
After commit 09b011097f34f8e89b04a9aedfcd75ab64e95959 (data:
street-housenumbers-hungary.overpassql: add timestamp, fixme,
2023-06-01), to be written in stats::update_invalid_addr_cities(), to be
read in webframe::handle_invalid_addr_cities().

Change-Id: I8a480b2e8c00124aac15ec65c7f004136f1ed324
