### PR TITLE
relation lints: implement l10n for source

### DIFF
--- a/po/hu/osm-gimmisn.po
+++ b/po/hu/osm-gimmisn.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: osm-gimmisn\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-25 21:05+0000\n"
-"PO-Revision-Date: 2023-08-25 23:07+0200\n"
+"POT-Creation-Date: 2023-08-26 12:28+0000\n"
+"PO-Revision-Date: 2023-08-26 14:29+0200\n"
 "Last-Translator: Miklos Vajna <osm-gimmisn@vmiklos.hu>\n"
 "Language-Team: Hungarian\n"
 "Language: hu\n"
@@ -17,19 +17,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/areas.rs:502
+#: src/areas.rs:533
 msgid "street"
 msgstr "utca"
 
-#: src/areas.rs:996 src/wsgi.rs:408 src/wsgi_additional.rs:175
+#: src/areas.rs:1027 src/wsgi.rs:411 src/wsgi_additional.rs:175
 msgid "Street name"
 msgstr "Utcanév"
 
-#: src/areas.rs:997
+#: src/areas.rs:1028
 msgid "Missing count"
 msgstr "Hiányzik db"
 
-#: src/areas.rs:998
+#: src/areas.rs:1029
 msgid "House numbers"
 msgstr "Házszámok"
 
@@ -112,7 +112,7 @@ msgstr "Lekérdezés megtekintése"
 msgid "Missing house numbers"
 msgstr "Hiányzó házszámok"
 
-#: src/webframe.rs:237 src/wsgi.rs:1395
+#: src/webframe.rs:237 src/wsgi.rs:1398
 msgid "Additional house numbers"
 msgstr "További házszámok"
 
@@ -120,7 +120,7 @@ msgstr "További házszámok"
 msgid "Missing streets"
 msgstr "Hiányzó utcák"
 
-#: src/webframe.rs:264 src/wsgi.rs:1397
+#: src/webframe.rs:264 src/wsgi.rs:1400
 msgid "Additional streets"
 msgstr "További utcák"
 
@@ -136,12 +136,12 @@ msgstr "Meglévő utcák"
 msgid "Area list"
 msgstr "Területek listája"
 
-#: src/webframe.rs:367 src/wsgi.rs:1292
+#: src/webframe.rs:367 src/wsgi.rs:1295
 msgid "Waiting for Overpass..."
 msgstr "Overpass: várakozás..."
 
 #: src/webframe.rs:368 src/webframe.rs:1207 src/webframe.rs:1228
-#: src/wsgi.rs:1293
+#: src/wsgi.rs:1296
 msgid "Error from Overpass: "
 msgstr "Overpass hiba: "
 
@@ -157,7 +157,7 @@ msgstr "Hiba a referenciától: "
 msgid "Overpass turbo"
 msgstr "Overpass turbo"
 
-#: src/webframe.rs:393 src/wsgi.rs:1398
+#: src/webframe.rs:393 src/wsgi.rs:1401
 msgid "Area boundary"
 msgstr "Terület határa"
 
@@ -193,7 +193,7 @@ msgstr "A kért URL nem található ezen a kiszolgálón."
 msgid "City name"
 msgstr "Város neve"
 
-#: src/webframe.rs:593 src/webframe.rs:683 src/wsgi.rs:1394
+#: src/webframe.rs:593 src/webframe.rs:683 src/wsgi.rs:1397
 msgid "House number coverage"
 msgstr "Házszám lefedettség"
 
@@ -483,19 +483,19 @@ msgstr "Nincsenek referencia utcák: létrehozás referenciából..."
 msgid "No reference streets: creating from reference..."
 msgstr "Nincsenek referencia utcák: létrehozás referenciából..."
 
-#: src/wsgi.rs:72 src/wsgi.rs:141 src/wsgi.rs:656
+#: src/wsgi.rs:72 src/wsgi.rs:141 src/wsgi.rs:659
 msgid "Update successful: "
 msgstr "Frissítés sikeres: "
 
-#: src/wsgi.rs:76 src/wsgi.rs:144 src/wsgi.rs:659
+#: src/wsgi.rs:76 src/wsgi.rs:144 src/wsgi.rs:662
 msgid "View missing house numbers"
 msgstr "Hiányzó házszámok megtekintése"
 
-#: src/wsgi.rs:79 src/wsgi.rs:673
+#: src/wsgi.rs:79 src/wsgi.rs:676
 msgid "Update successful."
 msgstr "Frissítés sikeres."
 
