### PR TITLE
wsgi, missing_housenumbers_view_txt: take osm housenumbers mtime from sql

### DIFF
--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -576,10 +576,7 @@ fn missing_housenumbers_view_txt(
         return Ok(tr("No existing streets"));
     }
 
-    if !ctx
-        .get_file_system()
-        .path_exists(&relation.get_files().get_osm_housenumbers_path())
-    {
+    if !stats::has_sql_mtime(ctx, &format!("housenumbers/{}", relation_name))? {
         return Ok(tr("No existing house numbers"));
     }
 

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -967,6 +967,11 @@ fn test_missing_housenumbers_view_result_txt() {
             ["streets/budafok", &mtime],
         )
         .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/budafok", &mtime],
+        )
+        .unwrap();
     }
 
     let result = test_wsgi.get_txt_for_path("/missing-housenumbers/budafok/view-result.txt");
@@ -1074,6 +1079,11 @@ fn test_missing_housenumbers_view_result_txt_even_odd() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }
@@ -1497,6 +1507,11 @@ fn test_missing_housenumbers_view_result_txt_no_ref_housenumbers() {
         conn.execute(
             "insert into mtimes (page, last_modified) values (?1, ?2)",
             ["streets/gazdagret", &mtime],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }


### PR DESCRIPTION
Similar to commit 285129e831afca301860722cb735b4b4a1b0a783 (wsgi,
missing_housenumbers_view_txt: take osm streets mtime from sql,
2023-12-05).

Change-Id: I9aba1b5c0160203a7ae665258a58d0536ccf10ac
