### PR TITLE
wsgi, html: also store osm streets in sql

### DIFF
--- a/src/fixtures/network/overpass-streets-gazdagret.json
+++ b/src/fixtures/network/overpass-streets-gazdagret.json
@@ -1,0 +1,36 @@
+{
+    "osm3s": {
+        "timestamp_osm_base": "2023-11-16T13:34:15Z",
+        "timestamp_areas_base": "2023-11-16T10:23:59Z"
+    },
+    "elements": [
+        {
+            "type": "way",
+            "id": 1,
+            "tags": {
+                "name": "Tűzkő utca"
+            }
+        },
+        {
+            "type": "way",
+            "id": 2,
+            "tags": {
+                "name": "Törökugrató utca"
+            }
+        },
+        {
+            "type": "way",
+            "id": 3,
+            "tags": {
+                "name": "OSM Name 1"
+            }
+        },
+        {
+            "type": "way",
+            "id": 4,
+            "tags": {
+                "name": "Hamzsabégi út"
+            }
+        }
+    ]
+}

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -63,6 +63,7 @@ fn handle_streets(
         let pre = doc.tag("pre", &[]);
         pre.text(&relation.get_osm_streets_query()?);
     } else if action == "update-result" {
+        // Old style: CSV.
         let query = relation.get_osm_streets_query()?;
         match overpass_query::overpass_query(ctx, &query) {
             Ok(buf) => {
@@ -78,6 +79,16 @@ fn handle_streets(
                 } else {
                     doc.text(&tr("Update successful."));
                 }
+            }
+            Err(err) => {
+                doc.append_value(util::handle_overpass_error(ctx, &err.to_string()).get_value());
+            }
+        }
+        // New style: JSON.
+        let query = relation.get_osm_streets_json_query()?;
+        match overpass_query::overpass_query(ctx, &query) {
+            Ok(buf) => {
+                relation.get_files().write_osm_json_streets(ctx, &buf)?;
             }
             Err(err) => {
                 doc.append_value(util::handle_overpass_error(ctx, &err.to_string()).get_value());

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -243,11 +243,18 @@ fn test_handle_streets_view_query_well_formed() {
 #[test]
 fn test_handle_streets_update_result_well_formed() {
     let mut test_wsgi = TestWsgi::new();
-    let routes = vec![context::tests::URLRoute::new(
-        /*url=*/ "https://overpass-api.de/api/interpreter",
-        /*data_path=*/ "",
-        /*result_path=*/ "src/fixtures/network/overpass-streets-gazdagret.csv",
-    )];
+    let routes = vec![
+        context::tests::URLRoute::new(
+            /*url=*/ "https://overpass-api.de/api/interpreter",
+            /*data_path=*/ "",
+            /*result_path=*/ "src/fixtures/network/overpass-streets-gazdagret.csv",
+        ),
+        context::tests::URLRoute::new(
+            /*url=*/ "https://overpass-api.de/api/interpreter",
+            /*data_path=*/ "",
+            /*result_path=*/ "src/fixtures/network/overpass-streets-gazdagret.json",
+        ),
+    ];
     let network = context::tests::TestNetwork::new(&routes);
     let network_rc: Rc<dyn context::Network> = Rc::new(network);
     test_wsgi.ctx.set_network(network_rc);
@@ -322,7 +329,8 @@ fn test_handle_streets_update_result_error_well_formed() {
     let root = test_wsgi.get_dom_for_path("/streets/gazdagret/update-result");
 
     let results = TestWsgi::find_all(&root, "body/div[@id='overpass-error']");
-    assert_eq!(results.len(), 1);
+    // CSV and JSON.
+    assert_eq!(results.len(), 2);
 }
 
 /// Tests handle_streets(): if the update-result output is well-formed for

--- a/src/wsgi_json.rs
+++ b/src/wsgi_json.rs
@@ -30,11 +30,21 @@ fn streets_update_result_json(
     let relation = relations
         .get_relation(relation_name)
         .context("get_relation() failed")?;
-    let query = relation.get_osm_streets_query()?;
     let mut ret: HashMap<String, String> = HashMap::new();
+    // Old style: CSV.
+    let query = relation.get_osm_streets_query()?;
     match overpass_query::overpass_query(ctx, &query) {
         Ok(buf) => {
             relation.get_files().write_osm_streets(ctx, &buf)?;
+            ret.insert("error".into(), "".into())
+        }
+        Err(err) => ret.insert("error".into(), err.to_string()),
+    };
+    // New style: JSON.
+    let query = relation.get_osm_streets_json_query()?;
+    match overpass_query::overpass_query(ctx, &query) {
+        Ok(buf) => {
+            relation.get_files().write_osm_json_streets(ctx, &buf)?;
             ret.insert("error".into(), "".into())
         }
         Err(err) => ret.insert("error".into(), err.to_string()),

--- a/src/wsgi_json/tests.rs
+++ b/src/wsgi_json/tests.rs
@@ -26,11 +26,18 @@ use crate::wsgi;
 #[test]
 fn test_json_streets_update_result() {
     let mut test_wsgi = wsgi::tests::TestWsgi::new();
-    let routes = vec![context::tests::URLRoute::new(
-        /*url=*/ "https://overpass-api.de/api/interpreter",
-        /*data_path=*/ "",
-        /*result_path=*/ "src/fixtures/network/overpass-streets-gazdagret.csv",
-    )];
+    let routes = vec![
+        context::tests::URLRoute::new(
+            /*url=*/ "https://overpass-api.de/api/interpreter",
+            /*data_path=*/ "",
+            /*result_path=*/ "src/fixtures/network/overpass-streets-gazdagret.csv",
+        ),
+        context::tests::URLRoute::new(
+            /*url=*/ "https://overpass-api.de/api/interpreter",
+            /*data_path=*/ "",
+            /*result_path=*/ "src/fixtures/network/overpass-streets-gazdagret.json",
+        ),
+    ];
     let network = context::tests::TestNetwork::new(&routes);
     let network_rc: Rc<dyn context::Network> = Rc::new(network);
     test_wsgi.get_ctx().set_network(network_rc);


### PR DESCRIPTION
Do this for all the 3 "UI": html, json and cron.

No reading of the osm/areas timestamps yet.

Change-Id: Id5c0d61cc83003bf45b771ee939f565f84d5d1df
