### PR TITLE
cron: start tracking .citycount in SQL as well

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -151,7 +151,19 @@ pub fn init(conn: &rusqlite::Connection) -> anyhow::Result<()> {
             [],
         )?;
     }
-    conn.execute("pragma user_version = 7", [])?;
+    if user_version < 8 {
+        // Tracks house numbers of cities over time.
+        conn.execute(
+            "create table stats_citycounts (
+            date text not null,
+            city text not null,
+            count text not null,
+            unique(date, city)
+        )",
+            [],
+        )?;
+    }
+    conn.execute("pragma user_version = 8", [])?;
     Ok(())
 }
 


### PR DESCRIPTION
See
<https://stackoverflow.com/questions/66904339/sqlite-on-conflict-two-or-more-columns>
wrt "insert or update" when the unique constraint is on multiple
columns.

Change-Id: If56938b75b311350437092caca6c0cc3fe3445e3
