### PR TITLE
areas: take ref streets directly from sql

### DIFF
--- a/guide/src/hacking.md
+++ b/guide/src/hacking.md
@@ -45,7 +45,7 @@ make
 To run a single test:
 
 ```bash
-cargo test --lib -- --exact --nocapture wsgi_json::tests::test_missing_streets_update_result_json
+RUST_BACKTRACE=1 cargo test --lib -- --exact --nocapture wsgi_json::tests::test_missing_streets_update_result_json
 ```
 
 Tests follow the [Favor real dependencies for unit

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -153,35 +153,6 @@ fn update_ref_housenumbers(
     Ok(())
 }
 
-/// Update the reference street list of all relations.
-fn update_ref_streets(
-    ctx: &context::Context,
-    relations: &mut areas::Relations<'_>,
-    update: bool,
-) -> anyhow::Result<()> {
-    for relation_name in relations.get_active_names()? {
-        let relation = relations.get_relation(&relation_name)?;
-        if !update
-            && ctx
-                .get_file_system()
-                .path_exists(&relation.get_files().get_ref_streets_path())
-        {
-            continue;
-        }
-        let reference = ctx.get_ini().get_reference_street_path()?;
-        let streets = relation.get_config().should_check_missing_streets();
-        if streets == "no" {
-            continue;
-        }
-
-        info!("update_ref_streets: start: {relation_name}");
-        relation.write_ref_streets(&reference)?;
-        info!("update_ref_streets: end: {relation_name}");
-    }
-
-    Ok(())
-}
-
 /// Update the relation's house number coverage stats.
 fn update_missing_housenumbers(
     relations: &mut areas::Relations<'_>,
@@ -503,7 +474,6 @@ fn our_main_inner(
     if mode == "all" || mode == "relations" {
         update_osm_streets(ctx, relations, update)?;
         update_osm_housenumbers(ctx, relations, update)?;
-        update_ref_streets(ctx, relations, update)?;
         update_ref_housenumbers(ctx, relations, update)?;
         update_missing_streets(relations, update)?;
         update_missing_housenumbers(relations, update)?;

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -822,12 +822,6 @@ fn handle_invalid_refstreets(
         if !stats::has_sql_mtime(ctx, &format!("streets/{}", relation.get_name())).unwrap() {
             continue;
         }
-        if !ctx
-            .get_file_system()
-            .path_exists(&relation.get_files().get_ref_streets_path())
-        {
-            continue;
-        }
         let (osm_invalids, ref_invalids) = relation
             .get_invalid_refstreets()
             .context("get_invalid_refstreets() failed")?;
@@ -1240,26 +1234,6 @@ pub fn handle_no_ref_housenumbers(prefix: &str, relation_name: &str) -> yattag::
         (
             "str-reference-wait",
             tr("No reference house numbers: creating from reference..."),
-        ),
-        ("str-reference-error", tr("Error from reference: ")),
-    ];
-    emit_l10n_strings_for_js(&doc, string_pairs);
-    doc
-}
-
-/// Handles the no-ref-streets error on a page using JS.
-pub fn handle_no_ref_streets(prefix: &str, relation_name: &str) -> yattag::Doc {
-    let doc = yattag::Doc::new();
-    let link = format!("{prefix}/missing-streets/{relation_name}/update-result");
-    {
-        let div = doc.tag("div", &[("id", "no-ref-streets")]);
-        let a = div.tag("a", &[("href", &link)]);
-        a.text(&tr("No street list: create from reference..."));
-    }
-    let string_pairs = &[
-        (
-            "str-reference-wait",
-            tr("No reference streets: creating from reference..."),
         ),
         ("str-reference-error", tr("Error from reference: ")),
     ];

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -616,6 +616,8 @@ fn test_missing_housenumbers_well_formed() {
             },
         },
         "relation-gazdagret.yaml": {
+            "refcounty": "01",
+            "refsettlement": "011",
             "refstreets": {
                 "Misspelled OSM Name 1": "OSM Name 1",
             },
@@ -2018,6 +2020,8 @@ fn test_missing_streets_well_formed() {
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
+                "refcounty": "01",
+                "refsettlement": "011",
                 "osmrelation": 42,
             },
         },
@@ -2086,6 +2090,8 @@ fn test_missing_streets_well_formed_compat() {
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
+                "refcounty": "01",
+                "refsettlement": "011",
                 "osmrelation": 42,
             },
         },
@@ -2161,66 +2167,6 @@ fn test_missing_streets_no_osm_streets_well_formed() {
     assert_eq!(results.len(), 1);
 }
 
-/// Tests the missing streets page: if the output is well-formed, no ref streets case.
-#[test]
-fn test_missing_streets_no_ref_streets_well_formed() {
-    let mut test_wsgi = TestWsgi::new();
-    let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
-    let relation = relations.get_relation("gazdagret").unwrap();
-    let hide_path = relation.get_files().get_ref_streets_path();
-    let mut file_system = context::tests::TestFileSystem::new();
-    file_system.set_hide_paths(&[hide_path]);
-    let yamls_cache = serde_json::json!({
-        "relations.yaml": {
-            "gazdagret": {
-                "osmrelation": 2713748,
-            },
-        },
-    });
-    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
-    let files = context::tests::TestFileSystem::make_files(
-        &test_wsgi.ctx,
-        &[("data/yamls.cache", &yamls_cache_value)],
-    );
-    file_system.set_files(&files);
-    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_rc);
-    let mtime = test_wsgi.get_ctx().get_time().now_string();
-    {
-        let conn = test_wsgi.ctx.get_database_connection().unwrap();
-        conn.execute(
-            r#"insert into osm_streets (relation, osm_id, name, highway, service, surface, leisure, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"#,
-            ["gazdagret", "1", "Tűzkő utca", "", "", "", "", ""],
-        )
-        .unwrap();
-        conn.execute(
-            r#"insert into osm_streets (relation, osm_id, name, highway, service, surface, leisure, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"#,
-            ["gazdagret", "2", "Törökugrató utca", "", "", "", "", ""],
-        )
-        .unwrap();
-        conn.execute(
-            r#"insert into osm_streets (relation, osm_id, name, highway, service, surface, leisure, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"#,
-            ["gazdagret", "3", "OSM Name 1", "", "", "", "", ""],
-        )
-        .unwrap();
-        conn.execute(
-            r#"insert into osm_streets (relation, osm_id, name, highway, service, surface, leisure, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"#,
-            ["gazdagret", "4", "Hamzsabégi út", "", "", "", "", ""],
-        )
-        .unwrap();
-        conn.execute(
-            "insert into mtimes (page, last_modified) values (?1, ?2)",
-            ["streets/gazdagret", &mtime],
-        )
-        .unwrap();
-    }
-
-    let root = test_wsgi.get_dom_for_path("/missing-streets/gazdagret/view-result");
-
-    let results = TestWsgi::find_all(&root, "body/div[@id='no-ref-streets']");
-    assert_eq!(results.len(), 1);
-}
-
 /// Tests the missing streets page: the txt output.
 #[test]
 fn test_missing_streets_view_result_txt() {
@@ -2228,6 +2174,8 @@ fn test_missing_streets_view_result_txt() {
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
+                "refcounty": "01",
+                "refsettlement": "011",
                 "osmrelation": 42,
             },
         },
@@ -2286,6 +2234,8 @@ fn test_missing_streets_view_result_chkl() {
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
+                "refcounty": "01",
+                "refsettlement": "011",
                 "osmrelation": 42,
             },
         },
