### PR TITLE
browser, stats: don't begin the y axis in the usertotal chart

### DIFF
--- a/src/browser/stats.ts
+++ b/src/browser/stats.ts
@@ -402,6 +402,7 @@ function addCharts(stats: Stats) {
                     },
                 },
                 y: {
+                    beginAtZero: false, // default would be false
                     title: {
                         display: true,
                         text: getString("str-usertotal-y-axis"),


### PR DESCRIPTION
This was like this before the chartjs3 migration, then it was lost, it
seems.

Change-Id: Ide8c1107e9daec43f6b40105fa93bb33bd7e1135
