### PR TITLE
JSON API: stop writing OSM streets as CSV

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -100,11 +100,6 @@ impl RelationFiles {
         format!("{}/streets-reference-{}.lst", self.workdir, self.name)
     }
 
-    /// Build the file name of the OSM street list of a relation.
-    pub fn get_osm_streets_path(&self) -> String {
-        format!("{}/streets-{}.csv", self.workdir, self.name)
-    }
-
     /// Build the file name of the OSM house number list of a relation.
     pub fn get_osm_housenumbers_path(&self) -> String {
         format!("{}/street-housenumbers-{}.csv", self.workdir, self.name)
@@ -211,22 +206,6 @@ impl RelationFiles {
     ) -> anyhow::Result<Rc<RefCell<dyn Read>>> {
         let path = self.get_housenumbers_additional_count_path();
         ctx.get_file_system().open_read(&path)
-    }
-
-    /// Opens the OSM street list of a relation for writing.
-    fn get_osm_streets_write_stream(
-        &self,
-        ctx: &context::Context,
-    ) -> anyhow::Result<Rc<RefCell<dyn Write>>> {
-        let path = self.get_osm_streets_path();
-        ctx.get_file_system().open_write(&path)
-    }
-
-    /// Writes the result for overpass of Relation.get_osm_streets_query().
-    pub fn write_osm_streets(&self, ctx: &context::Context, result: &str) -> anyhow::Result<usize> {
-        let write = self.get_osm_streets_write_stream(ctx)?;
-        let mut guard = write.borrow_mut();
-        Ok(guard.write(result.as_bytes())?)
     }
 
     /// Writes the result for overpass of Relation.get_osm_streets_json_query().

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -760,13 +760,11 @@ fn test_update_osm_streets_xml_as_json() {
         .borrow_mut()
         .write_all(b"aaa @RELATION@ bbb @AREA@ ccc\n")
         .unwrap();
-    let osm_streets_value = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
         &[
             ("data/yamls.cache", &yamls_cache_value),
             ("data/streets-template.overpassql", &template_value),
-            ("workdir/streets-gazdagret.csv", &osm_streets_value),
         ],
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);

--- a/src/fixtures/network/overpass-streets-gazdagret.csv
+++ b/src/fixtures/network/overpass-streets-gazdagret.csv
@@ -1,5 +1,0 @@
-@id	name
-1	Tűzkő utca
-2	Törökugrató utca
-3	OSM Name 1
-4	Hamzsabégi út

--- a/src/fixtures/network/overpass-streets-ujbuda.csv
+++ b/src/fixtures/network/overpass-streets-ujbuda.csv
@@ -1,4 +1,0 @@
-@id	name
-3	OSM Name 1
-2	Törökugrató utca
-1	Tűzkő utca

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -2539,12 +2539,8 @@ fn test_handle_invalid_refstreets_no_osm_sreets() {
         &test_wsgi.ctx,
         &[("data/yamls.cache", &yamls_cache_value)],
     );
-    let mut file_system = context::tests::TestFileSystem::new();
-    file_system.set_files(&files);
-    let hide_path = test_wsgi.ctx.get_abspath("workdir/streets-gazdagret.csv");
-    file_system.set_hide_paths(&[hide_path]);
-    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_rc);
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    test_wsgi.ctx.set_file_system(&file_system);
 
     let root = test_wsgi.get_dom_for_path("/lints/whole-country/invalid-relations");
 
@@ -2563,17 +2559,11 @@ fn test_handle_invalid_refstreets_no_invalids() {
         },
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
-    let osm_streets = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &test_wsgi.ctx,
-        &[
-            ("data/yamls.cache", &yamls_cache_value),
-            ("workdir/streets-myrelation.csv", &osm_streets),
-        ],
+        &[("data/yamls.cache", &yamls_cache_value)],
     );
-    let mut file_system = context::tests::TestFileSystem::new();
-    file_system.set_files(&files);
-    let file_system: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    let file_system = context::tests::TestFileSystem::from_files(&files);
     test_wsgi.ctx.set_file_system(&file_system);
     let mtime = test_wsgi.get_ctx().get_time().now_string();
     {

--- a/src/wsgi_additional/tests.rs
+++ b/src/wsgi_additional/tests.rs
@@ -367,11 +367,6 @@ fn test_additional_housenumbers_well_formed() {
 #[test]
 fn test_additional_housenumbers_no_osm_streets_well_formed() {
     let mut test_wsgi = wsgi::tests::TestWsgi::new();
-    let hide_path = test_wsgi
-        .get_ctx()
-        .get_abspath("workdir/streets-gazdagret.csv");
-    let mut file_system = context::tests::TestFileSystem::new();
-    file_system.set_hide_paths(&[hide_path]);
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
@@ -384,9 +379,8 @@ fn test_additional_housenumbers_no_osm_streets_well_formed() {
         test_wsgi.get_ctx(),
         &[("data/yamls.cache", &yamls_cache_value)],
     );
-    file_system.set_files(&files);
-    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
-    test_wsgi.get_ctx().set_file_system(&file_system_rc);
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    test_wsgi.get_ctx().set_file_system(&file_system);
 
     let root = test_wsgi.get_dom_for_path("/additional-housenumbers/gazdagret/view-result");
 
@@ -605,11 +599,6 @@ fn test_streets_street_from_housenr_well_formed() {
 #[test]
 fn test_streets_no_osm_streets_well_formed() {
     let mut test_wsgi = wsgi::tests::TestWsgi::new();
-    let hide_path = test_wsgi
-        .get_ctx()
-        .get_abspath("workdir/streets-gazdagret.csv");
-    let mut file_system = context::tests::TestFileSystem::new();
-    file_system.set_hide_paths(&[hide_path]);
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
@@ -622,9 +611,8 @@ fn test_streets_no_osm_streets_well_formed() {
         test_wsgi.get_ctx(),
         &[("data/yamls.cache", &yamls_cache_value)],
     );
-    file_system.set_files(&files);
-    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
-    test_wsgi.get_ctx().set_file_system(&file_system_rc);
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    test_wsgi.get_ctx().set_file_system(&file_system);
 
     let root = test_wsgi.get_dom_for_path("/additional-streets/gazdagret/view-result");
 

--- a/src/wsgi_json.rs
+++ b/src/wsgi_json.rs
@@ -31,16 +31,6 @@ fn streets_update_result_json(
         .get_relation(relation_name)
         .context("get_relation() failed")?;
     let mut ret: HashMap<String, String> = HashMap::new();
-    // Old style: CSV.
-    let query = relation.get_osm_streets_query()?;
-    match overpass_query::overpass_query(ctx, &query) {
-        Ok(buf) => {
-            relation.get_files().write_osm_streets(ctx, &buf)?;
-            ret.insert("error".into(), "".into())
-        }
-        Err(err) => ret.insert("error".into(), err.to_string()),
-    };
-    // New style: JSON.
     let query = relation.get_osm_streets_json_query()?;
     match overpass_query::overpass_query(ctx, &query) {
         Ok(buf) => {


### PR DESCRIPTION
Which allows removing the last traces of OSM streets as CSV files.
Everything is in SQL now, including the 2 (osm, areas) dates of the
streets.

Addresses the streets part of
<https://github.com/vmiklos/osm-gimmisn/issues/3105>.

Change-Id: Icb671f569c533fa6961b3167e69db3ed4bd50233
