### PR TITLE
gpx: improve mime type

### DIFF
--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1450,7 +1450,7 @@ fn our_application_gpx(
     relations: &mut areas::Relations<'_>,
     request_uri: &str,
 ) -> anyhow::Result<rouille::Response> {
-    let content_type = "text/xml; charset=utf-8";
+    let content_type = "text/gpx+xml; charset=utf-8";
     let mut headers: webframe::Headers = Vec::new();
     // assume prefix + "/additional-streets/"
     let (output, relation_name) =

--- a/src/wsgi_additional/tests.rs
+++ b/src/wsgi_additional/tests.rs
@@ -80,7 +80,7 @@ fn test_streets_view_result_gpx() {
     let network = context::tests::TestNetwork::new(&routes);
     let network_rc: Rc<dyn context::Network> = Rc::new(network);
     test_wsgi.get_ctx().set_network(network_rc);
-    test_wsgi.set_content_type("text/xml; charset=utf-8");
+    test_wsgi.set_content_type("text/gpx+xml; charset=utf-8");
 
     let _root = test_wsgi.get_dom_for_path("/additional-streets/gazdagret/view-result.gpx");
 


### PR DESCRIPTION
text/xml is fine, but this way Android doesn't rename .gpx to .gpx.xml
on download.

Change-Id: I6b93058b2b4687bae8c6c53468fcb2463a62168f
