### PR TITLE
cron: stop writing OSM streets as CSV

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -224,11 +224,6 @@ impl RelationFiles {
 
     /// Writes the result for overpass of Relation.get_osm_streets_query().
     pub fn write_osm_streets(&self, ctx: &context::Context, result: &str) -> anyhow::Result<usize> {
-        if result.starts_with("<?xml") {
-            // Not a CSV, reject.
-            return Ok(0);
-        }
-
         let write = self.get_osm_streets_write_stream(ctx)?;
         let mut guard = write.borrow_mut();
         Ok(guard.write(result.as_bytes())?)

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -58,31 +58,6 @@ fn update_osm_streets(
         if !update && stats::has_sql_mtime(ctx, &format!("streets/{}", relation_name))? {
             continue;
         }
-        // Old style: CSV.
-        info!("update_osm_streets: start: {relation_name}");
-        let mut retry = 0;
-        while should_retry(retry) {
-            if retry > 0 {
-                info!("update_osm_streets: try #{retry}");
-            }
-            retry += 1;
-            overpass_sleep(ctx);
-            let query = relation.get_osm_streets_query()?;
-            let buf = match overpass_query::overpass_query(ctx, &query) {
-                Ok(value) => value,
-                Err(err) => {
-                    info!("update_osm_streets: http error: {err:?}");
-                    continue;
-                }
-            };
-            if relation.get_files().write_osm_streets(ctx, &buf)? == 0 {
-                info!("update_osm_streets: short write");
-                continue;
-            }
-            break;
-        }
-        info!("update_osm_streets: end: {relation_name}");
-        // New style: JSON.
         info!("update_osm_streets, json: start: {relation_name}");
         let mut retry = 0;
         while should_retry(retry) {


### PR DESCRIPTION
The HTML UI and the JSON API still does it, though.

Change-Id: Iea95273f59a6738d5e83b206b9daef32fa1b8db0
