### PR TITLE
additional streets: add gpx output

### DIFF
--- a/po/hu/osm-gimmisn.po
+++ b/po/hu/osm-gimmisn.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: osm-gimmisn\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-29 13:15+0000\n"
-"PO-Revision-Date: 2023-06-29 15:15+0200\n"
+"POT-Creation-Date: 2023-07-21 21:16+0000\n"
+"PO-Revision-Date: 2023-07-21 23:16+0200\n"
 "Last-Translator: Miklos Vajna <osm-gimmisn@vmiklos.hu>\n"
 "Language-Team: Hungarian\n"
 "Language: hu\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "street"
 msgstr "utca"
 
-#: src/areas.rs:915 src/wsgi.rs:348 src/wsgi_additional.rs:94
+#: src/areas.rs:915 src/wsgi.rs:348 src/wsgi_additional.rs:175
 msgid "Street name"
 msgstr "Utcanév"
 
@@ -232,11 +232,11 @@ msgstr ""
 "Csak olyan irányítószámok szerepelnek benne, amiknek van az OSM-ben "
 "házszámuk."
 
-#: src/webframe.rs:748 src/wsgi_additional.rs:91
+#: src/webframe.rs:748 src/wsgi_additional.rs:172
 msgid "Identifier"
 msgstr "Azonosító"
 
-#: src/webframe.rs:749 src/wsgi_additional.rs:92
+#: src/webframe.rs:749 src/wsgi_additional.rs:173
 msgid "Type"
 msgstr "Típus"
 
@@ -511,26 +511,26 @@ msgstr ""
 msgid " (existing: {0}, ready: {1})."
 msgstr " (meglévő: {0}, készültség: {1})."
 
-#: src/wsgi.rs:228 src/wsgi_additional.rs:239
+#: src/wsgi.rs:228 src/wsgi_additional.rs:331
 msgid ""
 "https://vmiklos.hu/osm-gimmisn/usage.html#filtering-out-incorrect-information"
 msgstr ""
 "https://wiki.openstreetmap.org/wiki/Hungary/osm-gimmisn#T%C3%A9ves_inform"
 "%C3%A1ci%C3%B3_kisz%C5%B1r%C3%A9se"
 
-#: src/wsgi.rs:231 src/wsgi_additional.rs:243
+#: src/wsgi.rs:231 src/wsgi_additional.rs:335
 msgid "Filter incorrect information"
 msgstr "Téves információ szűrése"
 
-#: src/wsgi.rs:243 src/wsgi_additional.rs:153
+#: src/wsgi.rs:243 src/wsgi_additional.rs:245
 msgid "Overpass turbo query for the below streets"
 msgstr "Overpass lekérdezés a lenti utcákra"
 
-#: src/wsgi.rs:254 src/wsgi.rs:386 src/wsgi_additional.rs:131
+#: src/wsgi.rs:254 src/wsgi.rs:386 src/wsgi_additional.rs:212
 msgid "Plain text format"
 msgstr "Egyszerű szöveg formátum"
 
-#: src/wsgi.rs:265 src/wsgi.rs:397 src/wsgi_additional.rs:142
+#: src/wsgi.rs:265 src/wsgi.rs:397 src/wsgi_additional.rs:223
 msgid "Checklist format"
 msgstr "Csekklista formátum"
 
@@ -542,7 +542,7 @@ msgstr "Elképzelhető, hogy az OpenStreetMap nem tartalmazza a lenti {0} utcát
 msgid "Overpass turbo query for streets with questionable names"
 msgstr "Overpass lekérdezés a kérdéses nevű utcákra"
 
-#: src/wsgi.rs:425 src/wsgi.rs:494 src/wsgi.rs:564 src/wsgi_additional.rs:40
+#: src/wsgi.rs:425 src/wsgi.rs:494 src/wsgi.rs:564 src/wsgi_additional.rs:121
 msgid "No existing streets"
 msgstr "Nincsenek meglévő utcák"
 
@@ -550,7 +550,7 @@ msgstr "Nincsenek meglévő utcák"
 msgid "No reference house numbers"
 msgstr "Nincsenek referencia házszámok"
 
