### PR TITLE
validator: catch duplicated yaml keys in a relation

### DIFF
--- a/src/validator.rs
+++ b/src/validator.rs
@@ -296,6 +296,11 @@ pub fn our_main(
             serde_yaml::from_str(&data).context("serde_yaml::from_str() failed")?;
         validate_relations(&mut errors, &relations_dict)?;
     } else {
+        // This will fail if the data is not well-formed (e.g. in case of duplicated keys):
+        serde_yaml::from_str::<serde_yaml::Value>(&data)
+            .context(format!("failed to validate {yaml_path}"))?;
+
+        // Then check if the data is valid:
         let relation_dict: areas::RelationDict =
             serde_yaml::from_str(&data).context(format!("failed to validate {yaml_path}"))?;
         let parent = "";


### PR DESCRIPTION
Fails with commit 80f1b0e12d1235b46eaafaa5680da0992f64c6da (data: fix
duplicated keys, 2023-09-26) reverted.

Change-Id: I5d91f9440f2ae8e923983fe50709d7074c403c37
