### PR TITLE
cron: ignore duplicated streets in relations from overpass

### DIFF
--- a/src/area_files/tests.rs
+++ b/src/area_files/tests.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#![deny(warnings)]
+#![warn(clippy::all)]
+#![warn(missing_docs)]
+
+//! Tests for the area_files module.
+
+use super::*;
+use crate::areas;
+
+/// Tests RelationFiles::write_osm_json_streets(), when the json has duplicated streets.
+#[test]
+fn test_write_osm_json_streets_duplicate() {
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let yamls_cache = serde_json::json!({
+        "relations.yaml": {
+            "gazdagret": {
+                "osmrelation": 2713748,
+            },
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[("data/yamls.cache", &yamls_cache_value)],
+    );
+    let mut file_system = context::tests::TestFileSystem::new();
+    file_system.set_files(&files);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
+    let mut relations = areas::Relations::new(&ctx).unwrap();
+    let relation = relations.get_relation("gazdagret").unwrap();
+    let result =
+        std::fs::read_to_string("src/fixtures/network/overpass-streets-duplicate.json").unwrap();
+
+    relation
+        .get_files()
+        .write_osm_json_streets(&ctx, &result)
+        .unwrap();
+}

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -103,7 +103,10 @@ fn update_osm_streets(
                     continue;
                 }
             };
-            relation.get_files().write_osm_json_streets(ctx, &buf)?;
+            relation
+                .get_files()
+                .write_osm_json_streets(ctx, &buf)
+                .context("write_osm_json_streets() failed")?;
             break;
         }
         info!("update_osm_streets, json: end: {relation_name}");

--- a/src/fixtures/network/overpass-streets-duplicate.json
+++ b/src/fixtures/network/overpass-streets-duplicate.json
@@ -1,0 +1,22 @@
+{
+    "osm3s": {
+        "timestamp_osm_base": "2023-11-16T13:34:15Z",
+        "timestamp_areas_base": "2023-11-16T10:23:59Z"
+    },
+    "elements": [
+        {
+            "type": "way",
+            "id": 1,
+            "tags": {
+                "name": "Tűzkő utca"
+            }
+        },
+        {
+            "type": "way",
+            "id": 1,
+            "tags": {
+                "name": "Törökugrató utca"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Failed like this:

	2023-12-01 00:11:57 [INFO] update_osm_streets, json: start: budapest_10
	2023-12-01 00:11:58 [ERROR] main: unhandled error: our_main_inner failed

	Caused by:
	    0: UNIQUE constraint failed: osm_streets.relation, osm_streets.osm_id
	    1: Error code 2067: A UNIQUE constraint failed
