### PR TITLE
cron: port test_update_osm_streets_http_error() to sql

### DIFF
--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -716,16 +716,30 @@ fn test_update_osm_streets_http_error() {
     let network = context::tests::TestNetwork::new(&routes);
     let network_rc: Rc<dyn context::Network> = Rc::new(network);
     ctx.set_network(network_rc);
+    {
+        let conn = ctx.get_database_connection().unwrap();
+        conn.execute(
+            r#"insert into osm_streets (relation, osm_id, name, highway, service, surface, leisure, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"#,
+            ["gazdagret", "1", "Tűzkő utca", "", "", "", "", ""],
+        )
+        .unwrap();
+    }
     let mut relations = areas::Relations::new(&ctx).unwrap();
-    let path = ctx.get_abspath("workdir/streets-gazdagret.csv");
-    let expected = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
 
     update_osm_streets(&ctx, &mut relations, /*update=*/ true).unwrap();
 
     // Make sure that in case we keep getting errors we give up at some stage and
     // leave the last state unchanged.
-    let actual = String::from_utf8(std::fs::read(&path).unwrap()).unwrap();
-    assert_eq!(actual, expected);
+    assert_eq!(
+        relations
+            .get_relation("gazdagret")
+            .unwrap()
+            .get_files()
+            .get_osm_json_streets(&ctx)
+            .unwrap()
+            .len(),
+        1
+    );
 }
 
 /// Tests update_osm_streets(): the case when we ask for CSV but get XML.


### PR DESCRIPTION
Still 14 tests fail when tests/workdir/streets-gazdagret.csv is deleted.

Change-Id: I0bc896b0e5182ad7828dee2e7c649d447d3dbf68
