### PR TITLE
stats: extract 2 lints from the stats page to an own lints page

### DIFF
--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -6,6 +6,7 @@
 - The `/missing-housenumbers/.../update-result` is now about 6 times faster (replaced home-grown
   JSON cache with SQL indexes)
 - New `/housenumber-stats/.../invalid-addr-cities` endpoint, tries to find invalid addr:city values
+- Resolves: gh#2986 stats: the length of the invalid addr:city values list now has a chart
 - Resolves: gh#2994 areas: find ref-not-in-reflist problems in `Relation.get_invalid_refstreets()`
 
 ## 7.5

--- a/po/hu/osm-gimmisn.po
+++ b/po/hu/osm-gimmisn.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: osm-gimmisn\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-24 20:23+0000\n"
-"PO-Revision-Date: 2023-06-24 22:24+0200\n"
+"POT-Creation-Date: 2023-06-29 13:15+0000\n"
+"PO-Revision-Date: 2023-06-29 15:15+0200\n"
 "Last-Translator: Miklos Vajna <osm-gimmisn@vmiklos.hu>\n"
 "Language-Team: Hungarian\n"
 "Language: hu\n"
@@ -140,7 +140,7 @@ msgstr "Területek listája"
 msgid "Waiting for Overpass..."
 msgstr "Overpass: várakozás..."
 
-#: src/webframe.rs:368 src/webframe.rs:1164 src/webframe.rs:1185
+#: src/webframe.rs:368 src/webframe.rs:1207 src/webframe.rs:1228
 #: src/wsgi.rs:1231
 msgid "Error from Overpass: "
 msgstr "Overpass hiba: "
@@ -149,7 +149,7 @@ msgstr "Overpass hiba: "
 msgid "Creating from reference..."
 msgstr "Létrehozás referenciából..."
 
-#: src/webframe.rs:373 src/webframe.rs:1206 src/webframe.rs:1226
+#: src/webframe.rs:373 src/webframe.rs:1249 src/webframe.rs:1269
 msgid "Error from reference: "
 msgstr "Hiba a referenciától: "
 
@@ -165,47 +165,51 @@ msgstr "Terület határa"
 msgid "Statistics"
 msgstr "Statisztikák"
 
-#: src/webframe.rs:412
+#: src/webframe.rs:419
+msgid "Lints"
+msgstr "Ellenőrző eszközök"
+
+#: src/webframe.rs:425
 msgid "https://vmiklos.hu/osm-gimmisn"
 msgstr "https://wiki.openstreetmap.org/wiki/Hungary/osm-gimmisn"
 
-#: src/webframe.rs:413
+#: src/webframe.rs:426
 msgid "Documentation"
 msgstr "Dokumentáció"
 
-#: src/webframe.rs:488
+#: src/webframe.rs:501
 msgid "Internal error when serving {0}"
 msgstr "Belső hiba a {0} kiszolgálása során"
 
-#: src/webframe.rs:509
+#: src/webframe.rs:522
 msgid "Not Found"
 msgstr "Nem található"
 
-#: src/webframe.rs:513
+#: src/webframe.rs:526
 msgid "The requested URL was not found on this server."
 msgstr "A kért URL nem található ezen a kiszolgálón."
 
-#: src/webframe.rs:579 src/webframe.rs:927
+#: src/webframe.rs:592 src/webframe.rs:932
 msgid "City name"
 msgstr "Város neve"
 
-#: src/webframe.rs:580 src/webframe.rs:670 src/wsgi.rs:1332
+#: src/webframe.rs:593 src/webframe.rs:683 src/wsgi.rs:1332
 msgid "House number coverage"
 msgstr "Házszám lefedettség"
 
-#: src/webframe.rs:581 src/webframe.rs:671
+#: src/webframe.rs:594 src/webframe.rs:684
 msgid "OSM count"
 msgstr "OSM szám"
 
-#: src/webframe.rs:582 src/webframe.rs:672
+#: src/webframe.rs:595 src/webframe.rs:685
 msgid "Reference count"
 msgstr "Referencia szám"
 
