### PR TITLE
additional street counts: port the web UI to SQL

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -142,11 +142,6 @@ impl RelationFiles {
         format!("{}/additional-cache-{}.json", self.workdir, self.name)
     }
 
-    /// Builds the file name of the street additional count file of a relation.
-    pub fn get_streets_additional_count_path(&self) -> String {
-        format!("{}/{}-additional-streets.count", self.workdir, self.name)
-    }
-
     /// Builds the file name of the housenumber additional count file of a relation.
     pub fn get_housenumbers_additional_count_path(&self) -> String {
         format!(

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1073,14 +1073,7 @@ impl<'a> Relation<'a> {
     pub fn write_additional_streets(&self) -> anyhow::Result<Vec<util::Street>> {
         let additional_streets = self.get_additional_streets(/*sorted_result=*/ true)?;
 
-        // Remember the count, so the index page show it fast.
-        // Old style: file.
-        let file = &self.file;
-        self.ctx.get_file_system().write_from_string(
-            &additional_streets.len().to_string(),
-            &file.get_streets_additional_count_path(),
-        )?;
-        // New style: SQL.
+        // Remember the count, so the index page can show it fast.
         stats::set_sql_count(self.ctx, &self.name, additional_streets.len())?;
 
         Ok(additional_streets)

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -504,6 +504,16 @@ pub fn set_sql_count(ctx: &context::Context, relation: &str, count: usize) -> an
     Ok(())
 }
 
+pub fn get_sql_count(ctx: &context::Context, relation: &str) -> anyhow::Result<String> {
+    let conn = ctx.get_database_connection()?;
+    let mut stmt =
+        conn.prepare("select count from additional_streets_counts where relation = ?1")?;
+    let mut rows = stmt.query([relation])?;
+    let row = rows.next()?.context("no count")?;
+    let count: String = row.get(0)?;
+    Ok(count)
+}
+
 pub fn has_sql_count(ctx: &context::Context, relation: &str) -> anyhow::Result<bool> {
     let conn = ctx.get_database_connection()?;
     let mut stmt =

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1028,15 +1028,13 @@ fn handle_main_street_additional_count(
         relation.get_name()
     );
     let mut additional_count: String = "".into();
-    let files = relation.get_files();
-    let path = files.get_streets_additional_count_path();
-    if ctx.get_file_system().path_exists(&path) {
-        additional_count = ctx.get_file_system().read_to_string(&path)?;
+    if stats::has_sql_count(ctx, &relation.get_name())? {
+        additional_count = stats::get_sql_count(ctx, &relation.get_name())?;
     }
 
     let doc = yattag::Doc::new();
     if !additional_count.is_empty() {
-        let date = get_last_modified(ctx, &path)?;
+        let date = webframe::format_timestamp(&relation.get_osm_street_coverage_mtime()?)?;
         let strong = doc.tag("strong", &[]);
         let a = strong.tag(
             "a",


### PR DESCRIPTION
Can now remove workdir/<relation>-additional-streets.count files.

Change-Id: I28b42ea655323ecaac4f88c993163b1fc8f5ecbf