-#: src/wsgi.rs:569 src/wsgi_additional.rs:45
+#: src/wsgi.rs:569 src/wsgi_additional.rs:126
 msgid "No reference streets"
 msgstr "Nincsenek referencia utcák"
 
@@ -652,15 +652,19 @@ msgstr "meglévő házszámok"
 msgid "existing streets"
 msgstr "meglévő utcák"
 
-#: src/wsgi_additional.rs:93
+#: src/wsgi_additional.rs:174
 msgid "Source"
 msgstr "Forrás"
 
-#: src/wsgi_additional.rs:119
+#: src/wsgi_additional.rs:200
 msgid "OpenStreetMap additionally has the below {0} streets."
 msgstr "Az OpenStreetMap tartalmazza a lenti {0} további utcát."
 
-#: src/wsgi_additional.rs:229
+#: src/wsgi_additional.rs:234
+msgid "GPX format"
+msgstr "GPX formátum"
+
+#: src/wsgi_additional.rs:321
 msgid ""
 "OpenStreetMap additionally has the below {0} house numbers for {1} streets."
 msgstr ""

--- a/po/osm-gimmisn.pot
+++ b/po/osm-gimmisn.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-29 13:15+0000\n"
+"POT-Creation-Date: 2023-07-21 21:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 msgid "street"
 msgstr ""
 
-#: src/areas.rs:915 src/wsgi.rs:348 src/wsgi_additional.rs:94
+#: src/areas.rs:915 src/wsgi.rs:348 src/wsgi_additional.rs:175
 msgid "Street name"
 msgstr ""
 
@@ -207,11 +207,11 @@ msgid "These statistics are estimates, not taking house number filters into acco
 "Only zip codes with house numbers in OSM are considered."
 msgstr ""
 
-#: src/webframe.rs:748 src/wsgi_additional.rs:91
+#: src/webframe.rs:748 src/wsgi_additional.rs:172
 msgid "Identifier"
 msgstr ""
 
-#: src/webframe.rs:749 src/wsgi_additional.rs:92
+#: src/webframe.rs:749 src/wsgi_additional.rs:173
 msgid "Type"
 msgstr ""
 
@@ -470,23 +470,23 @@ msgstr ""
 msgid " (existing: {0}, ready: {1})."
 msgstr ""
 
-#: src/wsgi.rs:228 src/wsgi_additional.rs:239
+#: src/wsgi.rs:228 src/wsgi_additional.rs:331
 msgid "https://vmiklos.hu/osm-gimmisn/usage.html#filtering-out-incorrect-information"
 msgstr ""
 
-#: src/wsgi.rs:231 src/wsgi_additional.rs:243
+#: src/wsgi.rs:231 src/wsgi_additional.rs:335
 msgid "Filter incorrect information"
 msgstr ""
 
-#: src/wsgi.rs:243 src/wsgi_additional.rs:153
+#: src/wsgi.rs:243 src/wsgi_additional.rs:245
 msgid "Overpass turbo query for the below streets"
 msgstr ""
 
-#: src/wsgi.rs:254 src/wsgi.rs:386 src/wsgi_additional.rs:131
+#: src/wsgi.rs:254 src/wsgi.rs:386 src/wsgi_additional.rs:212
 msgid "Plain text format"
 msgstr ""
 
-#: src/wsgi.rs:265 src/wsgi.rs:397 src/wsgi_additional.rs:142
+#: src/wsgi.rs:265 src/wsgi.rs:397 src/wsgi_additional.rs:223
 msgid "Checklist format"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Overpass turbo query for streets with questionable names"
 msgstr ""
 
-#: src/wsgi.rs:425 src/wsgi.rs:494 src/wsgi.rs:564 src/wsgi_additional.rs:40
+#: src/wsgi.rs:425 src/wsgi.rs:494 src/wsgi.rs:564 src/wsgi_additional.rs:121
 msgid "No existing streets"
 msgstr ""
 
@@ -506,7 +506,7 @@ msgstr ""
 msgid "No reference house numbers"
 msgstr ""
 
