### PR TITLE
Better error message for gpx when a 'street' is a node

### DIFF
--- a/src/wsgi_additional.rs
+++ b/src/wsgi_additional.rs
@@ -87,7 +87,10 @@ pub fn additional_streets_view_gpx(
                 .iter()
                 .find(|i| i.id == street.get_osm_id())
                 .unwrap();
-            let node_id = overpass_way.nodes.clone().unwrap()[0];
+            let node_id = overpass_way
+                .nodes
+                .clone()
+                .context(format!("street {} has no nodes", street.get_osm_id()))?[0];
             let overpass_node = overpass.elements.iter().find(|i| i.id == node_id).unwrap();
             let lat = overpass_node.lat.unwrap().to_string();
             let lon = overpass_node.lon.unwrap().to_string();


### PR DESCRIPTION
Still fails with:

	/osm/additional-streets/balatonfuzfo/view-result.gpx

but gives the problematic object id.

Change-Id: I317d915b6042e139323b9a087f683b98a8712c9a
