### PR TITLE
cron: enable inactive relations which are invalid

### DIFF
--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -5,10 +5,11 @@
 - Rouille: new `--host` parameter to specify the bind address
 - The `/missing-housenumbers/.../update-result` is now about 6 times faster (replaced home-grown
   JSON cache with SQL indexes)
-- New `/housenumber-stats/.../invalid-addr-cities` endpoint, tries to find invalid addr:city values
+- New `/lints/.../invalid-addr-cities` endpoint, tries to find invalid addr:city values
 - Resolves: gh#2986 stats: the length of the invalid addr:city values list now has a chart
 - Resolves: gh#2987 stats: extract 2 lints from the stats page to an own lints page
 - Resolves: gh#2994 areas: find ref-not-in-reflist problems in `Relation.get_invalid_refstreets()`
+- Resolves: gh#2988 cron: enable inactive relations which are invalid
 
 ## 7.5
 

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -577,6 +577,7 @@ pub fn our_main(
     let first_day_of_month = now.date().day() == 1;
     relations.activate_all(ctx.get_ini().get_cron_update_inactive() || first_day_of_month);
     relations.activate_new();
+    relations.activate_invalid();
     let refcounty: Option<&String> = args.get_one("refcounty");
     relations.limit_to_refcounty(&refcounty)?;
     // Use map(), which handles optional values.


### PR DESCRIPTION
The idea is that in case /lints/whole-country/invalid-relations points
out a problem, then check for a fix for that problem daily, so the fixed
relation disappears on the next day (even for inactive relations), not
only at the start of the next month.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/2988>.

Change-Id: I3095b5a9e0dc9033ab04efc66018ba1fd8774ea0
