### PR TITLE
stats, update_invalid_addr_cities: track timestamp/fixme cols from overpass

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -519,8 +519,8 @@ pub fn update_invalid_addr_cities(ctx: &context::Context, state_dir: &str) -> an
             let row: util::OsmLightHouseNumber = result?;
             let city = row.city.to_lowercase();
             if !valid_settlements.contains(&city) && city != "budapest" {
-                tx.execute("insert into stats_invalid_addr_cities (osm_id, osm_type, postcode, city, street, housenumber, user) values (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-                       [row.osm_id, row.osm_type, row.postcode, row.city, row.street, row.housenumber, row.user])?;
+                tx.execute("insert into stats_invalid_addr_cities (osm_id, osm_type, postcode, city, street, housenumber, user, timestamp, fixme) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                       [row.osm_id, row.osm_type, row.postcode, row.city, row.street, row.housenumber, row.user, row.timestamp, row.fixme])?;
             }
         }
         tx.commit()?;


### PR DESCRIPTION
So that later the web interface can show this.

Change-Id: I35947eeb8f9851fbe4e3a956eacbb845d07028bb