@@ -2346,37 +2296,6 @@ fn test_missing_streets_view_result_txt_no_osm_streets() {
     let result = test_wsgi.get_txt_for_path("/missing-streets/gazdagret/view-result.txt");
 
     assert_eq!(result, "No existing streets");
-}
-
-/// Tests the missing streets page: the txt output, no ref streets case.
-#[test]
-fn test_missing_streets_view_result_txt_no_ref_streets() {
-    let mut test_wsgi = TestWsgi::new();
-    let mut relations = areas::Relations::new(&test_wsgi.ctx).unwrap();
-    let relation = relations.get_relation("gazdagret").unwrap();
-    let hide_path = relation.get_files().get_ref_streets_path();
-    let mut file_system = context::tests::TestFileSystem::new();
-    file_system.set_hide_paths(&[hide_path]);
-    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
-    test_wsgi.ctx.set_file_system(&file_system_rc);
-    let mtime = test_wsgi.get_ctx().get_time().now_string();
-    {
-        let conn = test_wsgi.ctx.get_database_connection().unwrap();
-        conn.execute(
-            r#"insert into osm_streets (relation, osm_id, name, highway, service, surface, leisure, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"#,
-            ["gazdagret", "1", "my street", "", "", "", "", ""],
-        )
-        .unwrap();
-        conn.execute(
-            "insert into mtimes (page, last_modified) values (?1, ?2)",
-            ["streets/gazdagret", &mtime],
-        )
-        .unwrap();
-    }
-
-    let result = test_wsgi.get_txt_for_path("/missing-streets/gazdagret/view-result.txt");
-
-    assert_eq!(result, "No reference streets");
 }
 
 /// Tests the missing streets page: if the view-query output is well-formed.
