### PR TITLE
cache: port osm housenumber mtime from csv to sql

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -52,11 +52,13 @@ fn is_missing_housenumbers_json_cached(relation: &mut areas::Relation<'_>) -> an
     let datadir = relation.get_ctx().get_abspath("data");
     let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
     let dependencies = vec![
-        relation.get_files().get_osm_housenumbers_path(),
         relation.get_files().get_ref_housenumbers_path(),
         relation_path,
     ];
-    let sql_dependencies = vec![format!("streets/{}", relation.get_name())];
+    let sql_dependencies = vec![
+        format!("streets/{}", relation.get_name()),
+        format!("housenumbers/{}", relation.get_name()),
+    ];
     is_cache_current(
         relation.get_ctx(),
         &cache_path,
@@ -100,11 +102,13 @@ fn is_additional_housenumbers_json_cached(
     let datadir = relation.get_ctx().get_abspath("data");
     let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
     let dependencies = vec![
-        relation.get_files().get_osm_housenumbers_path(),
         relation.get_files().get_ref_housenumbers_path(),
         relation_path,
     ];
-    let sql_dependencies = vec![format!("streets/{}", relation.get_name())];
+    let sql_dependencies = vec![
+        format!("streets/{}", relation.get_name()),
+        format!("housenumbers/{}", relation.get_name()),
+    ];
     is_cache_current(
         relation.get_ctx(),
         &cache_path,


### PR DESCRIPTION
Similar to commit f0b24c55e97a5e44338d65a53670a6d196899510 (cache: port
osm street mtime from csv to sql, 2023-12-12).

Change-Id: Iaedd63e6e3b3e24b6981130c1879f5dba2448632
