### PR TITLE
areas: write lint results to sql

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1237,6 +1237,21 @@ impl<'a> Relation<'a> {
         Ok(())
     }
 
+    pub fn write_lints(&self) -> anyhow::Result<()> {
+        let conn = self.ctx.get_database_connection()?;
+        conn.execute(
+            "delete from relation_lints where relation_name = ?1",
+            [&self.name],
+        )?;
+        for lint in self.lints.iter() {
+            conn.execute(
+                r#"insert into relation_lints (relation_name, street_name, source, housenumber, reason) values (?1, ?2, ?3, ?4, ?5)"#,
+                 [&lint.relation_name, &lint.street_name, &lint.source, &lint.housenumber, &lint.reason],
+                 )?;
+        }
+        Ok(())
+    }
+
     pub fn get_osm_housenumber_coverage(&self) -> anyhow::Result<String> {
         let conn = self.ctx.get_database_connection()?;
         let mut stmt = conn

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -69,6 +69,9 @@ pub fn get_missing_housenumbers_json(relation: &mut areas::Relation<'_>) -> anyh
         .get_ctx()
         .get_file_system()
         .write_from_string(&output, &jsoncache_path)?;
+
+    relation.write_lints()?;
+
     Ok(output)
 }
 

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -124,7 +124,21 @@ pub fn init(conn: &rusqlite::Connection) -> anyhow::Result<()> {
             [],
         )?;
     }
-    conn.execute("pragma user_version = 5", [])?;
+    if user_version < 6 {
+        // Tracks lint results for a relation.
+        conn.execute(
+            "create table relation_lints (
+            id integer primary key autoincrement,
+            relation_name text not null,
+            street_name text not null,
+            source text not null,
+            housenumber text not null,
+            reason text not null
+        )",
+            [],
+        )?;
+    }
+    conn.execute("pragma user_version = 6", [])?;
     Ok(())
 }
 


### PR DESCRIPTION
Do this when the missing-housenumbers cache is not hit, so a cached case
won't empty previously found lints.

The web interface still has to show this somewhere.

Change-Id: I334fac79827f929a84214fedb90a6f633c5645ec
