### PR TITLE
cron: start tracking .topusers in SQL as well

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -163,7 +163,19 @@ pub fn init(conn: &rusqlite::Connection) -> anyhow::Result<()> {
             [],
         )?;
     }
-    conn.execute("pragma user_version = 8", [])?;
+    if user_version < 9 {
+        // Tracks house numbers of cities over time.
+        conn.execute(
+            "create table stats_topusers (
+            date text not null,
+            user text not null,
+            count text not null,
+            unique(date, user)
+        )",
+            [],
+        )?;
+    }
+    conn.execute("pragma user_version = 10", [])?;
     Ok(())
 }
 


### PR DESCRIPTION
We never diff this data, so this is easier than .citycount which is
diffed between now and a month ago.

Change-Id: I7f99fff96163ac54225aa2447f28736ee89ca141