-#: src/webframe.rs:603 src/webframe.rs:695 src/webframe.rs:1065
+#: src/webframe.rs:616 src/webframe.rs:708 src/webframe.rs:1042
 msgid "Note"
 msgstr "Megjegyzés"
 
-#: src/webframe.rs:608
+#: src/webframe.rs:621
 msgid ""
 "These statistics are estimates, not taking house number filters into "
 "account.\n"
@@ -214,11 +218,11 @@ msgstr ""
 "Ezek a statisztikák becslések, nem véve figyelembe a házszám szűrőket.\n"
 "Csak olyan városok szerepelnek benne, amiknek van az OSM-ben házszámuk."
 
-#: src/webframe.rs:669
+#: src/webframe.rs:682
 msgid "ZIP code"
 msgstr "Irányítószám"
 
-#: src/webframe.rs:700
+#: src/webframe.rs:713
 msgid ""
 "These statistics are estimates, not taking house number filters into "
 "account.\n"
@@ -228,208 +232,204 @@ msgstr ""
 "Csak olyan irányítószámok szerepelnek benne, amiknek van az OSM-ben "
 "házszámuk."
 
-#: src/webframe.rs:735 src/wsgi_additional.rs:91
+#: src/webframe.rs:748 src/wsgi_additional.rs:91
 msgid "Identifier"
 msgstr "Azonosító"
 
-#: src/webframe.rs:736 src/wsgi_additional.rs:92
+#: src/webframe.rs:749 src/wsgi_additional.rs:92
 msgid "Type"
 msgstr "Típus"
 
-#: src/webframe.rs:737
+#: src/webframe.rs:750
 msgid "Postcode"
 msgstr "Irányítószám"
 
-#: src/webframe.rs:738
+#: src/webframe.rs:751
 msgid "City"
 msgstr "Város"
 
-#: src/webframe.rs:739
+#: src/webframe.rs:752
 msgid "Street"
 msgstr "Utca"
 
-#: src/webframe.rs:740
+#: src/webframe.rs:753
 msgid "Housenumber"
 msgstr "Házszám"
 
-#: src/webframe.rs:741
+#: src/webframe.rs:754
 msgid "User"
 msgstr "Felhasználó neve"
 
-#: src/webframe.rs:742
+#: src/webframe.rs:755
 msgid "Timestamp"
 msgstr "Időbélyeg"
 
-#: src/webframe.rs:743
+#: src/webframe.rs:756
 msgid "Fixme"
 msgstr "Javíts ki (fixme)"
 
-#: src/webframe.rs:782
+#: src/webframe.rs:795
 msgid ""
 "The addr:city key of the below {0} objects probably has an invalid value."
 msgstr ""
 "Az alábbi {0} objektum addr:city kulcsának értéke valószínűleg érvénytelen."
 
-#: src/webframe.rs:895
+#: src/webframe.rs:900
 msgid "New house numbers, last 2 weeks, as of {}"
 msgstr "Új házszámok, utolsó 2 hét, frissítve: {}"
 
-#: src/webframe.rs:897 src/webframe.rs:962
+#: src/webframe.rs:902 src/webframe.rs:967
 msgid "During this day"
 msgstr "E nap folyamán"
 
-#: src/webframe.rs:898 src/webframe.rs:904 src/webframe.rs:971
+#: src/webframe.rs:903 src/webframe.rs:909 src/webframe.rs:976
 msgid "New house numbers"
 msgstr "Új házszámok"
 
-#: src/webframe.rs:901
+#: src/webframe.rs:906
 msgid "New house numbers, last year, as of {}"
 msgstr "Új házszámok, elmúlt év, frissítve: {}"
 
-#: src/webframe.rs:903
+#: src/webframe.rs:908
 msgid "During this month"
 msgstr "E hónap folyamán"
 
-#: src/webframe.rs:907
+#: src/webframe.rs:912
 msgid "All house numbers, last year, as of {}"
 msgstr "Összes házszám, elmúlt év, frissítve: {}"
 
-#: src/webframe.rs:909
+#: src/webframe.rs:914
 msgid "Latest for this month"
 msgstr "Legutóbbi erre a hónapra"
 
