### PR TITLE
stats: use execute_batch() in test_handle_topcities()

### DIFF
--- a/src/stats/tests.rs
+++ b/src/stats/tests.rs
@@ -170,29 +170,12 @@ fn test_handle_topcities() {
     let ctx = context::tests::make_test_context().unwrap();
     {
         let conn = ctx.get_database_connection().unwrap();
-        conn.execute(
-            r#"insert into stats_citycounts (date, city, count) values (?1, ?2, ?3)"#,
-            ["2020-04-10", "budapest_01", "10"],
-        )
-        .unwrap();
-        conn.execute(
-            r#"insert into stats_citycounts (date, city, count) values (?1, ?2, ?3)"#,
-            ["2020-04-10", "budapest_02", "10"],
-        )
-        .unwrap();
-        conn.execute(
-            r#"insert into stats_citycounts (date, city, count) values (?1, ?2, ?3)"#,
-            ["2020-05-10", "budapest_01", "100"],
-        )
-        .unwrap();
-        conn.execute(
-            r#"insert into stats_citycounts (date, city, count) values (?1, ?2, ?3)"#,
-            ["2020-05-10", "budapest_02", "200"],
-        )
-        .unwrap();
-        conn.execute(
-            r#"insert into stats_citycounts (date, city, count) values (?1, ?2, ?3)"#,
-            ["2020-05-10", "budapest_03", "300"],
+        conn.execute_batch(
+            "insert into stats_citycounts (date, city, count) values ('2020-04-10', 'budapest_01', '10');
+             insert into stats_citycounts (date, city, count) values ('2020-04-10', 'budapest_02', '10');
+             insert into stats_citycounts (date, city, count) values ('2020-05-10', 'budapest_01', '100');
+             insert into stats_citycounts (date, city, count) values ('2020-05-10', 'budapest_02', '200');
+             insert into stats_citycounts (date, city, count) values ('2020-05-10', 'budapest_03', '300');"
         )
         .unwrap();
     }


### PR DESCRIPTION
git grep 'conn.execute(' src/*/tests.rs

shows 480 other places where this could be done, do it only at a single
place as a start, because it's a more compact way of seeding the DB.

Change-Id: I00de45b5318c404c328b67cfa3bb8bb40ddffb73
