### PR TITLE
areas: find unused 'invalid' list items

### DIFF
--- a/src/missing_housenumbers/tests.rs
+++ b/src/missing_housenumbers/tests.rs
@@ -29,8 +29,8 @@ fn test_main() {
     let mut actual: Vec<u8> = Vec::new();
     buf.read_to_end(&mut actual).unwrap();
     assert_eq!(
-        actual,
-        b"Kalotaszeg utca\t3\n[\"25\", \"27-37\", \"31*\"]\n"
+        String::from_utf8(actual).unwrap(),
+        "Kalotaszeg utca\t3\n[\"25\", \"27-37\", \"31*\"]\n"
     );
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -261,8 +261,13 @@ impl HouseNumber {
     }
 
     /// Decides if house_number is invalid according to invalids.
-    pub fn is_invalid(house_number: &str, invalids: &[String]) -> bool {
+    pub fn is_invalid(
+        house_number: &str,
+        invalids: &[String],
+        used_invalids: &mut Vec<String>,
+    ) -> bool {
         if invalids.contains(&house_number.to_string()) {
+            used_invalids.push(house_number.to_string());
             return true;
         }
 
@@ -285,7 +290,11 @@ impl HouseNumber {
         }
 
         let house_number = number + &suffix;
-        invalids.contains(&house_number)
+        let ret = invalids.contains(&house_number);
+        if ret {
+            used_invalids.push(house_number);
+        }
+        ret
     }
 
     /// Determines if the input is a house number, allowing letter suffixes. This means not only

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -397,16 +397,29 @@ fn test_house_number() {
 /// Tests HouseNumber::is_invalid().
 #[test]
 fn test_house_number_is_invalid() {
-    assert_eq!(HouseNumber::is_invalid("15 a", &["15a".to_string()]), true);
-    assert_eq!(HouseNumber::is_invalid("15/a", &["15a".to_string()]), true);
-    assert_eq!(HouseNumber::is_invalid("15A", &["15a".to_string()]), true);
+    let mut used_invalids: Vec<String> = Vec::new();
     assert_eq!(
-        HouseNumber::is_invalid("67/5*", &["67/5".to_string()]),
+        HouseNumber::is_invalid("15 a", &["15a".to_string()], &mut used_invalids),
+        true
+    );
+    assert_eq!(
+        HouseNumber::is_invalid("15/a", &["15a".to_string()], &mut used_invalids),
+        true
+    );
+    assert_eq!(
+        HouseNumber::is_invalid("15A", &["15a".to_string()], &mut used_invalids),
+        true
+    );
+    assert_eq!(
+        HouseNumber::is_invalid("67/5*", &["67/5".to_string()], &mut used_invalids),
         true
     );
 
     // Make sure we don't panic on input which does not start with a number.
-    assert_eq!(HouseNumber::is_invalid("A", &["15a".to_string()]), false);
+    assert_eq!(
+        HouseNumber::is_invalid("A", &["15a".to_string()], &mut used_invalids),
+        false
+    );
 }
 
 /// Tests HouseNumber::has_letter_suffix().


### PR DESCRIPTION
This can happen two ways:

- trying to filter out from reference: but it's no longer in the ref

- trying to silence some missing OSM object: but the OSM object is there

This is just the lint collection, still need to record the result
somewhere and present it on the web UI.

Change-Id: Ifacf03ff6569be8262a41dcd6060ef3bf683f8e3
