### PR TITLE
sql: fix missing index on osm_streets

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -203,6 +203,11 @@ pub fn init(conn: &rusqlite::Connection) -> anyhow::Result<()> {
         )",
             [],
         )?;
+        conn.execute(
+            "create index idx_osm_streets
+            on osm_streets (relation)",
+            [],
+        )?;
     }
     conn.execute("pragma user_version = 11", [])?;
     Ok(())


### PR DESCRIPTION
Similar to per-relation CSV files kind of provided a fast access to the
streets of a given relation.

Change-Id: I8b007510c47c7d4675bf5534d2921df17962fe9e
