### PR TITLE
relation lint, web ui: differentiate between deleted-from-ref vs out-of-range

### DIFF
--- a/po/hu/osm-gimmisn.po
+++ b/po/hu/osm-gimmisn.po
@@ -17,19 +17,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/areas.rs:579
+#: src/areas.rs:582
 msgid "street"
 msgstr "utca"
 
-#: src/areas.rs:1081 src/wsgi.rs:441 src/wsgi_additional.rs:206
+#: src/areas.rs:1096 src/wsgi.rs:441 src/wsgi_additional.rs:206
 msgid "Street name"
 msgstr "Utcanév"
 
-#: src/areas.rs:1082
+#: src/areas.rs:1097
 msgid "Missing count"
 msgstr "Hiányzik db"
 
-#: src/areas.rs:1083
+#: src/areas.rs:1098
 msgid "House numbers"
 msgstr "Házszámok"
 
@@ -519,10 +519,13 @@ msgstr "érvénytelen házszámok"
 msgid "created in OSM"
 msgstr "létrehozva az OSM-ben"
 
-#. deleted from reference or outside the declared range
+#: src/wsgi.rs:239
+msgid "deleted from reference"
+msgstr "törölve a referenciából"
+
 #: src/wsgi.rs:240
-msgid "unused filter"
-msgstr "nem használt szűrő"
+msgid "out of range"
+msgstr "tartományon kívül"
 
 #: src/wsgi.rs:270
 msgid ""
@@ -700,6 +703,3 @@ msgid ""
 msgstr ""
 "Az OpenStreetmap tartalmazza a lenti {1} utcához tartozó további {0} "
 "házszámot."
-
-#~ msgid "deleted from reference"
-#~ msgstr "törölve a referenciából"

--- a/po/osm-gimmisn.pot
+++ b/po/osm-gimmisn.pot
@@ -17,19 +17,19 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/areas.rs:579
+#: src/areas.rs:582
 msgid "street"
 msgstr ""
 
-#: src/areas.rs:1081 src/wsgi.rs:441 src/wsgi_additional.rs:206
+#: src/areas.rs:1096 src/wsgi.rs:441 src/wsgi_additional.rs:206
 msgid "Street name"
 msgstr ""
 
-#: src/areas.rs:1082
+#: src/areas.rs:1097
 msgid "Missing count"
 msgstr ""
 
-#: src/areas.rs:1083
+#: src/areas.rs:1098
 msgid "House numbers"
 msgstr ""
 
@@ -482,9 +482,12 @@ msgstr ""
 msgid "created in OSM"
 msgstr ""
 
-#. deleted from reference or outside the declared range
+#: src/wsgi.rs:239
+msgid "deleted from reference"
+msgstr ""
+
 #: src/wsgi.rs:240
-msgid "unused filter"
+msgid "out of range"
 msgstr ""
 
 #: src/wsgi.rs:270

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -1384,6 +1384,55 @@ fn test_relation_get_lints() {
     );
 }
 
+/// Tests Relation::get_lints(), the out-of-range case.
+#[test]
+fn test_relation_get_lints_out_of_range() {
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let yamls_cache = serde_json::json!({
+        "relations.yaml": {
+        },
+        "relation-gh3073.yaml": {
+            "filters": {
+                "Hadak útja": {
+                    "invalid": [ "3" ],
+                    "ranges": [
+                        {"start": "5", "end": "7"},
+                    ],
+                },
+                "Hadak útja2": {
+                    "invalid": [ "3" ],
+                    "ranges": [
+                        {"start": "5", "end": "7"},
+                    ],
+                },
+            },
+            "housenumber-letters": true,
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[("data/yamls.cache", &yamls_cache_value)],
+    );
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    ctx.set_file_system(&file_system);
+    let mut relations = Relations::new(&ctx).unwrap();
+    let relation_name = "gh3073";
+    let mut relation = relations.get_relation(relation_name).unwrap();
+    let _missing_housenumbers = relation.get_missing_housenumbers().unwrap();
+
+    let lints = relation.get_lints();
+
+    assert!(!lints.is_empty());
+    let lint = lints[0].clone();
+    assert_eq!(lint.relation_name, "gh3073");
+    assert_eq!(lint.street_name, "Hadak útja");
+    assert_eq!(lint.source, RelationLintSource::Invalid);
+    assert_eq!(lint.housenumber, "3");
+    assert_eq!(lint.reason, RelationLintReason::OutOfRange);
+    assert_eq!(RelationLintReason::OutOfRange.to_string(), "out-of-range");
+}
+
 /// Tests Relation::write_lints().
 #[test]
 fn test_relation_write_lints() {

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -236,8 +236,8 @@ fn missing_housenumbers_view_lints(
             let object_type: String = lint.get(5).unwrap();
             let reason_string = match reason {
                 areas::RelationLintReason::CreatedInOsm => tr("created in OSM"),
-                // deleted from reference or outside the declared range
-                areas::RelationLintReason::DeletedFromRef => tr("unused filter"),
+                areas::RelationLintReason::DeletedFromRef => tr("deleted from reference"),
+                areas::RelationLintReason::OutOfRange => tr("out of range"),
             };
             cells.push(yattag::Doc::from_text(&street));
             cells.push(yattag::Doc::from_text(&source_string));

--- a/tests/workdir/street-housenumbers-gh3073.csv
+++ b/tests/workdir/street-housenumbers-gh3073.csv
@@ -1,0 +1,2 @@
+@id	addr:street	addr:housenumber	addr:postcode	addr:place	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
+15812165	Hadak útja	5	1119								Trendo 11 lakópark	relation

--- a/tests/workdir/street-housenumbers-reference-gh3073.lst
+++ b/tests/workdir/street-housenumbers-reference-gh3073.lst
@@ -1,0 +1,1 @@
+Hadak útja	3	

--- a/tests/workdir/streets-gh3073.csv
+++ b/tests/workdir/streets-gh3073.csv
@@ -1,0 +1,3 @@
+@id	name	highway	service	surface	leisure	@type
+7988705	Hadak útja	residential		asphalt		way
+7988706	Hadak útja2	residential		asphalt		way


### PR DESCRIPTION
One case is when it's really not in the reference, or only the filter is
outside the declared ranges.

Change-Id: I4580e68e39d9ee9cefbe93f29b112e6790a33005