-#: src/wsgi.rs:158 src/wsgi.rs:492 src/wsgi.rs:559
+#: src/wsgi.rs:158 src/wsgi.rs:495 src/wsgi.rs:562
 msgid "No existing house numbers"
 msgstr "Nincsenek meglévő házszámok"
 
@@ -507,13 +507,16 @@ msgstr "Forrás"
 msgid "Reason"
 msgstr "Ok"
 
-#: src/wsgi.rs:237
+#: src/wsgi.rs:225
+msgid "invalid housenumbers"
+msgstr "érvénytelen házszámok"
+
+#: src/wsgi.rs:240
 msgid ""
 "The below {0} filters for this relation are probably no longer necessary."
-msgstr ""
-"Az alábbi {0} szűrő ehhez a relációhoz valószínűleg már nem szükséges."
+msgstr "Az alábbi {0} szűrő ehhez a relációhoz valószínűleg már nem szükséges."
 
-#: src/wsgi.rs:261
+#: src/wsgi.rs:264
 msgid ""
 "OpenStreetMap is possibly missing the below {0} house numbers for {1} "
 "streets."
@@ -521,152 +524,152 @@ msgstr ""
 "Elképzelhető, hogy az OpenStreetMap nem tartalmazza a lenti {1} utcához "
 "tartozó {0} házszámot."
 
-#: src/wsgi.rs:267 src/wsgi.rs:420
+#: src/wsgi.rs:270 src/wsgi.rs:423
 msgid " (existing: {0}, ready: {1})."
 msgstr " (meglévő: {0}, készültség: {1})."
 
-#: src/wsgi.rs:277 src/wsgi_additional.rs:331
+#: src/wsgi.rs:280 src/wsgi_additional.rs:331
 msgid ""
 "https://vmiklos.hu/osm-gimmisn/usage.html#filtering-out-incorrect-information"
 msgstr ""
 "https://wiki.openstreetmap.org/wiki/Hungary/osm-gimmisn#T%C3%A9ves_inform"
 "%C3%A1ci%C3%B3_kisz%C5%B1r%C3%A9se"
 
-#: src/wsgi.rs:280 src/wsgi_additional.rs:335
+#: src/wsgi.rs:283 src/wsgi_additional.rs:335
 msgid "Filter incorrect information"
 msgstr "Téves információ szűrése"
 
-#: src/wsgi.rs:292 src/wsgi_additional.rs:245
+#: src/wsgi.rs:295 src/wsgi_additional.rs:245
 msgid "Overpass turbo query for the below streets"
 msgstr "Overpass lekérdezés a lenti utcákra"
 
-#: src/wsgi.rs:303 src/wsgi.rs:446 src/wsgi_additional.rs:212
+#: src/wsgi.rs:306 src/wsgi.rs:449 src/wsgi_additional.rs:212
 msgid "Plain text format"
 msgstr "Egyszerű szöveg formátum"
 
-#: src/wsgi.rs:314 src/wsgi.rs:457 src/wsgi_additional.rs:223
+#: src/wsgi.rs:317 src/wsgi.rs:460 src/wsgi_additional.rs:223
 msgid "Checklist format"
 msgstr "Csekklista formátum"
 
-#: src/wsgi.rs:325
+#: src/wsgi.rs:328
 msgid "View lints"
 msgstr "Ellenőrzések megtekintése"
 
-#: src/wsgi.rs:416
+#: src/wsgi.rs:419
 msgid "OpenStreetMap is possibly missing the below {0} streets."
 msgstr "Elképzelhető, hogy az OpenStreetMap nem tartalmazza a lenti {0} utcát."
 
-#: src/wsgi.rs:434
+#: src/wsgi.rs:437
 msgid "Overpass turbo query for streets with questionable names"
 msgstr "Overpass lekérdezés a kérdéses nevű utcákra"
 
-#: src/wsgi.rs:485 src/wsgi.rs:554 src/wsgi.rs:624 src/wsgi_additional.rs:121
+#: src/wsgi.rs:488 src/wsgi.rs:557 src/wsgi.rs:627 src/wsgi_additional.rs:121
 msgid "No existing streets"
 msgstr "Nincsenek meglévő utcák"
 
-#: src/wsgi.rs:499 src/wsgi.rs:564
+#: src/wsgi.rs:502 src/wsgi.rs:567
 msgid "No reference house numbers"
 msgstr "Nincsenek referencia házszámok"
 
