### PR TITLE
Update dependencies (2024-01)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.74.0
+          toolchain: 1.75.0
           components: rustfmt, clippy, llvm-tools-preview
           default: true
       - name: Rust Cache
@@ -26,7 +26,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-1.74.0-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-1.75.0-${{ hashFiles('**/Cargo.toml') }}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "ca87830a3e3fb156dc96cfbd31cb620265dd053be734723f22b760d6cc3c3051"
 
 [[package]]
 name = "ascii"
@@ -333,18 +333,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.11"
+version = "4.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
+checksum = "dcfab8ba68f3668e89f6ff60f5b205cea56aa7b769451a59f34b8682f51c056d"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.11"
+version = "4.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -801,18 +801,18 @@ dependencies = [
 
 [[package]]
 name = "git-version"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ad01ffa8221f7fe8b936d6ffb2a3e7ad428885a04fad51866a5f33eafda57c"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
 dependencies = [
  "git-version-macro",
 ]
 
 [[package]]
 name = "git-version-macro"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84488ccbdb24ad6f56dc1863b4a8154a7856cd3c6c7610401634fab3cb588dae"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1236,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl-probe"
@@ -1265,7 +1265,7 @@ version = "7.6.0"
 dependencies = [
  "accept-language",
  "anyhow",
- "clap 4.4.11",
+ "clap 4.4.12",
  "csv",
  "derivative",
  "flate2",
@@ -1763,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
 dependencies = [
  "itoa",
  "ryu",
@@ -1783,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.27"
+version = "0.9.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
+checksum = "a15e0ef66bf939a7c890a0bf6d5a733c70202225f9888a89ed5c62298b019129"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1981,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
  "deranged",
  "itoa",
@@ -2003,9 +2003,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
 dependencies = [
  "time-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,18 +6,18 @@ license = "MIT"
 
 [dependencies]
 accept-language = "3.1.0"
-anyhow = "1.0.75"
-clap = "4.4.11"
+anyhow = "1.0.78"
+clap = "4.4.12"
 csv = "1.3.0"
 derivative = "2.2.0"
 gettext = "0.4.0"
-git-version = "0.3.8"
+git-version = "0.3.9"
 html-escape = "0.2.13"
 html_parser = "0.7.0"
 isahc = "1.7.2"
 lazy_static = "1.4.0"
 log = "0.4.20"
-once_cell = "1.18.0"
+once_cell = "1.19.0"
 regex = "1.10.2"
 rouille = "3.6.2"
 rusqlite = { version = "0.30.0", features = ["bundled"] }
@@ -25,10 +25,10 @@ rust_icu_ucol = { version = "4.2.3", optional = true }
 rust_icu_unumberformatter = { version = "4.2.3", optional = true }
 rust_icu_ustring = { version = "4.2.3", optional = true }
 serde = { version = "1.0.193", features = ["derive"] }
-serde_json = "1.0.108"
-serde_yaml = "0.9.27"
+serde_json = "1.0.109"
+serde_yaml = "0.9.29"
 simplelog = "0.12.1"
-time = { version = "0.3.30", features = ["formatting", "macros", "local-offset", "serde-well-known"] }
+time = { version = "0.3.31", features = ["formatting", "macros", "local-offset", "serde-well-known"] }
 toml = "0.8.8"
 unidecode = "0.3.0"
 url = "2.5.0"

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "license": "MIT",
   "dependencies": {
-    "@types/node": "20.10.3",
-    "@typescript-eslint/eslint-plugin": "6.13.2",
-    "@typescript-eslint/parser": "6.13.2",
+    "@types/node": "20.10.6",
+    "@typescript-eslint/eslint-plugin": "6.16.0",
+    "@typescript-eslint/parser": "6.16.0",
     "chart.js": "4.4.1",
     "chartjs-plugin-datalabels": "2.2.0",
     "chartjs-plugin-trendline": "2.0.5",
     "clean-css-cli": "5.6.3",
-    "eslint": "8.55.0",
+    "eslint": "8.56.0",
     "sorttable": "1.0.2",
     "ts-loader": "9.5.1",
-    "typescript": "5.3.2",
+    "typescript": "5.3.3",
     "webpack": "5.89.0",
     "webpack-cli": "5.1.4"
   },

--- a/src/context/system.rs
+++ b/src/context/system.rs
@@ -46,7 +46,7 @@ impl FileSystem for StdFileSystem {
 
     fn getmtime(&self, path: &str) -> anyhow::Result<time::OffsetDateTime> {
         let metadata = std::fs::metadata(path)?;
-        let modified = time::OffsetDateTime::try_from(metadata.modified()?)?;
+        let modified = time::OffsetDateTime::from(metadata.modified()?);
         Ok(modified.to_offset(get_tz_offset()))
     }
 

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -266,7 +266,7 @@ fn write_city_count_path(
     city_count_path: &str,
     cities: &HashMap<String, HashSet<String>>,
 ) -> anyhow::Result<()> {
-    let mut cities: Vec<_> = cities.iter().map(|(key, value)| (key, value)).collect();
+    let mut cities: Vec<_> = cities.iter().collect();
     // Locale-aware sort, by key.
     cities.sort_by_key(|(key, _value)| util::get_sort_key(key));
     cities.dedup();
@@ -299,7 +299,7 @@ fn write_zip_count_path(
     ctx: &context::Context,
     zips: &HashMap<String, HashSet<String>>,
 ) -> anyhow::Result<()> {
-    let mut zips: Vec<_> = zips.iter().map(|(key, value)| (key, value)).collect();
+    let mut zips: Vec<_> = zips.iter().collect();
     zips.sort_by_key(|(key, _value)| key.to_string());
     zips.dedup();
 
@@ -399,7 +399,7 @@ fn update_stats_topusers(ctx: &context::Context, today: &str) -> anyhow::Result<
         }
     }
     {
-        let mut users: Vec<_> = users.iter().map(|(key, value)| (key, value)).collect();
+        let mut users: Vec<_> = users.iter().collect();
         users.sort_by_key(|i| Reverse(i.1));
         users.dedup();
         users = users[0..std::cmp::min(20, users.len())].to_vec();

--- a/src/parse_access_log.rs
+++ b/src/parse_access_log.rs
@@ -88,7 +88,7 @@ fn get_frequent_relations(
         let entry = counts.entry(relation_name).or_insert(0);
         (*entry) += 1;
     }
-    let mut count_list: Vec<_> = counts.iter().map(|(key, value)| (key, value)).collect();
+    let mut count_list: Vec<_> = counts.iter().collect();
     // Reverse, by value.
     count_list.sort_by(|a, b| b.1.cmp(a.1));
 


### PR DESCRIPTION
And fix what the new
<https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_fallible_conversions>
finds.

Change-Id: I298b6f2e6872bed4103637a59ad807dc1974d78b