-#: src/webframe.rs:910 src/webframe.rs:916 src/webframe.rs:972
+#: src/webframe.rs:915 src/webframe.rs:921 src/webframe.rs:977
 msgid "All house numbers"
 msgstr "Minden házszám"
 
-#: src/webframe.rs:913
+#: src/webframe.rs:918
 msgid "All house numbers, last 2 weeks, as of {}"
 msgstr "Összes házszám, utolsó 2 hét, frissítve: {}"
 
-#: src/webframe.rs:915
+#: src/webframe.rs:920
 msgid "At the start of this day"
 msgstr "Ennek a napnak a kezdetén"
 
-#: src/webframe.rs:919
+#: src/webframe.rs:924
 msgid "Top house number editors, as of {}"
 msgstr "Legaktívabb házszám szerkesztők, frissítve: {}"
 
-#: src/webframe.rs:921
+#: src/webframe.rs:926
 msgid "User name"
 msgstr "Felhasználó neve"
 
-#: src/webframe.rs:924
+#: src/webframe.rs:929
 msgid "Number of house numbers last changed by this user"
 msgstr "Felhasználó által utoljára módosított házszámok száma"
 
-#: src/webframe.rs:926
+#: src/webframe.rs:931
 msgid "Top edited cities, as of {}"
 msgstr "Legaktívabb városok, frissítve: {}"
 
-#: src/webframe.rs:930
+#: src/webframe.rs:935
 msgid "Number of house numbers added in the past 30 days"
 msgstr "Az elmúlt 30 napban hozzáadott házszámok száma"
 
-#: src/webframe.rs:932
+#: src/webframe.rs:937
 msgid "(empty)"
 msgstr "(üres)"
 
-#: src/webframe.rs:933
+#: src/webframe.rs:938
 msgid "(invalid)"
 msgstr "(hibás)"
 
-#: src/webframe.rs:936
+#: src/webframe.rs:941
 msgid "Number of house number editors, as of {}"
 msgstr "Házszám szerkesztők száma, frissítve: {}"
 
-#: src/webframe.rs:938
+#: src/webframe.rs:943
 msgid "All editors"
 msgstr "Összes szerkesztő"
 
-#: src/webframe.rs:941
+#: src/webframe.rs:946
 msgid ""
 "Number of editors, at least one housenumber is last changed by these users"
 msgstr ""
 "Szerkesztők száma, legalább egy házszámot ezek a szerkesztők változtattak "
 "meg utoljára"
 
-#: src/webframe.rs:943
+#: src/webframe.rs:948
 msgid "Coverage is {1}%, as of {2}"
 msgstr "A lefedettség {1}%, frissítve: {2}"
 
-#: src/webframe.rs:946
+#: src/webframe.rs:951
 msgid "Number of house numbers in database"
 msgstr "Adatbázisban szereplő házszámok száma"
 
-#: src/webframe.rs:948
+#: src/webframe.rs:953
 msgid "Data source"
 msgstr "Adatforrás"
 
-#: src/webframe.rs:951
+#: src/webframe.rs:956
 msgid "Coverage is {1}% for the capital, as of {2}"
 msgstr "A főváros lefedettsége {1}%, frissítve: {2}"
 
-#: src/webframe.rs:955
+#: src/webframe.rs:960
 msgid "Number of house numbers in database for the capital"
 msgstr "Adatbázisban szereplő fővárosi házszámok száma"
 
-#: src/webframe.rs:957
+#: src/webframe.rs:962
 msgid "Reference"
 msgstr "Referencia"
 
-#: src/webframe.rs:960
+#: src/webframe.rs:965
 msgid "Invalid addr:city values, last 2 weeks, as of {}"
 msgstr "Érvénytelen addr:city értékek, utolsó 2 hét, frissítve: {}"
 
-#: src/webframe.rs:965 src/webframe.rs:983
+#: src/webframe.rs:970 src/webframe.rs:1088
 msgid "Invalid addr:city values"
 msgstr "Érvénytelen addr:city értékek"
 
