### PR TITLE
areas: port Relation::is_new() and is_invalid() to sql wrt osm housenumbers

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1544,7 +1544,8 @@ impl<'a> Relations<'a> {
         let osm_housenumber_coverage_exists = relation.has_osm_housenumber_coverage().unwrap();
         let osm_street_coverage_exists = relation.has_osm_street_coverage().unwrap();
         if stats::has_sql_mtime(self.ctx, &format!("streets/{}", relation.get_name())).unwrap()
-            && file_system.path_exists(&files.get_osm_housenumbers_path())
+            && stats::has_sql_mtime(self.ctx, &format!("housenumbers/{}", relation.get_name()))
+                .unwrap()
             && file_system.path_exists(&files.get_ref_streets_path())
             && file_system.path_exists(&files.get_ref_housenumbers_path())
             && osm_street_coverage_exists

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -3684,6 +3684,11 @@ fn test_relations_is_new() {
         )
         .unwrap();
         conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/myrelation", &mtime],
+        )
+        .unwrap();
+        conn.execute(
             r#"insert into osm_housenumber_coverages (relation_name, coverage, last_modified) values (?1, ?2, ?3)"#,
             ["myrelation", "", ""],
         ).unwrap();


### PR DESCRIPTION
Similar to commit 38fbcbf93f7d94dc9019d14b9707305ea55a8052 (areas: port
Relation::is_new() and is_invalid() to sql, 2023-12-11).

Change-Id: I8acdc58fca10ef311cf4bc335fca9bb55fd1d98b
