### PR TITLE
cron, stats: start tracking workdir/stats/<date>.count files in sql as well

### DIFF
--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -1227,6 +1227,18 @@ fn test_update_stats_count() {
     {
         let mut guard = today_count_value.borrow_mut();
         assert_eq!(guard.seek(SeekFrom::Current(0)).unwrap() > 0, true);
+        let conn = ctx.get_database_connection().unwrap();
+        let mut stmt = conn
+            .prepare("select date, count from stats_counts")
+            .unwrap();
+        let mut rows = stmt.query([]).unwrap();
+        while let Some(row) = rows.next().unwrap() {
+            let date: String = row.get(0).unwrap();
+            assert_eq!(date, "2020-05-10");
+            let count: String = row.get(1).unwrap();
+            let count: i64 = count.parse().unwrap();
+            assert_eq!(count, 1);
+        }
     }
     {
         let mut guard = today_citycount_value.borrow_mut();

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -104,7 +104,17 @@ pub fn init(conn: &rusqlite::Connection) -> anyhow::Result<()> {
             [],
         )?;
     }
-    conn.execute("pragma user_version = 3", [])?;
+    if user_version < 4 {
+        // Tracks the number of OSM house numbers over time.
+        conn.execute(
+            "create table stats_counts (
+            date text primary key not null,
+            count text not null
+        )",
+            [],
+        )?;
+    }
+    conn.execute("pragma user_version = 4", [])?;
     Ok(())
 }
 


### PR DESCRIPTION
It's much easier to query the date when it's in sql. Start tracking
this, so the query can switch to working from sql in 2 weeks.

Change-Id: I173836816258b1643a95f7272689ee341dbfa754