-#: src/webframe.rs:973
+#: src/webframe.rs:978
 msgid "New house numbers, monthly"
 msgstr "Új házszámok, havonta"
 
-#: src/webframe.rs:974
+#: src/webframe.rs:979
 msgid "All house numbers, monthly"
 msgstr "Minden házszám, havonta"
 
-#: src/webframe.rs:975
+#: src/webframe.rs:980
 msgid "Top house number editors"
 msgstr "Legaktívabb házszám szerkesztők"
 
-#: src/webframe.rs:976
+#: src/webframe.rs:981
 msgid "Top edited cities"
 msgstr "Legaktívabb városok"
 
-#: src/webframe.rs:977
+#: src/webframe.rs:982
 msgid "All house number editors"
 msgstr "Összes házszám szerkesztő"
 
-#: src/webframe.rs:978
+#: src/webframe.rs:983
 msgid "Coverage"
 msgstr "Lefedettség"
 
-#: src/webframe.rs:979
+#: src/webframe.rs:984
 msgid "Capital coverage"
 msgstr "A főváros lefedettsége"
 
-#: src/webframe.rs:980
+#: src/webframe.rs:985
 msgid "Per-city coverage"
 msgstr "Városonkénti lefedettség"
 
-#: src/webframe.rs:981
+#: src/webframe.rs:986
 msgid "Per-ZIP coverage"
 msgstr "Irányítószámonkénti lefedettség"
 
-#: src/webframe.rs:982
-msgid "Invalid relation settings"
-msgstr "Érvénytelen területi beállítások"
-
-#: src/webframe.rs:985
+#: src/webframe.rs:988
 msgid "Invalid addr:city values history"
 msgstr "Érvénytelen addr:city értékek története"
 
-#: src/webframe.rs:1070
+#: src/webframe.rs:1047
 msgid ""
 "These statistics are provided purely for interested editors, and are not\n"
 "intended to reflect quality of work done by any given editor in OSM. If you "
@@ -443,39 +443,43 @@ msgstr ""
 "használni, hogy motiváljad magad, az rendben van, de ne felejtsd, hogy "
 "kevesebb hasznos munka többet ér, mint sok haszontalan munka."
 
-#: src/webframe.rs:1145
+#: src/webframe.rs:1087
+msgid "Invalid relation settings"
+msgstr "Érvénytelen területi beállítások"
+
+#: src/webframe.rs:1188
 msgid "No such relation: {0}"
 msgstr "Nincs ilyen reláció: {0}"
 
-#: src/webframe.rs:1157
+#: src/webframe.rs:1200
 msgid "No existing streets: call Overpass to create..."
 msgstr "Nincsenek meglévő utcák: létrehozás Overpass hívásával..."
 
-#: src/webframe.rs:1162
+#: src/webframe.rs:1205
 msgid "No existing streets: waiting for Overpass..."
 msgstr "Nincsenek meglévő utcák: Overpass: várakozás..."
 
-#: src/webframe.rs:1177
+#: src/webframe.rs:1220
 msgid "No existing house numbers: call Overpass to create..."
 msgstr "Nincsenek meglévő házszámok: létrehozás Overpass hívásával..."
 
-#: src/webframe.rs:1183
+#: src/webframe.rs:1226
 msgid "No existing house numbers: waiting for Overpass..."
 msgstr "Nincsenek meglévő házszámok: Overpass: várakozás..."
 
-#: src/webframe.rs:1198
+#: src/webframe.rs:1241
 msgid "No reference house numbers: create from reference..."
 msgstr "Nincsenek referencia házszámok: létrehozás referenciából..."
 
-#: src/webframe.rs:1204
+#: src/webframe.rs:1247
 msgid "No reference house numbers: creating from reference..."
 msgstr "Nincsenek referencia házszámok: létrehozás referenciából..."
 
-#: src/webframe.rs:1219
+#: src/webframe.rs:1262
 msgid "No street list: create from reference..."
 msgstr "Nincsenek referencia utcák: létrehozás referenciából..."
 
