### PR TITLE
stats: replace 'insert' with 'insert or update' for the stats_invalid_addr_cities_counts table

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -531,7 +531,8 @@ pub fn update_invalid_addr_cities(ctx: &context::Context, state_dir: &str) -> an
         let format = time::format_description::parse("[year]-[month]-[day]")?;
         let today = now.format(&format)?;
         tx.execute(
-            "insert into stats_invalid_addr_cities_counts (date, count) values (?1, ?2)",
+            r#"insert into stats_invalid_addr_cities_counts (date, count) values (?1, ?2)
+               on conflict(date) do update set count = excluded.count"#,
             [today, count.to_string()],
         )?;
         tx.commit()?;


### PR DESCRIPTION
So that 'cargo run -- cron --mode stats --no-overpass' runs again more
than once a day without errors.

Change-Id: I782a2b4c7da0efc0b69a005cfeddf9c86aee795c