-#: src/wsgi.rs:629 src/wsgi_additional.rs:126
+#: src/wsgi.rs:632 src/wsgi_additional.rs:126
 msgid "No reference streets"
 msgstr "Nincsenek referencia utcák"
 
-#: src/wsgi.rs:940 src/wsgi.rs:980 src/wsgi.rs:1021 src/wsgi.rs:1079
+#: src/wsgi.rs:943 src/wsgi.rs:983 src/wsgi.rs:1024 src/wsgi.rs:1082
 msgid "updated"
 msgstr "frissítve"
 
-#: src/wsgi.rs:951
+#: src/wsgi.rs:954
 msgid "missing house numbers"
 msgstr "hiányzó házszámok"
 
-#: src/wsgi.rs:991 src/wsgi.rs:1438
+#: src/wsgi.rs:994 src/wsgi.rs:1441
 msgid "missing streets"
 msgstr "hiányzó utcák"
 
-#: src/wsgi.rs:1024
+#: src/wsgi.rs:1027
 msgid "{} streets"
 msgstr "{} utca"
 
-#: src/wsgi.rs:1030
+#: src/wsgi.rs:1033
 msgid "additional streets"
 msgstr "további utcák"
 
-#: src/wsgi.rs:1082
+#: src/wsgi.rs:1085
 msgid "{} house numbers"
 msgstr "{} házszám"
 
-#: src/wsgi.rs:1088
+#: src/wsgi.rs:1091
 msgid "additional house numbers"
 msgstr "további házszámok"
 
-#: src/wsgi.rs:1245
+#: src/wsgi.rs:1248
 msgid "Based on position"
 msgstr "Pozíció alapján"
 
-#: src/wsgi.rs:1253
+#: src/wsgi.rs:1256
 msgid "Show complete areas"
 msgstr "Kész területek mutatása"
 
-#: src/wsgi.rs:1276 src/wsgi.rs:1459
+#: src/wsgi.rs:1279 src/wsgi.rs:1462
 msgid "Where to map?"
 msgstr "Hol térképezzek?"
 
-#: src/wsgi.rs:1280
+#: src/wsgi.rs:1283
 msgid "Filters:"
 msgstr "Szűrők:"
 
-#: src/wsgi.rs:1290
+#: src/wsgi.rs:1293
 msgid "Waiting for GPS..."
 msgstr "GPS: várakozás..."
 
-#: src/wsgi.rs:1291
+#: src/wsgi.rs:1294
 msgid "Error from GPS: "
 msgstr "GPS hiba: "
 
-#: src/wsgi.rs:1294
+#: src/wsgi.rs:1297
 msgid "Waiting for relations..."
 msgstr "Területek: várakozás..."
 
-#: src/wsgi.rs:1295
+#: src/wsgi.rs:1298
 msgid "Error from relations: "
 msgstr "Hiba a relációktól: "
 
-#: src/wsgi.rs:1296
+#: src/wsgi.rs:1299
 msgid "Waiting for redirect..."
 msgstr "Átirányítás: várakozás..."
 
-#: src/wsgi.rs:1358
+#: src/wsgi.rs:1361
 msgid "area boundary"
 msgstr "terület határa"
 
-#: src/wsgi.rs:1393
+#: src/wsgi.rs:1396
 msgid "Area"
 msgstr "Terület"
 
-#: src/wsgi.rs:1396
+#: src/wsgi.rs:1399
 msgid "Street coverage"
 msgstr "Utca lefedettség"
 
-#: src/wsgi.rs:1414
+#: src/wsgi.rs:1417
 msgid "https://vmiklos.hu/osm-gimmisn/usage.html#how-to-add-a-new-area"
 msgstr ""
 "https://wiki.openstreetmap.org/wiki/Hungary/osm-gimmisn#%C3%9Aj_rel%C3%A1ci"
 "%C3%B3_hozz%C3%A1ad%C3%A1sa"
 
-#: src/wsgi.rs:1417
+#: src/wsgi.rs:1420
 msgid "Add new area"
 msgstr "Új terület hozzáadása"
 
-#: src/wsgi.rs:1436
+#: src/wsgi.rs:1439
 msgid "{0} missing house numbers"
 msgstr "{0} hiányzó házszámok"
 
-#: src/wsgi.rs:1439
+#: src/wsgi.rs:1442
 msgid "existing house numbers"
 msgstr "meglévő házszámok"
 