-#: src/webframe.rs:1224
+#: src/webframe.rs:1267
 msgid "No reference streets: creating from reference..."
 msgstr "Nincsenek referencia utcák: létrehozás referenciából..."
 

--- a/po/osm-gimmisn.pot
+++ b/po/osm-gimmisn.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-24 20:23+0000\n"
+"POT-Creation-Date: 2023-06-29 13:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -125,7 +125,7 @@ msgstr ""
 msgid "Waiting for Overpass..."
 msgstr ""
 
-#: src/webframe.rs:368 src/webframe.rs:1164 src/webframe.rs:1185 src/wsgi.rs:1231
+#: src/webframe.rs:368 src/webframe.rs:1207 src/webframe.rs:1228 src/wsgi.rs:1231
 msgid "Error from Overpass: "
 msgstr ""
 
@@ -133,7 +133,7 @@ msgstr ""
 msgid "Creating from reference..."
 msgstr ""
 
-#: src/webframe.rs:373 src/webframe.rs:1206 src/webframe.rs:1226
+#: src/webframe.rs:373 src/webframe.rs:1249 src/webframe.rs:1269
 msgid "Error from reference: "
 msgstr ""
 
@@ -149,296 +149,300 @@ msgstr ""
 msgid "Statistics"
 msgstr ""
 
-#: src/webframe.rs:412
+#: src/webframe.rs:419
+msgid "Lints"
+msgstr ""
+
+#: src/webframe.rs:425
 msgid "https://vmiklos.hu/osm-gimmisn"
 msgstr ""
 
-#: src/webframe.rs:413
+#: src/webframe.rs:426
 msgid "Documentation"
 msgstr ""
 
-#: src/webframe.rs:488
+#: src/webframe.rs:501
 msgid "Internal error when serving {0}"
 msgstr ""
 
-#: src/webframe.rs:509
+#: src/webframe.rs:522
 msgid "Not Found"
 msgstr ""
 
-#: src/webframe.rs:513
+#: src/webframe.rs:526
 msgid "The requested URL was not found on this server."
 msgstr ""
 
-#: src/webframe.rs:579 src/webframe.rs:927
+#: src/webframe.rs:592 src/webframe.rs:932
 msgid "City name"
 msgstr ""
 
-#: src/webframe.rs:580 src/webframe.rs:670 src/wsgi.rs:1332
+#: src/webframe.rs:593 src/webframe.rs:683 src/wsgi.rs:1332
 msgid "House number coverage"
 msgstr ""
 
-#: src/webframe.rs:581 src/webframe.rs:671
+#: src/webframe.rs:594 src/webframe.rs:684
 msgid "OSM count"
 msgstr ""
 
-#: src/webframe.rs:582 src/webframe.rs:672
+#: src/webframe.rs:595 src/webframe.rs:685
 msgid "Reference count"
 msgstr ""
 
-#: src/webframe.rs:603 src/webframe.rs:695 src/webframe.rs:1065
+#: src/webframe.rs:616 src/webframe.rs:708 src/webframe.rs:1042
 msgid "Note"
 msgstr ""
 
-#: src/webframe.rs:608
+#: src/webframe.rs:621
 msgid "These statistics are estimates, not taking house number filters into account.\n"
 "Only cities with house numbers in OSM are considered."
 msgstr ""
 
-#: src/webframe.rs:669
+#: src/webframe.rs:682
 msgid "ZIP code"
 msgstr ""
 
-#: src/webframe.rs:700
+#: src/webframe.rs:713
 msgid "These statistics are estimates, not taking house number filters into account.\n"
 "Only zip codes with house numbers in OSM are considered."
 msgstr ""
 
-#: src/webframe.rs:735 src/wsgi_additional.rs:91
+#: src/webframe.rs:748 src/wsgi_additional.rs:91
 msgid "Identifier"
 msgstr ""
 
-#: src/webframe.rs:736 src/wsgi_additional.rs:92
+#: src/webframe.rs:749 src/wsgi_additional.rs:92
 msgid "Type"
 msgstr ""
 
