### PR TITLE
Relation::get_osm_streets: port osm housenumbers to sql

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -565,8 +565,7 @@ impl<'a> Relation<'a> {
             street.set_source(&tr("street"));
             ret.push(street)
         }
-        let path = self.file.get_osm_housenumbers_path();
-        if self.ctx.get_file_system().path_exists(&path) {
+        if stats::has_sql_mtime(self.ctx, &format!("housenumbers/{}", self.name))? {
             ret.append(
                 &mut util::get_street_from_housenumber(
                     &self.file.get_osm_json_housenumbers(self.ctx)?,

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -525,6 +525,7 @@ fn test_normalize_separator_comma() {
 #[test]
 fn test_relation_get_osm_streets() {
     let ctx = context::tests::make_test_context().unwrap();
+    let mtime = ctx.get_time().now_string();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute(
@@ -558,6 +559,11 @@ fn test_relation_get_osm_streets() {
             ["test", "3", "", "", "", "", "", "", "", "", "", "", "", "node"],
         )
         .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/test", &mtime],
+        )
+        .unwrap();
     }
     let mut relations = Relations::new(&ctx).unwrap();
     let relation = relations.get_relation("test").unwrap();
@@ -576,11 +582,17 @@ fn test_relation_get_osm_streets() {
 #[test]
 fn test_relation_get_osm_streets_street_is_node() {
     let ctx = context::tests::make_test_context().unwrap();
+    let mtime = ctx.get_time().now_string();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gh830", "3136661536", "Bártfai utca", "52/b", "1115", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gh830", &mtime],
         )
         .unwrap();
     }
@@ -625,11 +637,17 @@ fn test_relation_get_osm_streets_no_house_number() {
 #[test]
 fn test_relation_get_osm_streets_conscriptionnumber() {
     let ctx = context::tests::make_test_context().unwrap();
+    let mtime = ctx.get_time().now_string();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gh754", "295291710", "Barcfa dűlő", "", "8272", "", "", "045/2", "", "", "", "", "Villa Alexandra", "way"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gh754", &mtime],
         )
         .unwrap();
     }
@@ -1530,6 +1548,7 @@ fn test_relation_get_lints() {
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
+    let mtime = ctx.get_time().now_string();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute(
@@ -1570,6 +1589,11 @@ fn test_relation_get_lints() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }
@@ -1621,11 +1645,17 @@ fn test_relation_get_lints_hn_letters() {
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
+    let mtime = ctx.get_time().now_string();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gh964", "1", "", "52/b", "", "Tolvajos tanya", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gh964", &mtime],
         )
         .unwrap();
     }
@@ -1730,6 +1760,7 @@ fn test_relation_write_lints() {
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
+    let mtime = ctx.get_time().now_string();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute(
@@ -1770,6 +1801,11 @@ fn test_relation_write_lints() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }
@@ -1995,11 +2031,17 @@ fn test_relation_get_missing_housenumbers_letter_suffix_normalize() {
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
+    let mtime = ctx.get_time().now_string();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gh286", "460828116", "Királyleányka utca", "10/B", "1112", "", "", "", "", "", "", "", "", "way"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gh286", &mtime],
         )
         .unwrap();
     }
@@ -2068,11 +2110,17 @@ fn test_relation_get_missing_housenumbers_letter_suffix_normalize_semicolon() {
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
+    let mtime = ctx.get_time().now_string();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gh303", "6852648009", "Albert utca", "43/B;43/C", "1119", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gh303", &mtime],
         )
         .unwrap();
     }
