### PR TITLE
cron, stats: switch from <date>.csv to whole-country.csv

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -318,7 +318,7 @@ fn write_zip_count_path(
 /// Counts the # of all house numbers as of today.
 fn update_stats_count(ctx: &context::Context, today: &str) -> anyhow::Result<()> {
     let statedir = ctx.get_abspath("workdir/stats");
-    let csv_path = format!("{statedir}/{today}.csv");
+    let csv_path = format!("{statedir}/whole-country.csv");
     if !ctx.get_file_system().path_exists(&csv_path) {
         return Ok(());
     }
@@ -381,7 +381,7 @@ fn update_stats_count(ctx: &context::Context, today: &str) -> anyhow::Result<()>
 /// Counts the top housenumber editors as of today.
 fn update_stats_topusers(ctx: &context::Context, today: &str) -> anyhow::Result<()> {
     let statedir = ctx.get_abspath("workdir/stats");
-    let csv_path = format!("{statedir}/{today}.csv");
+    let csv_path = format!("{statedir}/whole-country.csv");
     if !ctx.get_file_system().path_exists(&csv_path) {
         return Ok(());
     }
@@ -453,7 +453,7 @@ fn update_stats(ctx: &context::Context, overpass: bool) -> anyhow::Result<()> {
     let now = ctx.get_time().now();
     let format = time::format_description::parse("[year]-[month]-[day]")?;
     let today = now.format(&format)?;
-    let csv_path = format!("{statedir}/{today}.csv");
+    let csv_path = format!("{statedir}/whole-country.csv");
 
     if overpass {
         info!("update_stats: talking to overpass");

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -736,7 +736,7 @@ fn test_update_stats() {
             ("workdir/stats/2020-05-10.zipcount", &zipcount_value),
             ("workdir/stats/2020-05-10.count", &count_value),
             ("workdir/stats/2020-05-10.topusers", &topusers_value),
-            ("workdir/stats/2020-05-10.csv", &csv_value),
+            ("workdir/stats/whole-country.csv", &csv_value),
             ("workdir/stats/2020-05-10.usercount", &usercount_value),
             ("workdir/stats/ref.count", &ref_count),
             ("workdir/stats/stats.json", &stats_json),
@@ -750,7 +750,7 @@ fn test_update_stats() {
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
-    let path = ctx.get_abspath("workdir/stats/2020-05-10.csv");
+    let path = ctx.get_abspath("workdir/stats/whole-country.csv");
     mtimes.insert(path, Rc::new(RefCell::new(ctx.get_time().now())));
     let path = ctx.get_abspath("workdir/stats/old.csv");
     mtimes.insert(
@@ -761,10 +761,7 @@ fn test_update_stats() {
     let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
     ctx.set_file_system(&file_system_rc);
 
-    let now = ctx.get_time().now();
-    let format = time::format_description::parse("[year]-[month]-[day]").unwrap();
-    let today = now.format(&format).unwrap();
-    let path = ctx.get_abspath(&format!("workdir/stats/{today}.csv"));
+    let path = ctx.get_abspath(&format!("workdir/stats/whole-country.csv"));
 
     update_stats(&ctx, /*overpass=*/ true).unwrap();
 
@@ -1078,7 +1075,7 @@ fn test_our_main_stats() {
                 "data/street-housenumbers-hungary.overpassql",
                 &overpass_template,
             ),
-            ("workdir/stats/2020-05-10.csv", &today_csv),
+            ("workdir/stats/whole-country.csv", &today_csv),
             ("workdir/stats/2020-05-10.count", &today_count),
             ("workdir/stats/2020-05-10.citycount", &today_citycount),
             ("workdir/stats/2020-05-10.zipcount", &today_zipcount),
@@ -1089,7 +1086,7 @@ fn test_our_main_stats() {
     );
     file_system.set_files(&files);
     let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
-    let path = ctx.get_abspath("workdir/stats/2020-05-10.csv");
+    let path = ctx.get_abspath("workdir/stats/whole-country.csv");
     mtimes.insert(path, Rc::new(RefCell::new(ctx.get_time().now())));
     file_system.set_mtimes(&mtimes);
     let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
@@ -1212,7 +1209,7 @@ fn test_update_stats_count() {
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
         &[
-            ("workdir/stats/2020-05-10.csv", &today_csv_value),
+            ("workdir/stats/whole-country.csv", &today_csv_value),
             ("workdir/stats/2020-05-10.count", &today_count_value),
             ("workdir/stats/2020-05-10.citycount", &today_citycount_value),
             ("workdir/stats/2020-05-10.zipcount", &today_zipcount_value),
@@ -1263,7 +1260,7 @@ fn test_update_stats_count_no_csv() {
         ],
     );
     file_system.set_files(&files);
-    file_system.set_hide_paths(&[ctx.get_abspath("workdir/stats/2020-05-10.csv")]);
+    file_system.set_hide_paths(&[ctx.get_abspath("workdir/stats/whole-country.csv")]);
     let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
     ctx.set_file_system(&file_system_rc);
 
@@ -1296,7 +1293,7 @@ fn test_update_stats_count_xml_as_csv() {
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
         &[
-            ("workdir/stats/2020-05-10.csv", &today_csv_value),
+            ("workdir/stats/whole-country.csv", &today_csv_value),
             ("workdir/stats/2020-05-10.count", &today_count_value),
             ("workdir/stats/2020-05-10.citycount", &today_citycount_value),
             ("workdir/stats/2020-05-10.zipcount", &today_zipcount_value),
@@ -1335,7 +1332,7 @@ fn test_update_stats_topusers() {
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
         &[
-            ("workdir/stats/2020-05-10.csv", &today_csv_value),
+            ("workdir/stats/whole-country.csv", &today_csv_value),
             ("workdir/stats/2020-05-10.topusers", &today_topusers_value),
             ("workdir/stats/2020-05-10.usercount", &today_usercount_value),
         ],
@@ -1372,7 +1369,7 @@ fn test_update_stats_topusers_no_csv() {
         ],
     );
     file_system.set_files(&files);
-    file_system.set_hide_paths(&[ctx.get_abspath("workdir/stats/2020-05-10.csv")]);
+    file_system.set_hide_paths(&[ctx.get_abspath("workdir/stats/whole-country.csv")]);
     let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
     ctx.set_file_system(&file_system_rc);
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -525,10 +525,7 @@ pub fn update_invalid_addr_cities(ctx: &context::Context, state_dir: &str) -> an
     info!("stats: updating invalid_addr_cities");
     let valid_settlements =
         util::get_valid_settlements(ctx).context("get_valid_settlements() failed")?;
-    let now = ctx.get_time().now();
-    let format = time::format_description::parse("[year]-[month]-[day]")?;
-    let today = now.format(&format)?;
-    let csv_path = format!("{state_dir}/{today}.csv");
+    let csv_path = format!("{state_dir}/whole-country.csv");
     if !ctx.get_file_system().path_exists(&csv_path) {
         warn!("update_invalid_addr_cities: no such path: {csv_path}");
         return Ok(());

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -474,7 +474,7 @@ fn test_update_invalid_addr_cities() {
         .unwrap();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
-        &[("workdir/stats/2020-05-10.csv", &today_csv)],
+        &[("workdir/stats/whole-country.csv", &today_csv)],
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);


### PR DESCRIPTION
This is less code and we never look at the whole-country CSV from the
past, only for today.

The original idea was to have some idea about new rows in that CSV, but
these days we have a @timestamp column for that.

Change-Id: I802f2370c8b98c6f213fa13881f3fc3eb1ebe5f6
