### PR TITLE
data: fix duplicated keys

### DIFF
--- a/data/relation-balatonalmadi.yaml
+++ b/data/relation-balatonalmadi.yaml
@@ -436,9 +436,6 @@ filters:
     #,62, 64 nincs kiírva 2023-04. RESURVEY 2024
     # 82 új ház, még nincs szám nincs kiírva 2023-04. RESURVEY 2024
     invalid: ['30', '62', '64', '82']
-  Szürkebarát utca:
-    # 40: Felső vízszintes részen nincsenek kint házszámok és utcanév se: 2023-04. RESURVEY 2024
-    invalid: ['40']
   Szúnyog utca:
     # 1-9 nincsenek házak csak fák, nádas
     invalid: ['9']

--- a/data/relation-hodmezovasarhely.yaml
+++ b/data/relation-hodmezovasarhely.yaml
@@ -41,7 +41,6 @@ refstreets:
   'Ciriák utca': 'Erzsébet Ciriák utca'
   'Gyöngyvirág utca': 'Erzsébet Gyöngyvirág utca'
   'Kossuth utca': 'Erzsébet Kossuth utca'
-  'Tiszavirág utca': 'Erzsébet Gyöngyvirág utca'
   'Posta utca': 'Erzsébet Posta utca'
   'Vasvári utca': 'Erzsébet Vasvári utca'
   # Kútvölgy


### PR DESCRIPTION
- balatonalmadi: the two values were the same, remove one.

- hodmezovasarhely: the first key was invalid (a 1:1 mapping is
  required, the first value was used elsewhere already), remove it.

Change-Id: Ia220290831c4c7ddad5e88a59a929a09f01a7616