@@ -2185,6 +2233,7 @@ fn test_relation_get_additional_streets() {
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
+    let mtime = ctx.get_time().now_string();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute(
@@ -2225,6 +2274,11 @@ fn test_relation_get_additional_streets() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }
@@ -2297,6 +2351,7 @@ fn test_relation_get_additional_housenumbers() {
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
+    let mtime = ctx.get_time().now_string();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute(
@@ -2337,6 +2392,11 @@ fn test_relation_get_additional_housenumbers() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }
@@ -3468,6 +3528,7 @@ fn test_get_invalid_filter_keys() {
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
+    let mtime = ctx.get_time().now_string();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute(
@@ -3508,6 +3569,11 @@ fn test_get_invalid_filter_keys() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -302,6 +302,7 @@ fn test_update_missing_housenumbers() {
     file_system.set_mtimes(&mtimes);
     let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
     ctx.set_file_system(&file_system_rc);
+    let mtime = ctx.get_time().now_string();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute(
@@ -342,6 +343,11 @@ fn test_update_missing_housenumbers() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }
@@ -490,6 +496,7 @@ fn test_update_additional_streets() {
     file_system.set_mtimes(&mtimes);
     let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
     ctx.set_file_system(&file_system_rc);
+    let mtime = ctx.get_time().now_string();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute(
@@ -530,6 +537,11 @@ fn test_update_additional_streets() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -458,6 +458,7 @@ fn test_per_relation_lints() {
     file_system.set_mtimes(&mtimes);
     let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
     test_wsgi.ctx.set_file_system(&file_system_rc);
+    let mtime = test_wsgi.get_ctx().get_time().now_string();
     {
         let conn = test_wsgi.get_ctx().get_database_connection().unwrap();
         conn.execute(
@@ -498,6 +499,11 @@ fn test_per_relation_lints() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }
@@ -569,11 +575,17 @@ fn test_per_relation_lints_out_of_range() {
     file_system.set_mtimes(&mtimes);
     let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
     test_wsgi.ctx.set_file_system(&file_system_rc);
+    let mtime = test_wsgi.get_ctx().get_time().now_string();
     {
         let conn = test_wsgi.get_ctx().get_database_connection().unwrap();
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gh3073", "15812165", "Hadak útja", "5", "1119", "", "", "", "", "", "", "", "Trendo 11 lakópark", "relation"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gh3073", &mtime],
         )
         .unwrap();
     }
@@ -1578,6 +1590,7 @@ fn test_missing_housenumbers_view_turbo_well_formed() {
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     test_wsgi.ctx.set_file_system(&file_system);
+    let mtime = test_wsgi.get_ctx().get_time().now_string();
     {
         let conn = test_wsgi.get_ctx().get_database_connection().unwrap();
         conn.execute(
@@ -1618,6 +1631,11 @@ fn test_missing_housenumbers_view_turbo_well_formed() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }
@@ -1680,6 +1698,7 @@ fn test_missing_housenumbers_update_result_link() {
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     test_wsgi.ctx.set_file_system(&file_system);
+    let mtime = test_wsgi.get_ctx().get_time().now_string();
     {
         let conn = test_wsgi.get_ctx().get_database_connection().unwrap();
         conn.execute(
@@ -1720,6 +1739,11 @@ fn test_missing_housenumbers_update_result_link() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }

--- a/src/wsgi_additional/tests.rs
+++ b/src/wsgi_additional/tests.rs
@@ -114,6 +114,11 @@ fn test_streets_view_result_txt() {
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
         )
         .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
+        )
+        .unwrap();
     }
 
     let result = test_wsgi.get_txt_for_path("/additional-streets/gazdagret/view-result.txt");
@@ -153,6 +158,7 @@ fn test_streets_view_result_gpx() {
     let network_rc: Rc<dyn context::Network> = Rc::new(network);
     test_wsgi.get_ctx().set_network(network_rc);
     test_wsgi.set_content_type("text/gpx+xml; charset=utf-8");
+    let mtime = test_wsgi.get_ctx().get_time().now_string();
     {
         let conn = test_wsgi.get_ctx().get_database_connection().unwrap();
         conn.execute(
@@ -193,6 +199,11 @@ fn test_streets_view_result_gpx() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }
@@ -293,6 +304,11 @@ fn test_streets_view_result_chkl() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }
@@ -519,6 +535,11 @@ fn test_additional_housenumbers_well_formed() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }

--- a/src/wsgi_json/tests.rs
+++ b/src/wsgi_json/tests.rs
@@ -250,6 +250,7 @@ fn test_missing_housenumbers_update_result_json() {
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     test_wsgi.get_ctx().set_file_system(&file_system);
+    let mtime = test_wsgi.get_ctx().get_time().now_string();
     {
         let conn = test_wsgi.get_ctx().get_database_connection().unwrap();
         conn.execute(
@@ -290,6 +291,11 @@ fn test_missing_housenumbers_update_result_json() {
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "8", "Second Only In OSM utca", "1", "", "", "", "", "", "", "", "", "", "node"],
+        )
+        .unwrap();
+        conn.execute(
+            "insert into mtimes (page, last_modified) values (?1, ?2)",
+            ["housenumbers/gazdagret", &mtime],
         )
         .unwrap();
     }

--- a/tests/workdir/street-housenumbers-budafok.csv
+++ b/tests/workdir/street-housenumbers-budafok.csv
@@ -1,2 +1,0 @@
-@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
-

--- a/tests/workdir/street-housenumbers-empty.csv
+++ b/tests/workdir/street-housenumbers-empty.csv
@@ -1,2 +1,0 @@
-@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
-

--- a/tests/workdir/street-housenumbers-gh286.csv
+++ b/tests/workdir/street-housenumbers-gh286.csv
@@ -1,3 +1,0 @@
-@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
-
-460828116	Királyleányka utca	10/B	1112								way

--- a/tests/workdir/street-housenumbers-gh296.csv
+++ b/tests/workdir/street-housenumbers-gh296.csv
@@ -1,2 +1,0 @@
-@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
-

--- a/tests/workdir/street-housenumbers-gh299.csv
+++ b/tests/workdir/street-housenumbers-gh299.csv
@@ -1,3 +1,0 @@
-@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
-
-3136661536	Bártfai utca	52/b	1115								node

--- a/tests/workdir/street-housenumbers-gh303.csv
+++ b/tests/workdir/street-housenumbers-gh303.csv
@@ -1,2 +1,0 @@
-@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
-6852648009	Albert utca	43/B;43/C	1119								node

--- a/tests/workdir/street-housenumbers-gh3073.csv
+++ b/tests/workdir/street-housenumbers-gh3073.csv
@@ -1,2 +1,0 @@
-@id	addr:street	addr:housenumber	addr:postcode	addr:place	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
-15812165	Hadak útja	5	1119								Trendo 11 lakópark	relation

--- a/tests/workdir/street-housenumbers-gh385.csv
+++ b/tests/workdir/street-housenumbers-gh385.csv
@@ -1,2 +1,0 @@
-@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
-

--- a/tests/workdir/street-housenumbers-gh414.csv
+++ b/tests/workdir/street-housenumbers-gh414.csv
@@ -1,2 +1,0 @@
-@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
-

--- a/tests/workdir/street-housenumbers-gh611.csv
+++ b/tests/workdir/street-housenumbers-gh611.csv
@@ -1,3 +1,0 @@
-@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
-
-6852648009	Albert utca	42									node

--- a/tests/workdir/street-housenumbers-gh754.csv
+++ b/tests/workdir/street-housenumbers-gh754.csv
@@ -1,2 +1,0 @@
-@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
-295291710	Barcfa dűlő		8272		045/2					Villa Alexandra	way

--- a/tests/workdir/street-housenumbers-gh830.csv
+++ b/tests/workdir/street-housenumbers-gh830.csv
@@ -1,3 +1,0 @@
-@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
-
-3136661536	Bártfai utca	52/b	1115								node

--- a/tests/workdir/street-housenumbers-gh964.csv
+++ b/tests/workdir/street-housenumbers-gh964.csv
@@ -1,3 +1,0 @@
-@id	addr:street	addr:housenumber	addr:postcode	addr:place	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
-
-3136661536		52/b	1115	Tolvajos tanya								node

--- a/tests/workdir/street-housenumbers-test.csv
+++ b/tests/workdir/street-housenumbers-test.csv
@@ -1,6 +1,0 @@
-@id	addr:street	addr:housenumber	addr:postcode	addr:housename	addr:conscriptionnumber	addr:flats	addr:floor	addr:door	addr:unit	name	@type
-
-0	HB2	HC2									node
-1	HB1	HC1									node
-2		HC0									node
-3											node


### PR DESCRIPTION
Allows getting rid of tests/workdir/street-housenumbers-gh964.csv.

Change-Id: I40615f4189d99a160135317fcacdbfcd40c87756
