### PR TITLE
validator: catch useless filter key with null value

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -48,6 +48,18 @@ pub struct RelationFiltersDict {
     show_refstreet: Option<bool>,
 }
 
+impl RelationFiltersDict {
+    /// Determines if at least one Option is Some.
+    pub fn is_some(&self) -> bool {
+        self.interpolation.is_some()
+            || self.invalid.is_some()
+            || self.ranges.is_some()
+            || self.valid.is_some()
+            || self.refsettlement.is_some()
+            || self.show_refstreet.is_some()
+    }
+}
+
 /// A relation from data/relation-<name>.yaml.
 #[derive(Clone, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -135,6 +135,12 @@ fn validate_filters(
 ) -> anyhow::Result<()> {
     let context = format!("{parent}.");
     for (key, value) in filters {
+        if !value.is_some() {
+            errors.push(format!(
+                "expected at least one sub-key for '{context}{key}'"
+            ));
+        }
+
         validate_filter(errors, &format!("{context}{key}"), value)?;
     }
 

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -477,3 +477,14 @@ fn test_end_whitespace() {
     let expected = "expected value type for 'filters.Budaörsi út.ranges[0].end' is a digit str\nfailed to validate {0}\n";
     assert_failure_msg(content, expected);
 }
+
+/// Tests that we do not accept keys with null values.
+#[test]
+fn test_null_value() {
+    let content = r#"filters:
+  'Budaörsi út':
+"#;
+    let expected =
+        "expected at least one sub-key for 'filters.Budaörsi út'\nfailed to validate {0}\n";
+    assert_failure_msg(content, expected);
+}


### PR DESCRIPTION
serde_yaml doesn't catch this, but serde_json will complain about this
later, so just reject this.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/3174>.

Change-Id: I9ede5f8c7279d69d5da5b3591e986fbcd055ff15
