### PR TITLE
sql: fix typo

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -175,7 +175,7 @@ pub fn init(conn: &rusqlite::Connection) -> anyhow::Result<()> {
             [],
         )?;
     }
-    conn.execute("pragma user_version = 10", [])?;
+    conn.execute("pragma user_version = 9", [])?;
     Ok(())
 }
 


### PR DESCRIPTION
Old version was 8, incrementing to 9 is enough.

Change-Id: I81cac70b353635e85559b6ce54fbf2af86ef8769
