### PR TITLE
wsgi: improve error handling while serving .gpx

### DIFF
--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1548,7 +1548,8 @@ fn our_application_gpx(
     let mut headers: webframe::Headers = Vec::new();
     // assume prefix + "/additional-streets/"
     let (output, relation_name) =
-        wsgi_additional::additional_streets_view_gpx(ctx, relations, request_uri)?;
+        wsgi_additional::additional_streets_view_gpx(ctx, relations, request_uri)
+            .context("additional_streets_view_gpx() failed")?;
     headers.push((
         "Content-Disposition".into(),
         format!(r#"attachment;filename="{relation_name}.gpx""#).into(),
@@ -1675,7 +1676,8 @@ fn our_application(
     }
 
     if ext == "gpx" {
-        return our_application_gpx(ctx, &mut relations, &request_uri);
+        return our_application_gpx(ctx, &mut relations, &request_uri)
+            .context("our_application_gpx() failed");
     }
 
     let prefix = ctx.get_ini().get_uri_prefix();


### PR DESCRIPTION
Before:

	Internal error when serving /osm/additional-streets/balatonfuzfo/view-result.gpx
	our_application() failed

	Caused by:
	    street 6697355203 has no nodes

After:

	Internal error when serving /osm/additional-streets/balatonfuzfo/view-result.gpx
	our_application() failed

	Caused by:
	    0: our_application_gpx() failed
	    1: additional_streets_view_gpx() failed
	    2: street 6697355203 has no nodes

Change-Id: Ib3bcb393fa62f3be25705e4811af70d3ad5d8b93
