### PR TITLE
stats: port handle_progress to read workdir/stats/<date>.count from sql

### DIFF
--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -24,6 +24,14 @@ fn make_test_time_old() -> context::tests::TestTime {
 #[test]
 fn test_handle_progress() {
     let mut ctx = context::tests::make_test_context().unwrap();
+    {
+        let conn = ctx.get_database_connection().unwrap();
+        conn.execute(
+            r#"insert into stats_counts (date, count) values (?1, ?2)"#,
+            ["2020-05-10", "254651"],
+        )
+        .unwrap();
+    }
     let ref_count = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,


### PR DESCRIPTION
`grep '}.count' src/stats.rs` says there are about 4 more places to go.

Change-Id: Idd2c02dbe33235b37887ba4dac1d515786f7069a
