### PR TITLE
osm streets, sql: store mtime

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -11,6 +11,7 @@
 //! The area_files module contains file handling functionality, to be used by the areas module.
 
 use crate::context;
+use crate::stats;
 use anyhow::Context;
 use std::cell::RefCell;
 use std::io::Read;
@@ -211,6 +212,9 @@ impl RelationFiles {
                 return Ok(());
             }
         };
+
+        // Insert or update the mtime for the osm streets of this relation.
+        stats::set_sql_mtime(ctx, &format!("streets/{}", self.name))?;
 
         let mut conn = ctx.get_database_connection()?;
         let tx = conn.transaction()?;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -473,7 +473,7 @@ pub fn generate_json(
     Ok(())
 }
 
-fn set_sql_mtime(ctx: &context::Context, page: &str) -> anyhow::Result<()> {
+pub fn set_sql_mtime(ctx: &context::Context, page: &str) -> anyhow::Result<()> {
     let conn = ctx.get_database_connection()?;
     conn.execute(
         r#"insert into mtimes (page, last_modified) values (?1, ?2)


### PR DESCRIPTION
This is the timestamp of the overpass query, to know when to invalidate
the cache.

Change-Id: Ic12103e1c62bfc1a16789acacd7d2ebb828ab531
