### PR TITLE
tools, container: drop not needed REF_URL

### DIFF
--- a/tools/container/run.sh
+++ b/tools/container/run.sh
@@ -5,11 +5,8 @@
 # SPDX-License-Identifier: MIT
 #
 
-REF_URL="$1"
-
 mkdir -p workdir
 podman run \
-    --env "REF_URL=$REF_URL" \
     --hostname osm-gimmisn \
     --interactive \
     --name osm-gimmisn \


### PR DESCRIPTION
guide/src/installation.md explains how to run sync-ref instead.

Change-Id: I355fd85a3497edce0b1c4d2fc7216a7cb188601b
