### PR TITLE
wsgi, missing housenumbers, chkl: take osm housenumbers mtime from sql

### DIFF
--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -637,10 +637,7 @@ fn missing_housenumbers_view_chkl(
     let output: String;
     if !stats::has_sql_mtime(ctx, &format!("streets/{}", relation_name))? {
         output = tr("No existing streets");
-    } else if !ctx
-        .get_file_system()
-        .path_exists(&relation.get_files().get_osm_housenumbers_path())
-    {
+    } else if !stats::has_sql_mtime(ctx, &format!("housenumbers/{}", relation_name))? {
         output = tr("No existing house numbers");
     } else if !ctx
         .get_file_system()

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -1142,6 +1142,11 @@ fn test_missing_housenumbers_view_result_chkl() {
             ["streets/budafok", &mtime],
         )
         .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/budafok", &mtime],
+        )
+        .unwrap();
     }
     let result = test_wsgi.get_txt_for_path("/missing-housenumbers/budafok/view-result.chkl");
     // Note how 12 is ordered after 2.
@@ -1240,6 +1245,11 @@ fn test_missing_housenumbers_view_result_chkl_even_odd() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }
@@ -1391,6 +1401,11 @@ Tűzkő utca	31
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
         )
         .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
+        )
+        .unwrap();
     }
 
     let result = test_wsgi.get_txt_for_path("/missing-housenumbers/gazdagret/view-result.chkl");
@@ -1451,6 +1466,11 @@ fn test_missing_housenumbers_view_result_chkl_no_ref_housenumbers() {
         conn.execute(
             "insert into mtimes (page, last_modified) values (?1, ?2)",
             ["streets/gazdagret", &mtime],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }


### PR DESCRIPTION
Similar to commit 7813b58b3d1470c3c017f44d86c1abfd1e286e1c (wsgi,
missing housenumbers, chkl: take osm streets mtime from sql,
2023-12-07).

Change-Id: Iccd29c3d816ae51478785a31abb5c122e0e60cee
