### PR TITLE
cron: ignore duplicated housenumbers in relations from overpass

### DIFF
--- a/src/area_files/tests.rs
+++ b/src/area_files/tests.rs
@@ -43,3 +43,35 @@ fn test_write_osm_json_streets_duplicate() {
         .write_osm_json_streets(&ctx, &result)
         .unwrap();
 }
+
+/// Tests RelationFiles::write_osm_json_housenumbers(), when the json has duplicated housenumbers.
+#[test]
+fn test_write_osm_json_housenumbers_duplicate() {
+    let mut ctx = context::tests::make_test_context().unwrap();
+    let yamls_cache = serde_json::json!({
+        "relations.yaml": {
+            "gazdagret": {
+                "osmrelation": 2713748,
+            },
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[("data/yamls.cache", &yamls_cache_value)],
+    );
+    let mut file_system = context::tests::TestFileSystem::new();
+    file_system.set_files(&files);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    ctx.set_file_system(&file_system_rc);
+    let mut relations = areas::Relations::new(&ctx).unwrap();
+    let relation = relations.get_relation("gazdagret").unwrap();
+    let result =
+        std::fs::read_to_string("src/fixtures/network/overpass-housenumbers-duplicate.json")
+            .unwrap();
+
+    relation
+        .get_files()
+        .write_osm_json_housenumbers(&ctx, &result)
+        .unwrap();
+}

--- a/src/fixtures/network/overpass-housenumbers-duplicate.json
+++ b/src/fixtures/network/overpass-housenumbers-duplicate.json
@@ -1,0 +1,24 @@
+{
+    "osm3s": {
+        "timestamp_osm_base": "2023-11-16T13:34:15Z",
+        "timestamp_areas_base": "2023-11-16T10:23:59Z"
+    },
+    "elements": [
+        {
+            "type": "node",
+            "id": 1,
+            "tags": {
+                "addr:street": "Törökugrató utca",
+                "addr:housenumber": "1"
+            }
+        },
+        {
+            "type": "node",
+            "id": 1,
+            "tags": {
+                "addr:street": "Törökugrató utca",
+                "addr:housenumber": "1"
+            }
+        }
+    ]
+}

--- a/src/fixtures/network/overpass-housenumbers-gazdagret.json
+++ b/src/fixtures/network/overpass-housenumbers-gazdagret.json
@@ -67,14 +67,6 @@
                 "addr:street": "Second Only In OSM utca",
                 "addr:housenumber": "1"
             }
-        },
-        {
-            "type": "node",
-            "id": 8,
-            "tags": {
-                "addr:street": "Second Only In OSM utca",
-                "addr:housenumber": "1"
-            }
         }
     ]
 }


### PR DESCRIPTION
Similar to commit ac9e7eb136565d68c021b93c613887f3fd8fd0ab (cron: ignore
duplicated streets in relations from overpass, 2023-12-02).

Deduplicate the old test data and add an explicit duplicated test
instead.

Change-Id: I8ddf682f769774ee9f5a0b95d7b2e68cbacb2469