-#: src/wsgi.rs:1440
+#: src/wsgi.rs:1443
 msgid "existing streets"
 msgstr "meglévő utcák"
 

--- a/po/osm-gimmisn.pot
+++ b/po/osm-gimmisn.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-25 21:05+0000\n"
+"POT-Creation-Date: 2023-08-26 12:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,19 +17,19 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/areas.rs:502
+#: src/areas.rs:533
 msgid "street"
 msgstr ""
 
-#: src/areas.rs:996 src/wsgi.rs:408 src/wsgi_additional.rs:175
+#: src/areas.rs:1027 src/wsgi.rs:411 src/wsgi_additional.rs:175
 msgid "Street name"
 msgstr ""
 
-#: src/areas.rs:997
+#: src/areas.rs:1028
 msgid "Missing count"
 msgstr ""
 
-#: src/areas.rs:998
+#: src/areas.rs:1029
 msgid "House numbers"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Missing house numbers"
 msgstr ""
 
-#: src/webframe.rs:237 src/wsgi.rs:1395
+#: src/webframe.rs:237 src/wsgi.rs:1398
 msgid "Additional house numbers"
 msgstr ""
 
@@ -105,7 +105,7 @@ msgstr ""
 msgid "Missing streets"
 msgstr ""
 
-#: src/webframe.rs:264 src/wsgi.rs:1397
+#: src/webframe.rs:264 src/wsgi.rs:1400
 msgid "Additional streets"
 msgstr ""
 
@@ -121,11 +121,11 @@ msgstr ""
 msgid "Area list"
 msgstr ""
 
-#: src/webframe.rs:367 src/wsgi.rs:1292
+#: src/webframe.rs:367 src/wsgi.rs:1295
 msgid "Waiting for Overpass..."
 msgstr ""
 
-#: src/webframe.rs:368 src/webframe.rs:1207 src/webframe.rs:1228 src/wsgi.rs:1293
+#: src/webframe.rs:368 src/webframe.rs:1207 src/webframe.rs:1228 src/wsgi.rs:1296
 msgid "Error from Overpass: "
 msgstr ""
 
@@ -141,7 +141,7 @@ msgstr ""
 msgid "Overpass turbo"
 msgstr ""
 
-#: src/webframe.rs:393 src/wsgi.rs:1398
+#: src/webframe.rs:393 src/wsgi.rs:1401
 msgid "Area boundary"
 msgstr ""
 
@@ -177,7 +177,7 @@ msgstr ""
 msgid "City name"
 msgstr ""
 
-#: src/webframe.rs:593 src/webframe.rs:683 src/wsgi.rs:1394
+#: src/webframe.rs:593 src/webframe.rs:683 src/wsgi.rs:1397
 msgid "House number coverage"
 msgstr ""
 
@@ -446,19 +446,19 @@ msgstr ""
 msgid "No reference streets: creating from reference..."
 msgstr ""
 
-#: src/wsgi.rs:72 src/wsgi.rs:141 src/wsgi.rs:656
+#: src/wsgi.rs:72 src/wsgi.rs:141 src/wsgi.rs:659
 msgid "Update successful: "
 msgstr ""
 
-#: src/wsgi.rs:76 src/wsgi.rs:144 src/wsgi.rs:659
+#: src/wsgi.rs:76 src/wsgi.rs:144 src/wsgi.rs:662
 msgid "View missing house numbers"
 msgstr ""
 
-#: src/wsgi.rs:79 src/wsgi.rs:673
+#: src/wsgi.rs:79 src/wsgi.rs:676
 msgid "Update successful."
 msgstr ""
 
-#: src/wsgi.rs:158 src/wsgi.rs:492 src/wsgi.rs:559
+#: src/wsgi.rs:158 src/wsgi.rs:495 src/wsgi.rs:562
 msgid "No existing house numbers"
 msgstr ""
 
@@ -470,155 +470,159 @@ msgstr ""
 msgid "Reason"
 msgstr ""
 
-#: src/wsgi.rs:237
+#: src/wsgi.rs:225
+msgid "invalid housenumbers"
+msgstr ""
+
+#: src/wsgi.rs:240
 msgid "The below {0} filters for this relation are probably no longer necessary."
 msgstr ""
 
-#: src/wsgi.rs:261
+#: src/wsgi.rs:264
 msgid "OpenStreetMap is possibly missing the below {0} house numbers for {1} streets."
 msgstr ""
 
-#: src/wsgi.rs:267 src/wsgi.rs:420
+#: src/wsgi.rs:270 src/wsgi.rs:423
 msgid " (existing: {0}, ready: {1})."
 msgstr ""
 
