### PR TITLE
tools, container: update to Fedora 38

### DIFF
--- a/tools/container/Containerfile
+++ b/tools/container/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:37
+FROM fedora:38
 
 RUN dnf install -y \
     cargo \


### PR DESCRIPTION
The container file is meant to show how to run this on latest Fedora.

Change-Id: Ib768d1d5e4b62fee98c24fd717ef961f7877aaa1
