### PR TITLE
cron: stop writing .citycount files

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -422,9 +422,7 @@ pub struct CityCount {
     /// Reference count of all housenumbers.
     #[serde(rename = "CNT")]
     pub count: u64,
-    /// Original city name.
-    ///
-    /// Missing for workdir/stats/<DATE>.citycount files.
+    /// Original city name, not lowercase.
     #[serde(rename = "ORIG")]
     pub orig: Option<String>,
 }


### PR DESCRIPTION
Nobody reads them, SQL is used instead.

Change-Id: I318c7e2307cb43633679dbfc2353dae30949dbef