-#: src/wsgi.rs:277 src/wsgi_additional.rs:331
+#: src/wsgi.rs:280 src/wsgi_additional.rs:331
 msgid "https://vmiklos.hu/osm-gimmisn/usage.html#filtering-out-incorrect-information"
 msgstr ""
 
-#: src/wsgi.rs:280 src/wsgi_additional.rs:335
+#: src/wsgi.rs:283 src/wsgi_additional.rs:335
 msgid "Filter incorrect information"
 msgstr ""
 
-#: src/wsgi.rs:292 src/wsgi_additional.rs:245
+#: src/wsgi.rs:295 src/wsgi_additional.rs:245
 msgid "Overpass turbo query for the below streets"
 msgstr ""
 
-#: src/wsgi.rs:303 src/wsgi.rs:446 src/wsgi_additional.rs:212
+#: src/wsgi.rs:306 src/wsgi.rs:449 src/wsgi_additional.rs:212
 msgid "Plain text format"
 msgstr ""
 
-#: src/wsgi.rs:314 src/wsgi.rs:457 src/wsgi_additional.rs:223
+#: src/wsgi.rs:317 src/wsgi.rs:460 src/wsgi_additional.rs:223
 msgid "Checklist format"
 msgstr ""
 
-#: src/wsgi.rs:325
+#: src/wsgi.rs:328
 msgid "View lints"
 msgstr ""
 
-#: src/wsgi.rs:416
+#: src/wsgi.rs:419
 msgid "OpenStreetMap is possibly missing the below {0} streets."
 msgstr ""
 
-#: src/wsgi.rs:434
+#: src/wsgi.rs:437
 msgid "Overpass turbo query for streets with questionable names"
 msgstr ""
 
-#: src/wsgi.rs:485 src/wsgi.rs:554 src/wsgi.rs:624 src/wsgi_additional.rs:121
+#: src/wsgi.rs:488 src/wsgi.rs:557 src/wsgi.rs:627 src/wsgi_additional.rs:121
 msgid "No existing streets"
 msgstr ""
 
-#: src/wsgi.rs:499 src/wsgi.rs:564
+#: src/wsgi.rs:502 src/wsgi.rs:567
 msgid "No reference house numbers"
 msgstr ""
 
-#: src/wsgi.rs:629 src/wsgi_additional.rs:126
+#: src/wsgi.rs:632 src/wsgi_additional.rs:126
 msgid "No reference streets"
 msgstr ""
 
-#: src/wsgi.rs:940 src/wsgi.rs:980 src/wsgi.rs:1021 src/wsgi.rs:1079
+#: src/wsgi.rs:943 src/wsgi.rs:983 src/wsgi.rs:1024 src/wsgi.rs:1082
 msgid "updated"
 msgstr ""
 
-#: src/wsgi.rs:951
+#: src/wsgi.rs:954
 msgid "missing house numbers"
 msgstr ""
 
-#: src/wsgi.rs:991 src/wsgi.rs:1438
+#: src/wsgi.rs:994 src/wsgi.rs:1441
 msgid "missing streets"
 msgstr ""
 
-#: src/wsgi.rs:1024
+#: src/wsgi.rs:1027
 msgid "{} streets"
 msgstr ""
 
-#: src/wsgi.rs:1030
+#: src/wsgi.rs:1033
 msgid "additional streets"
 msgstr ""
 
-#: src/wsgi.rs:1082
+#: src/wsgi.rs:1085
 msgid "{} house numbers"
 msgstr ""
 
-#: src/wsgi.rs:1088
+#: src/wsgi.rs:1091
 msgid "additional house numbers"
 msgstr ""
 
-#: src/wsgi.rs:1245
+#: src/wsgi.rs:1248
 msgid "Based on position"
 msgstr ""
 
-#: src/wsgi.rs:1253
+#: src/wsgi.rs:1256
 msgid "Show complete areas"
 msgstr ""
 
-#: src/wsgi.rs:1276 src/wsgi.rs:1459
+#: src/wsgi.rs:1279 src/wsgi.rs:1462
 msgid "Where to map?"
 msgstr ""
 
-#: src/wsgi.rs:1280
+#: src/wsgi.rs:1283
 msgid "Filters:"
 msgstr ""
 
-#: src/wsgi.rs:1290
+#: src/wsgi.rs:1293
 msgid "Waiting for GPS..."
 msgstr ""
 