-#: src/wsgi.rs:569 src/wsgi_additional.rs:45
+#: src/wsgi.rs:569 src/wsgi_additional.rs:126
 msgid "No reference streets"
 msgstr ""
 
@@ -606,14 +606,18 @@ msgstr ""
 msgid "existing streets"
 msgstr ""
 
-#: src/wsgi_additional.rs:93
+#: src/wsgi_additional.rs:174
 msgid "Source"
 msgstr ""
 
-#: src/wsgi_additional.rs:119
+#: src/wsgi_additional.rs:200
 msgid "OpenStreetMap additionally has the below {0} streets."
 msgstr ""
 
-#: src/wsgi_additional.rs:229
+#: src/wsgi_additional.rs:234
+msgid "GPX format"
+msgstr ""
+
+#: src/wsgi_additional.rs:321
 msgid "OpenStreetMap additionally has the below {0} house numbers for {1} streets."
 msgstr ""

--- a/src/fixtures/network/overpass-additional-streets.json
+++ b/src/fixtures/network/overpass-additional-streets.json
@@ -1,0 +1,25 @@
+{
+  "version": 0.6,
+  "generator": "Overpass API 0.7.61.2 bd0cdeae",
+  "osm3s": {
+    "timestamp_osm_base": "2023-07-21T19:52:15Z",
+    "timestamp_areas_base": "2023-07-21T17:35:15Z",
+    "copyright": "The data included in this document is from www.openstreetmap.org. The data is made available under ODbL."
+  },
+  "elements": [
+
+{
+  "type": "way",
+  "id": 1,
+  "nodes": [
+    2
+  ]
+},
+{
+  "type": "node",
+  "id": 2,
+  "lat": 47.0292178,
+  "lon": 18.1391030
+}
+  ]
+}

--- a/src/fixtures/network/overpass-additional-streets.overpassql
+++ b/src/fixtures/network/overpass-additional-streets.overpassql
@@ -1,0 +1,8 @@
+[out:json][timeout:425];
+rel(42)->.searchRelation;
+area(3600000042)->.searchArea;
+(node(1);
+);
+out body;
+>;
+out skel qt;

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -27,6 +27,7 @@ pub struct TestWsgi {
     bytes: Vec<u8>,
     absolute_path: bool,
     expected_status: u16,
+    content_type: String,
 }
 
 impl TestWsgi {
@@ -37,6 +38,7 @@ impl TestWsgi {
         let bytes: Vec<u8> = Vec::new();
         let absolute_path = false;
         let expected_status = 200_u16;
+        let content_type = "text/html; charset=utf-8".into();
         TestWsgi {
             gzip_compress,
             ctx,
@@ -44,6 +46,7 @@ impl TestWsgi {
             bytes,
             absolute_path,
             expected_status,
+            content_type,
         }
     }
 
@@ -60,6 +63,10 @@ impl TestWsgi {
             ret = nodeset.iter().map(|i| i.string_value()).collect();
         };
         ret
+    }
+
+    pub fn set_content_type(&mut self, content_type: &str) {
+        self.content_type = content_type.to_string();
     }
 
     /// Generates an XML DOM for a given wsgi path.
@@ -85,7 +92,7 @@ impl TestWsgi {
         for (key, value) in response.headers {
             headers_map.insert(key, value);
         }
-        assert_eq!(headers_map["Content-type"], "text/html; charset=utf-8");
+        assert_eq!(headers_map["Content-type"], self.content_type);
         assert_eq!(data.is_empty(), false);
         let mut output: Vec<u8> = Vec::new();
         if self.gzip_compress {


### PR DESCRIPTION
The core of this is the new additional_streets_view_gpx() function:

- run the query we originally just produced and the user had to
  copy&paste into overpass-turbo

- for each street:

  - look up the way in the overpass result

  - look up the first node in that way

This allows generating some simple GPX result ourself, without reaching
out to the external overpass-turbo.

This is meant to be much more easier on mobile than the old way.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/3018>.

Change-Id: I4e861216e35dfbb5f255d9d007fe2a4f302b6a56
