### PR TITLE
HTML UI: stop writing OSM streets as CSV

### DIFF
--- a/src/fixtures/network/overpass-streets-ujbuda.json
+++ b/src/fixtures/network/overpass-streets-ujbuda.json
@@ -1,0 +1,29 @@
+{
+    "osm3s": {
+        "timestamp_osm_base": "2023-11-16T13:34:15Z",
+        "timestamp_areas_base": "2023-11-16T10:23:59Z"
+    },
+    "elements": [
+        {
+            "type": "way",
+            "id": 1,
+            "tags": {
+                "name": "Tűzkő utca"
+            }
+        },
+        {
+            "type": "way",
+            "id": 2,
+            "tags": {
+                "name": "Törökugrató utca"
+            }
+        },
+        {
+            "type": "way",
+            "id": 3,
+            "tags": {
+                "name": "OSM Name 1"
+            }
+        }
+    ]
+}

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -73,11 +73,10 @@ fn handle_streets(
         let pre = doc.tag("pre", &[]);
         pre.text(&relation.get_osm_streets_query()?);
     } else if action == "update-result" {
-        // Old style: CSV.
-        let query = relation.get_osm_streets_query()?;
+        let query = relation.get_osm_streets_json_query()?;
         match overpass_query::overpass_query(ctx, &query) {
             Ok(buf) => {
-                relation.get_files().write_osm_streets(ctx, &buf)?;
+                relation.get_files().write_osm_json_streets(ctx, &buf)?;
                 let streets = relation.get_config().should_check_missing_streets();
                 if streets != "only" {
                     doc.text(&tr("Update successful: "));
@@ -89,16 +88,6 @@ fn handle_streets(
                 } else {
                     doc.text(&tr("Update successful."));
                 }
-            }
-            Err(err) => {
-                doc.append_value(util::handle_overpass_error(ctx, &err.to_string()).get_value());
-            }
-        }
-        // New style: JSON.
-        let query = relation.get_osm_streets_json_query()?;
-        match overpass_query::overpass_query(ctx, &query) {
-            Ok(buf) => {
-                relation.get_files().write_osm_json_streets(ctx, &buf)?;
             }
             Err(err) => {
                 doc.append_value(util::handle_overpass_error(ctx, &err.to_string()).get_value());


### PR DESCRIPTION
The JSON API still does it, though.

Change-Id: I464d72d57ddda500a64765699186f3dffdbafa84
