### PR TITLE
relation lint: track osm type/id for the create-in-osm + invalid case

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -686,10 +686,10 @@ impl<'a> Relation<'a> {
                         let relation_name = self.get_name();
                         let street_name = street_name.to_string();
                         let source = RelationLintSource::Invalid;
-                        let housenumber = housenumber.get_number().to_string();
                         let reason = RelationLintReason::CreatedInOsm;
-                        let id: u64 = 0;
-                        let object_type = "".to_string();
+                        let id: u64 = housenumber.get_id().context("no osm id")?;
+                        let object_type = housenumber.get_object_type().context("no osm type")?;
+                        let housenumber = housenumber.get_number().to_string();
                         let lint = RelationLint {
                             relation_name,
                             street_name,

--- a/src/util.rs
+++ b/src/util.rs
@@ -363,9 +363,19 @@ impl HouseNumber {
         self.id = Some(id);
     }
 
+    /// Gets the housenumber's OSM object ID, if this comes from OSM.
+    pub fn get_id(&self) -> Option<u64> {
+        self.id
+    }
+
     /// Sets the housenumber's OSM type ID, if this comes from OSM.
     pub fn set_object_type(&mut self, object_type: &str) {
         self.object_type = Some(object_type.to_string());
+    }
+
+    /// Gets the housenumber's OSM type ID, if this comes from OSM.
+    pub fn get_object_type(&self) -> Option<String> {
+        self.object_type.clone()
     }
 }
 


### PR DESCRIPTION
Note that here we don't fall back to 0 / "" for the osm id / type: if we
have no OSM info, that's an error, normalize() should get the row of the
OSM object.

With this, /missing-housenumbers/.../view-lints has rows like:

<street name>, invalid housenumbers, <housenumber>, created in OSM, <osm id as link>, <osm type>

While the osm id and type used to be just empty.

Change-Id: I8a75b30763d282a5e8d3b4dcabf97debd9c628bb
