### PR TITLE
areas, osm housenumber split: handle ','

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -643,7 +643,7 @@ impl<'a> Relation<'a> {
                         street = value;
                     }
                 }
-                for house_number in row.housenumber.split(';') {
+                for house_number in row.housenumber.split(&[';', ',']) {
                     house_numbers
                         .entry(street.to_string())
                         .or_default()


### PR DESCRIPTION
The osm housenumber string was split by ';' already, no reason to not do
the same for ',' as well.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/3558>.

Change-Id: Ic9766a3540f058b4bb373a9cf7a65bdf66baf909