-#: src/webframe.rs:737
+#: src/webframe.rs:750
 msgid "Postcode"
 msgstr ""
 
-#: src/webframe.rs:738
+#: src/webframe.rs:751
 msgid "City"
 msgstr ""
 
-#: src/webframe.rs:739
+#: src/webframe.rs:752
 msgid "Street"
 msgstr ""
 
-#: src/webframe.rs:740
+#: src/webframe.rs:753
 msgid "Housenumber"
 msgstr ""
 
-#: src/webframe.rs:741
+#: src/webframe.rs:754
 msgid "User"
 msgstr ""
 
-#: src/webframe.rs:742
+#: src/webframe.rs:755
 msgid "Timestamp"
 msgstr ""
 
-#: src/webframe.rs:743
+#: src/webframe.rs:756
 msgid "Fixme"
 msgstr ""
 
-#: src/webframe.rs:782
+#: src/webframe.rs:795
 msgid "The addr:city key of the below {0} objects probably has an invalid value."
 msgstr ""
 
-#: src/webframe.rs:895
+#: src/webframe.rs:900
 msgid "New house numbers, last 2 weeks, as of {}"
 msgstr ""
 
-#: src/webframe.rs:897 src/webframe.rs:962
+#: src/webframe.rs:902 src/webframe.rs:967
 msgid "During this day"
 msgstr ""
 
-#: src/webframe.rs:898 src/webframe.rs:904 src/webframe.rs:971
+#: src/webframe.rs:903 src/webframe.rs:909 src/webframe.rs:976
 msgid "New house numbers"
 msgstr ""
 
-#: src/webframe.rs:901
+#: src/webframe.rs:906
 msgid "New house numbers, last year, as of {}"
 msgstr ""
 
-#: src/webframe.rs:903
+#: src/webframe.rs:908
 msgid "During this month"
 msgstr ""
 
-#: src/webframe.rs:907
+#: src/webframe.rs:912
 msgid "All house numbers, last year, as of {}"
 msgstr ""
 
-#: src/webframe.rs:909
+#: src/webframe.rs:914
 msgid "Latest for this month"
 msgstr ""
 
-#: src/webframe.rs:910 src/webframe.rs:916 src/webframe.rs:972
+#: src/webframe.rs:915 src/webframe.rs:921 src/webframe.rs:977
 msgid "All house numbers"
 msgstr ""
 
-#: src/webframe.rs:913
+#: src/webframe.rs:918
 msgid "All house numbers, last 2 weeks, as of {}"
 msgstr ""
 
-#: src/webframe.rs:915
+#: src/webframe.rs:920
 msgid "At the start of this day"
 msgstr ""
 
-#: src/webframe.rs:919
+#: src/webframe.rs:924
 msgid "Top house number editors, as of {}"
 msgstr ""
 
-#: src/webframe.rs:921
+#: src/webframe.rs:926
 msgid "User name"
 msgstr ""
 
-#: src/webframe.rs:924
+#: src/webframe.rs:929
 msgid "Number of house numbers last changed by this user"
 msgstr ""
 
-#: src/webframe.rs:926
+#: src/webframe.rs:931
 msgid "Top edited cities, as of {}"
 msgstr ""
 
-#: src/webframe.rs:930
+#: src/webframe.rs:935
 msgid "Number of house numbers added in the past 30 days"
 msgstr ""
 
-#: src/webframe.rs:932
+#: src/webframe.rs:937
 msgid "(empty)"
 msgstr ""
 
-#: src/webframe.rs:933
+#: src/webframe.rs:938
 msgid "(invalid)"
 msgstr ""
 
-#: src/webframe.rs:936
+#: src/webframe.rs:941
 msgid "Number of house number editors, as of {}"
 msgstr ""
 
-#: src/webframe.rs:938
+#: src/webframe.rs:943
 msgid "All editors"
 msgstr ""
 
-#: src/webframe.rs:941
+#: src/webframe.rs:946
 msgid "Number of editors, at least one housenumber is last changed by these users"
 msgstr ""
 
-#: src/webframe.rs:943
+#: src/webframe.rs:948
 msgid "Coverage is {1}%, as of {2}"
 msgstr ""
 