@@ -2879,6 +2798,8 @@ fn test_handle_invalid_refstreets() {
             },
         },
         "relation-gazdagret.yaml": {
+            "refcounty": "01",
+            "refsettlement": "011",
             "refstreets": {
                 "Misspelled OSM Name 1": "OSM Name 1",
             },

--- a/src/wsgi_additional.rs
+++ b/src/wsgi_additional.rs
@@ -145,14 +145,8 @@ pub fn additional_streets_view_txt(
         .get_relation(relation_name)
         .context("get_relation() failed")?;
 
-    let output: String;
-    if !stats::has_sql_mtime(ctx, &format!("streets/{}", relation_name))? {
-        output = tr("No existing streets");
-    } else if !ctx
-        .get_file_system()
-        .path_exists(&relation.get_files().get_ref_streets_path())
-    {
-        output = tr("No reference streets");
+    let output: String = if !stats::has_sql_mtime(ctx, &format!("streets/{}", relation_name))? {
+        tr("No existing streets")
     } else {
         let mut streets = relation.get_additional_streets(/*sorted_result=*/ true)?;
         streets.sort_by_key(|street| util::get_sort_key(street.get_osm_name()));
@@ -164,8 +158,8 @@ pub fn additional_streets_view_txt(
                 lines.push(format!("{}\n", street.get_osm_name()));
             }
         }
-        output = lines.join("");
-    }
+        lines.join("")
+    };
     Ok((output, relation_name.into()))
 }
 
@@ -184,8 +178,6 @@ pub fn additional_streets_view_result(
     let prefix = ctx.get_ini().get_uri_prefix();
     if !stats::has_sql_mtime(ctx, &format!("streets/{}", relation_name))? {
         doc.append_value(webframe::handle_no_osm_streets(&prefix, relation_name).get_value());
-    } else if !stats::has_sql_mtime(ctx, &format!("housenumbers/{}", relation_name))? {
-        doc.append_value(webframe::handle_no_ref_streets(&prefix, relation_name).get_value());
     } else {
         // Get "only in OSM" streets.
         let mut streets = relation.write_additional_streets()?;


### PR DESCRIPTION
This deprecates workdir/streets-reference-<relation>.lst files. We still
write them, but they are no longer read.

23 tests failed:

- areas::tests::test_relation_get_additional_streets: missing refcounty
  / refsettlement in test data
- test_relation_get_missing_streets: same
- test_relation_get_ref_streets: same
- areas::tests::test_relations_is_inactive: same
- areas::tests::test_relations_is_inactive_no_ref_streets: removed, ref
  streets are now always available
- areas::tests::test_write_missing_streets_empty: set refcounty and
  refsettlement to something non-existing
- wsgi_additional::tests::test_streets_street_from_housenr_well_formed:
  same
- cron::tests::test_our_main: update_ref_streets() is removed.
- wsgi::tests::test_handle_invalid_refstreets: missing refcounty /
  refsettlement in test data
- wsgi::tests::test_missing_housenumbers_well_formed: same
- wsgi::tests::test_missing_streets_no_ref_streets_well_formed: removed,
  ref streets are now always available
- wsgi::tests::test_missing_streets_view_result_txt_no_ref_streets: same
- wsgi_additional::tests::test_streets_no_ref_streets_well_formed: same
- wsgi_additional::tests::test_streets_view_result_txt_no_ref_streets:
  same
- wsgi::tests::test_missing_streets_view_result_chkl: missing refcounty
  / refsettlement in test data
- wsgi::tests::test_missing_streets_view_result_txt: same
- wsgi::tests::test_missing_streets_well_formed: same
- wsgi::tests::test_missing_streets_well_formed_compat: same
- wsgi_additional::tests::test_streets_view_result_chkl: same
- wsgi_additional::tests::test_streets_view_result_gpx: same
- wsgi_additional::tests::test_streets_view_result_txt: same
- wsgi_additional::tests::test_streets_view_turbo_well_formed: same
- wsgi_additional::tests::test_streets_well_formed: same

Change-Id: I685f0ca76dfbd727f349a4aac0bf859c11d18bc9
