### PR TITLE
areas: produce query for a relation's housenumbers, in json format

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1284,6 +1284,23 @@ impl<'a> Relation<'a> {
         ))
     }
 
+    /// Produces a query which lists housenumbers in relation, in JSON format.
+    pub fn get_osm_housenumbers_json_query(&self) -> anyhow::Result<String> {
+        let query = self.get_osm_housenumbers_query()?;
+        let mut i = 0;
+        let mut lines = Vec::new();
+        for line in query.lines() {
+            i += 1;
+            if i == 1 {
+                lines.push("[out:json];".to_string());
+                continue;
+            }
+
+            lines.push(line.to_string());
+        }
+        Ok(lines.join("\n"))
+    }
+
     /// Returns invalid osm names and ref names.
     pub fn get_invalid_refstreets(&self) -> anyhow::Result<(Vec<String>, Vec<String>)> {
         let mut osm_invalids: Vec<String> = Vec::new();

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -731,6 +731,41 @@ fn test_relation_get_osm_housenumbers_query() {
     assert_eq!(ret, "housenr aaa 42 bbb 3600000042 ccc\n");
 }
 
+/// Tests Relation.get_osm_housenumbers_json_query().
+#[test]
+fn test_relation_get_osm_housenumbers_json_query() {
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let yamls_cache = serde_json::json!({
+        "relations.yaml": {
+            "gazdagret": {
+                "osmrelation": 42,
+            },
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let overpass_template = context::tests::TestFileSystem::make_file();
+    overpass_template
+        .borrow_mut()
+        .write_all(b"[out:csv(::id)] [timeout:425];\nhousenr aaa @RELATION@ bbb @AREA@ ccc\n")
+        .unwrap();
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[
+            ("data/yamls.cache", &yamls_cache_value),
+            (
+                "data/street-housenumbers-template.overpassql",
+                &overpass_template,
+            ),
+        ],
+    );
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    ctx.set_file_system(&file_system);
+    let mut relations = Relations::new(&ctx).unwrap();
+    let relation = relations.get_relation("gazdagret").unwrap();
+    let ret = relation.get_osm_housenumbers_json_query().unwrap();
+    assert_eq!(ret, "[out:json];\nhousenr aaa 42 bbb 3600000042 ccc");
+}
+
 /// Tests RelationFiles.write_osm_streets().
 #[test]
 fn test_relation_files_write_osm_streets() {


### PR DESCRIPTION
Similar to commit 69960e4131d799ac6f99174341bfcec2c022d9a9 (areas:
produce query for a relation's streets, in json format, 2023-11-17).

Change-Id: Ia2f44997a98f0c318944879cd1bbbb5384ef3966