-#: src/webframe.rs:946
+#: src/webframe.rs:951
 msgid "Number of house numbers in database"
 msgstr ""
 
-#: src/webframe.rs:948
+#: src/webframe.rs:953
 msgid "Data source"
 msgstr ""
 
-#: src/webframe.rs:951
+#: src/webframe.rs:956
 msgid "Coverage is {1}% for the capital, as of {2}"
 msgstr ""
 
-#: src/webframe.rs:955
+#: src/webframe.rs:960
 msgid "Number of house numbers in database for the capital"
 msgstr ""
 
-#: src/webframe.rs:957
+#: src/webframe.rs:962
 msgid "Reference"
 msgstr ""
 
-#: src/webframe.rs:960
+#: src/webframe.rs:965
 msgid "Invalid addr:city values, last 2 weeks, as of {}"
 msgstr ""
 
-#: src/webframe.rs:965 src/webframe.rs:983
+#: src/webframe.rs:970 src/webframe.rs:1088
 msgid "Invalid addr:city values"
 msgstr ""
 
-#: src/webframe.rs:973
+#: src/webframe.rs:978
 msgid "New house numbers, monthly"
 msgstr ""
 
-#: src/webframe.rs:974
+#: src/webframe.rs:979
 msgid "All house numbers, monthly"
 msgstr ""
 
-#: src/webframe.rs:975
+#: src/webframe.rs:980
 msgid "Top house number editors"
 msgstr ""
 
-#: src/webframe.rs:976
+#: src/webframe.rs:981
 msgid "Top edited cities"
 msgstr ""
 
-#: src/webframe.rs:977
+#: src/webframe.rs:982
 msgid "All house number editors"
 msgstr ""
 
-#: src/webframe.rs:978
+#: src/webframe.rs:983
 msgid "Coverage"
 msgstr ""
 
-#: src/webframe.rs:979
+#: src/webframe.rs:984
 msgid "Capital coverage"
 msgstr ""
 
-#: src/webframe.rs:980
+#: src/webframe.rs:985
 msgid "Per-city coverage"
 msgstr ""
 
-#: src/webframe.rs:981
+#: src/webframe.rs:986
 msgid "Per-ZIP coverage"
 msgstr ""
 
-#: src/webframe.rs:982
-msgid "Invalid relation settings"
-msgstr ""
-
-#: src/webframe.rs:985
+#: src/webframe.rs:988
 msgid "Invalid addr:city values history"
 msgstr ""
 
-#: src/webframe.rs:1070
+#: src/webframe.rs:1047
 msgid "These statistics are provided purely for interested editors, and are not\n"
 "intended to reflect quality of work done by any given editor in OSM. If you want to use\n"
 "them to motivate yourself, that's fine, but keep in mind that a bit of useful work is\n"
 "more meaningful than a lot of useless work."
 msgstr ""
 
-#: src/webframe.rs:1145
+#: src/webframe.rs:1087
+msgid "Invalid relation settings"
+msgstr ""
+
+#: src/webframe.rs:1188
 msgid "No such relation: {0}"
 msgstr ""
 
-#: src/webframe.rs:1157
+#: src/webframe.rs:1200
 msgid "No existing streets: call Overpass to create..."
 msgstr ""
 
-#: src/webframe.rs:1162
+#: src/webframe.rs:1205
 msgid "No existing streets: waiting for Overpass..."
 msgstr ""
 
-#: src/webframe.rs:1177
+#: src/webframe.rs:1220
 msgid "No existing house numbers: call Overpass to create..."
 msgstr ""
 
-#: src/webframe.rs:1183
+#: src/webframe.rs:1226
 msgid "No existing house numbers: waiting for Overpass..."
 msgstr ""
 
-#: src/webframe.rs:1198
+#: src/webframe.rs:1241
 msgid "No reference house numbers: create from reference..."
 msgstr ""
 
-#: src/webframe.rs:1204
+#: src/webframe.rs:1247
 msgid "No reference house numbers: creating from reference..."
 msgstr ""
 
