### PR TITLE
util: make get_city_key() case-sensitive as well

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1196,8 +1196,6 @@ pub fn get_city_key(
     city: &str,
     valid_settlements: &HashSet<String>,
 ) -> anyhow::Result<String> {
-    let city = city.to_lowercase();
-
     if !city.is_empty() && postcode.starts_with('1') {
         let mut chars = postcode.chars();
         chars.next();
@@ -1209,13 +1207,13 @@ pub fn get_city_key(
             }
         };
         if (1..=23).contains(&district) {
-            return Ok(city + "_" + chars.as_str());
+            return Ok(city.to_string() + "_" + chars.as_str());
         }
-        return Ok(city);
+        return Ok(city.to_string());
     }
 
-    if valid_settlements.contains(&city) || city == "budapest" {
-        return Ok(city);
+    if valid_settlements.contains(&city.to_string()) || city == "Budapest" {
+        return Ok(city.to_string());
     }
     if !city.is_empty() {
         return Ok("_Invalid".into());

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -549,14 +549,14 @@ fn test_street() {
 #[test]
 fn test_get_city_key() {
     let mut valid_settlements: HashSet<String> = HashSet::new();
-    valid_settlements.insert("lábatlan".into());
+    valid_settlements.insert("Lábatlan".into());
     assert_eq!(
         get_city_key("1234", "Budapest", &valid_settlements).unwrap(),
-        "budapest_23"
+        "Budapest_23"
     );
     assert_eq!(
         get_city_key("1889", "Budapest", &valid_settlements).unwrap(),
-        "budapest"
+        "Budapest"
     );
     assert_eq!(
         get_city_key("9999", "", &valid_settlements).unwrap(),
@@ -564,7 +564,7 @@ fn test_get_city_key() {
     );
     assert_eq!(
         get_city_key("9999", "Lábatlan", &valid_settlements).unwrap(),
-        "lábatlan"
+        "Lábatlan"
     );
     assert_eq!(
         get_city_key("9999", "junk", &valid_settlements).unwrap(),
@@ -573,7 +573,7 @@ fn test_get_city_key() {
     // Even if the pos does not start with 1.
     assert_eq!(
         get_city_key("9999", "Budapest", &valid_settlements).unwrap(),
-        "budapest"
+        "Budapest"
     );
     // postcode vs housenumber swap.
     assert_eq!(


### PR DESCRIPTION
This went wrong in commit eef5e67591a9453d81a1de8e4782f0c267f8f0b2
(/lints/whole-country/invalid-addr-cities: make this case-sensitive,
2023-11-19), now .citycount files again contain no _Inlilid keys (i.e.
'City' was accepted as valid, but not 'city', make sure our input is not
lowercase, either.)

Change-Id: I8cfdb37c46c568e0ec1ce2595268138556ad73fc