-#: src/wsgi.rs:1291
+#: src/wsgi.rs:1294
 msgid "Error from GPS: "
 msgstr ""
 
-#: src/wsgi.rs:1294
+#: src/wsgi.rs:1297
 msgid "Waiting for relations..."
 msgstr ""
 
-#: src/wsgi.rs:1295
+#: src/wsgi.rs:1298
 msgid "Error from relations: "
 msgstr ""
 
-#: src/wsgi.rs:1296
+#: src/wsgi.rs:1299
 msgid "Waiting for redirect..."
 msgstr ""
 
-#: src/wsgi.rs:1358
+#: src/wsgi.rs:1361
 msgid "area boundary"
 msgstr ""
 
-#: src/wsgi.rs:1393
+#: src/wsgi.rs:1396
 msgid "Area"
 msgstr ""
 
-#: src/wsgi.rs:1396
+#: src/wsgi.rs:1399
 msgid "Street coverage"
 msgstr ""
 
-#: src/wsgi.rs:1414
+#: src/wsgi.rs:1417
 msgid "https://vmiklos.hu/osm-gimmisn/usage.html#how-to-add-a-new-area"
 msgstr ""
 
-#: src/wsgi.rs:1417
+#: src/wsgi.rs:1420
 msgid "Add new area"
 msgstr ""
 
-#: src/wsgi.rs:1436
+#: src/wsgi.rs:1439
 msgid "{0} missing house numbers"
 msgstr ""
 
-#: src/wsgi.rs:1439
+#: src/wsgi.rs:1442
 msgid "existing house numbers"
 msgstr ""
 
-#: src/wsgi.rs:1440
+#: src/wsgi.rs:1443
 msgid "existing streets"
 msgstr ""
 

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -370,6 +370,26 @@ pub enum RelationLintSource {
     Invalid,
 }
 
+impl TryFrom<&str> for RelationLintSource {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "invalid" => Ok(RelationLintSource::Invalid),
+            _ => Err(anyhow::anyhow!("invalid value: {value}")),
+        }
+    }
+}
+
+impl rusqlite::types::FromSql for RelationLintSource {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        let i = String::column_result(value)?;
+        i.as_str()
+            .try_into()
+            .map_err(|_| rusqlite::types::FromSqlError::InvalidType)
+    }
+}
+
 impl std::fmt::Display for RelationLintSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -11,6 +11,7 @@
 //! Tests for the areas module.
 
 use super::*;
+use rusqlite::types::FromSql as _;
 use std::io::Seek;
 use std::io::SeekFrom;
 use std::io::Write;
@@ -3200,4 +3201,21 @@ fn test_relations_is_inactive_no_ref_streets() {
     let actual = relations.get_active_names().unwrap();
 
     assert!(actual.is_empty());
+}
+
+/// Tests RelationLintSource::try_from().
+#[test]
+fn test_relation_lint_source_try_from() {
+    let result = RelationLintSource::try_from("test");
+    assert_eq!(result.is_err(), true);
+}
+
+/// Tests RelationLintSource::column_result().
+#[test]
+fn test_relation_lint_source_column_result() {
+    let value_ref = rusqlite::types::ValueRef::from("test");
+
+    let result = RelationLintSource::column_result(value_ref);
+
+    assert_eq!(result.is_err(), true);
 }

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -220,11 +220,14 @@ fn missing_housenumbers_view_lints(
         while let Some(lint) = lints.next()? {
             let mut cells: Vec<yattag::Doc> = Vec::new();
             let street: String = lint.get(0).unwrap();
-            let source: String = lint.get(1).unwrap();
+            let source: areas::RelationLintSource = lint.get(1).unwrap();
+            let source_string = match source {
+                areas::RelationLintSource::Invalid => tr("invalid housenumbers"),
+            };
             let housenumber: String = lint.get(2).unwrap();
             let reason: String = lint.get(3).unwrap();
             cells.push(yattag::Doc::from_text(&street));
-            cells.push(yattag::Doc::from_text(&source));
+            cells.push(yattag::Doc::from_text(&source_string));
             cells.push(yattag::Doc::from_text(&housenumber));
             cells.push(yattag::Doc::from_text(&reason));
             table.push(cells);


### PR DESCRIPTION
Decouple the machine-readable name (stored in sql) from the
human-readable name, presented (and localized) on the web UI.

Change-Id: I10e3142559cf2a9b42e3956cbd134e525b60e0b1
