### PR TITLE
additional street counts: start tracking these in sql as well

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1073,12 +1073,15 @@ impl<'a> Relation<'a> {
     pub fn write_additional_streets(&self) -> anyhow::Result<Vec<util::Street>> {
         let additional_streets = self.get_additional_streets(/*sorted_result=*/ true)?;
 
-        // Write the count to a file, so the index page show it fast.
+        // Remember the count, so the index page show it fast.
+        // Old style: file.
         let file = &self.file;
         self.ctx.get_file_system().write_from_string(
             &additional_streets.len().to_string(),
             &file.get_streets_additional_count_path(),
         )?;
+        // New style: SQL.
+        stats::set_sql_count(self.ctx, &self.name, additional_streets.len())?;
 
         Ok(additional_streets)
     }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -237,7 +237,21 @@ pub fn init(conn: &rusqlite::Connection) -> anyhow::Result<()> {
             [],
         )?;
     }
-    conn.execute("pragma user_version = 12", [])?;
+
+    if user_version < 13 {
+        // Tracks the number of additional streets for a relation.
+        conn.execute_batch(
+            "create table additional_streets_counts (
+                    relation text not null,
+                    count text not null,
+                    unique(relation)
+                );
+            create index idx_additional_streets_counts
+                on additional_streets_counts(relation);",
+        )?;
+    }
+
+    conn.execute("pragma user_version = 13", [])?;
     Ok(())
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -494,6 +494,16 @@ pub fn has_sql_mtime(ctx: &context::Context, page: &str) -> anyhow::Result<bool>
     Ok(rows.next()?.is_some())
 }
 
+pub fn set_sql_count(ctx: &context::Context, relation: &str, count: usize) -> anyhow::Result<()> {
+    let conn = ctx.get_database_connection()?;
+    conn.execute(
+        r#"insert into additional_streets_counts (relation, count) values (?1, ?2)
+             on conflict(relation) do update set count = excluded.count"#,
+        [relation, &count.to_string()],
+    )?;
+    Ok(())
+}
+
 pub fn update_invalid_addr_cities(ctx: &context::Context, state_dir: &str) -> anyhow::Result<()> {
     info!("stats: updating invalid_addr_cities");
     let valid_settlements =


### PR DESCRIPTION
This deprecates workdir/<relation>-additional-streets.count files.

Change-Id: If780b19ed3619efe808f5a0d221b35fc9ee6d8db
