### PR TITLE
stats: fix handle_capital_progress()

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -100,7 +100,7 @@ fn handle_capital_progress(
         let mut csv_reader = util::make_csv_reader(&mut read);
         for result in csv_reader.deserialize() {
             let row: util::CityCount = result?;
-            if row.city.starts_with("budapest_") {
+            if row.city.starts_with("Budapest_") {
                 osm_count += row.count;
             }
         }

--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -79,8 +79,8 @@ fn test_handle_capital_progress() {
     file_system
         .write_from_string(
             r#"CITY	CNT
-budapest_02	200
-budapest_11	11
+Budapest_02	200
+Budapest_11	11
 	42
 "#,
             &ctx.get_abspath("workdir/stats/2020-05-10.citycount"),


### PR DESCRIPTION
OSM names are not converted to lowercase(), the CITY column of the ref
names still do that.

Fixes the empty green part of
/housenumber-stats/whole-country/#_capital-progress.

Change-Id: I01aaec0f642f8e526a8d57029c93e2341a453a0b
