### PR TITLE
cron: no need to clean up old CSV files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "eslint": "8.43.0",
     "sorttable": "1.0.2",
     "ts-loader": "9.4.4",
-    "typescript": "5.1.6",
+    "typescript": "5.0.4",
     "webpack": "5.88.1",
     "webpack-cli": "5.1.4"
   },

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -495,21 +495,6 @@ fn update_stats(ctx: &context::Context, overpass: bool) -> anyhow::Result<()> {
     update_stats_refcount(ctx, &statedir)?;
     stats::update_invalid_addr_cities(ctx, &statedir)?;
 
-    // Old style: workdir/stats/<date>.csv files.
-    // Remove old CSV files as they are created daily and each is around 11M.
-    for file_name in ctx.get_file_system().listdir(&statedir)? {
-        if !file_name.ends_with("csv") {
-            continue;
-        }
-
-        let last_modified = ctx.get_time().now() - ctx.get_file_system().getmtime(&file_name)?;
-
-        if last_modified.whole_seconds() >= 24_i64 * 3600_i64 * 7_i64 {
-            ctx.get_file_system().unlink(&file_name)?;
-            info!("update_stats: removed old {file_name}");
-        }
-    }
-
     info!("update_stats: generating json");
     let json_path = format!("{}/stats.json", &statedir);
     stats::generate_json(ctx, &statedir, &json_path).context("generate_json() failed")?;

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -727,8 +727,6 @@ fn test_update_stats() {
     let ref_count = context::tests::TestFileSystem::make_file();
     let stats_json = context::tests::TestFileSystem::make_file();
     let overpass_template = context::tests::TestFileSystem::make_file();
-    let old_csv = context::tests::TestFileSystem::make_file();
-    let old_path = "workdir/stats/old.csv";
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
         &[
@@ -744,20 +742,10 @@ fn test_update_stats() {
                 "data/street-housenumbers-hungary.overpassql",
                 &overpass_template,
             ),
-            (old_path, &old_csv),
         ],
     );
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
-    let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
-    let path = ctx.get_abspath("workdir/stats/whole-country.csv");
-    mtimes.insert(path, Rc::new(RefCell::new(ctx.get_time().now())));
-    let path = ctx.get_abspath("workdir/stats/old.csv");
-    mtimes.insert(
-        path,
-        Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
-    );
-    file_system.set_mtimes(&mtimes);
     let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
     ctx.set_file_system(&file_system_rc);
 
@@ -770,13 +758,6 @@ fn test_update_stats() {
         actual,
         String::from_utf8(std::fs::read("src/fixtures/network/overpass-stats.csv").unwrap())
             .unwrap()
-    );
-
-    // Make sure that the old CSV is removed.
-    assert_eq!(
-        ctx.get_file_system()
-            .path_exists(&ctx.get_abspath(old_path)),
-        false
     );
 
     let num_ref: i64 = ctx


### PR DESCRIPTION
There is only workdir/stats/whole-country.csv by now, but that's updated
daily, so it won't be ever removed.

Change-Id: I1a721da289385ac15e18037441e89c984d15f1a0
