### PR TITLE
cron, stats: start tracking workdir/stats/<date>.usercount files in sql as well

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -415,9 +415,19 @@ fn update_stats_topusers(ctx: &context::Context, today: &str) -> anyhow::Result<
         }
     }
 
+    // Old style: workdir/stats/<date>.usercount files.
     let line = format!("{}\n", users.len());
     ctx.get_file_system()
-        .write_from_string(&line, &usercount_path)
+        .write_from_string(&line, &usercount_path)?;
+    // New style: sql row.
+    let mut conn = ctx.get_database_connection()?;
+    let tx = conn.transaction()?;
+    tx.execute(
+        r#"insert into stats_usercounts (date, count) values (?1, ?2)
+               on conflict(date) do update set count = excluded.count"#,
+        [today, &users.len().to_string()],
+    )?;
+    Ok(tx.commit()?)
 }
 
 /// Performs the update of workdir/stats/ref.count.

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -1352,6 +1352,19 @@ fn test_update_stats_topusers() {
         let mut guard = today_usercount_value.borrow_mut();
         assert_eq!(guard.seek(SeekFrom::Current(0)).unwrap() > 0, true);
     }
+
+    let conn = ctx.get_database_connection().unwrap();
+    let mut stmt = conn
+        .prepare("select date, count from stats_usercounts")
+        .unwrap();
+    let mut rows = stmt.query([]).unwrap();
+    while let Some(row) = rows.next().unwrap() {
+        let date: String = row.get(0).unwrap();
+        assert_eq!(date, "2020-05-10");
+        let count: String = row.get(1).unwrap();
+        let count: i64 = count.parse().unwrap();
+        assert_eq!(count, 2);
+    }
 }
 
 /// Tests update_stats_topusers(): the case then the .csv is missing.

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -114,7 +114,17 @@ pub fn init(conn: &rusqlite::Connection) -> anyhow::Result<()> {
             [],
         )?;
     }
-    conn.execute("pragma user_version = 4", [])?;
+    if user_version < 5 {
+        // Tracks the number of OSM house number editors over time.
+        conn.execute(
+            "create table stats_usercounts (
+            date text primary key not null,
+            count text not null
+        )",
+            [],
+        )?;
+    }
+    conn.execute("pragma user_version = 5", [])?;
     Ok(())
 }
 


### PR DESCRIPTION
Similar to commit 40a8ac313a161a747467a0558eff137caa839ab0 (cron, stats:
start tracking workdir/stats/<date>.count files in sql as well,
2023-06-26).

Change-Id: I81caf3059872bfdd8ac5bb587bfedbe37f8b7775