-#: src/webframe.rs:1219
+#: src/webframe.rs:1262
 msgid "No street list: create from reference..."
 msgstr ""
 
-#: src/webframe.rs:1224
+#: src/webframe.rs:1267
 msgid "No reference streets: creating from reference..."
 msgstr ""
 

--- a/src/webframe/tests.rs
+++ b/src/webframe/tests.rs
@@ -226,7 +226,7 @@ fn test_handle_invalid_addr_cities() {
         .unwrap();
     }
 
-    let root = test_wsgi.get_dom_for_path("/housenumber-stats/whole-country/invalid-addr-cities");
+    let root = test_wsgi.get_dom_for_path("/lints/whole-country/invalid-addr-cities");
 
     let results = wsgi::tests::TestWsgi::find_all(&root, "body/table/tr");
     // header + 1 row.
@@ -256,8 +256,20 @@ fn test_handle_invalid_refstreets_no_errors() {
     let file_system = context::tests::TestFileSystem::from_files(&files);
     test_wsgi.get_ctx().set_file_system(&file_system);
 
-    let root = test_wsgi.get_dom_for_path("/housenumber-stats/whole-country/invalid-relations");
+    let root = test_wsgi.get_dom_for_path("/lints/whole-country/invalid-relations");
 
     let results = wsgi::tests::TestWsgi::find_all(&root, "body/h1/a");
     assert_eq!(results.is_empty(), true);
+}
+
+/// Tests handle_lints().
+#[test]
+fn test_handle_lints() {
+    let mut test_wsgi = wsgi::tests::TestWsgi::new();
+
+    let root = test_wsgi.get_dom_for_path("/lints/whole-country/");
+
+    let results = wsgi::tests::TestWsgi::find_all(&root, "body/ul/li");
+    // 2 lint types.
+    assert_eq!(results.len(), 2);
 }

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1523,6 +1523,7 @@ lazy_static! {
         ret.insert("/street-housenumbers/".into(), handle_street_housenumbers);
         ret.insert("/missing-housenumbers/".into(), handle_missing_housenumbers);
         ret.insert("/housenumber-stats/".into(), webframe::handle_stats);
+        ret.insert("/lints/".into(), webframe::handle_lints);
         ret
     };
 }

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -1922,7 +1922,7 @@ fn test_handle_invalid_refstreets() {
     let file_system = context::tests::TestFileSystem::from_files(&files);
     test_wsgi.get_ctx().set_file_system(&file_system);
 
-    let root = test_wsgi.get_dom_for_path("/housenumber-stats/whole-country/invalid-relations");
+    let root = test_wsgi.get_dom_for_path("/lints/whole-country/invalid-relations");
 
     let mut results = TestWsgi::find_all(&root, "body/h1/a");
     assert_eq!(results.is_empty(), false);
@@ -1955,7 +1955,7 @@ fn test_handle_invalid_refstreets_no_osm_sreets() {
     let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
     test_wsgi.ctx.set_file_system(&file_system_rc);
 
-    let root = test_wsgi.get_dom_for_path("/housenumber-stats/whole-country/invalid-relations");
+    let root = test_wsgi.get_dom_for_path("/lints/whole-country/invalid-relations");
 
     let results = TestWsgi::find_all(&root, "body");
     assert_eq!(results.is_empty(), false);
@@ -1985,7 +1985,7 @@ fn test_handle_invalid_refstreets_no_invalids() {
     let file_system: Rc<dyn context::FileSystem> = Rc::new(file_system);
     test_wsgi.ctx.set_file_system(&file_system);
 
-    let root = test_wsgi.get_dom_for_path("/housenumber-stats/whole-country/invalid-relations");
+    let root = test_wsgi.get_dom_for_path("/lints/whole-country/invalid-relations");
 
     let results = TestWsgi::find_all(&root, "body/h1/a");
     assert_eq!(results.is_empty(), true);


### PR DESCRIPTION
The stats page continues to serve charts. The lints page provides
verification tools.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/2987>.

Change-Id: I592adde28d83ce1c6d797d47aed387c70fc39cb0
