### PR TITLE
osm streets: store timestamps in sql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0.190", features = ["derive"] }
 serde_json = "1.0.108"
 serde_yaml = "0.9.27"
 simplelog = "0.12.1"
-time = { version = "0.3.30", features = ["formatting", "macros", "local-offset"] }
+time = { version = "0.3.30", features = ["formatting", "macros", "local-offset", "serde-well-known"] }
 toml = "0.8.6"
 unidecode = "0.3.0"
 url = "2.4.1"


### PR DESCRIPTION
These two timestamps show the osm db date, not just the query date,
which is much more useful. This was not previously visible with CSV
query, but the newer JSON query contains the info.

Change-Id: I1ac0c456c6dc468f83e6d98e1bbc562a799965a5
