### PR TITLE
New /lints/whole-country/invalid-addr-cities/update-result endpoint

### DIFF
--- a/po/hu/osm-gimmisn.po
+++ b/po/hu/osm-gimmisn.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: osm-gimmisn\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 19:21+0000\n"
-"PO-Revision-Date: 2023-11-24 20:21+0100\n"
+"POT-Creation-Date: 2024-03-03 13:19+0000\n"
+"PO-Revision-Date: 2024-03-03 14:20+0100\n"
 "Last-Translator: Miklos Vajna <osm-gimmisn@vmiklos.hu>\n"
 "Language-Team: Hungarian\n"
 "Language: hu\n"
@@ -17,31 +17,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/areas.rs:582
+#: src/areas.rs:565
 msgid "street"
 msgstr "utca"
 
-#: src/areas.rs:1131 src/wsgi.rs:462 src/wsgi_additional.rs:206
+#: src/areas.rs:1086 src/wsgi.rs:471 src/wsgi_additional.rs:190
 msgid "Street name"
 msgstr "Utcanév"
 
-#: src/areas.rs:1132
+#: src/areas.rs:1087
 msgid "Missing count"
 msgstr "Hiányzik db"
 
-#: src/areas.rs:1133
+#: src/areas.rs:1088
 msgid "House numbers"
 msgstr "Házszámok"
 
-#: src/util.rs:739
+#: src/util.rs:737
 msgid "Overpass error: {0}"
 msgstr "Overpass hiba: {0}"
 
-#: src/util.rs:743
+#: src/util.rs:741
 msgid "Note: wait for {} seconds"
 msgstr "Megjegyzés: {} másodperc várakozás szükséges"
 
-#: src/util.rs:845
+#: src/util.rs:843
 msgid ""
 "Warning: broken OSM <-> reference mapping, the following OSM names are "
 "invalid:"
@@ -49,7 +49,7 @@ msgstr ""
 "Figyelem: sérült OSM <-> referencia hozzárendelés, a következő OSM nevek "
 "érvénytelenek:"
 
-#: src/util.rs:857
+#: src/util.rs:855
 msgid ""
 "Warning: broken OSM <-> reference mapping, the following reference names are "
 "invalid:"
@@ -57,12 +57,12 @@ msgstr ""
 "Figyelem: sérült OSM <-> referencia hozzárendelés, a következő referencia "
 "nevek érvénytelenek:"
 
-#: src/util.rs:868
+#: src/util.rs:866
 msgid "Note: an OSM name is invalid if it's not in the OSM database. "
 msgstr ""
 "Megjegyzés: egy OSM név érvénytelen ha nem szerepel az OSM adatbázisban. "
 
-#: src/util.rs:871
+#: src/util.rs:869
 msgid ""
 "A reference name is invalid if it's in the OSM database or it's not in the "
 "reference."
@@ -70,146 +70,146 @@ msgstr ""
 "Egy referencia név érvénytelen ha szerepel az OSM adatbázisban vagy ha nem "
 "szerepel a referenciában."
 
-#: src/util.rs:884
+#: src/util.rs:882
 msgid ""
 "Warning: broken filter key name, the following key names are not OSM names:"
 msgstr ""
 "Figyelem: sérült szűrő kulcs név, a következő kulcs nevek nem OSM nevek:"
 
-#: src/util.rs:1056
+#: src/util.rs:1069
 msgid "housenumber"
 msgstr "házszám"
 
-#: src/webframe.rs:32
+#: src/webframe.rs:33
 msgid "Version: "
 msgstr "Verzió: "
 
-#: src/webframe.rs:42
+#: src/webframe.rs:43
 msgid "OSM data © OpenStreetMap contributors."
 msgstr "OSM adatok © OpenStreetMap közreműködők."
 
-#: src/webframe.rs:46
+#: src/webframe.rs:47
 msgid "Last update: "
 msgstr "Utolsó frissítés: "
 
-#: src/webframe.rs:89 src/webframe.rs:123
+#: src/webframe.rs:90 src/webframe.rs:124
 msgid "Update from OSM"
 msgstr "Frissítés OSM-ből"
 
-#: src/webframe.rs:105 src/webframe.rs:139
+#: src/webframe.rs:106
 msgid "Update from reference"
 msgstr "Frissítés referenciából"
 
-#: src/webframe.rs:155 src/webframe.rs:183
+#: src/webframe.rs:140 src/webframe.rs:168
 msgid "Call Overpass to update"
 msgstr "Frissítés Overpass hívásával"
 
-#: src/webframe.rs:168 src/webframe.rs:196
+#: src/webframe.rs:153 src/webframe.rs:181
 msgid "View query"
 msgstr "Lekérdezés megtekintése"
 
-#: src/webframe.rs:223
+#: src/webframe.rs:208
 msgid "Missing house numbers"
 msgstr "Hiányzó házszámok"
 
-#: src/webframe.rs:237 src/wsgi.rs:1437
+#: src/webframe.rs:222 src/wsgi.rs:1385
 msgid "Additional house numbers"
 msgstr "További házszámok"
 
-#: src/webframe.rs:252
+#: src/webframe.rs:237
 msgid "Missing streets"
 msgstr "Hiányzó utcák"
 
-#: src/webframe.rs:264 src/wsgi.rs:1439
+#: src/webframe.rs:249 src/wsgi.rs:1387
 msgid "Additional streets"
 msgstr "További utcák"
 
-#: src/webframe.rs:290
+#: src/webframe.rs:275
 msgid "Existing house numbers"
 msgstr "Meglévő házszámok"
 
-#: src/webframe.rs:304
+#: src/webframe.rs:289
 msgid "Existing streets"
 msgstr "Meglévő utcák"
 
-#: src/webframe.rs:344
+#: src/webframe.rs:329
 msgid "Area list"
 msgstr "Területek listája"
 
-#: src/webframe.rs:367 src/wsgi.rs:1334
+#: src/webframe.rs:352 src/wsgi.rs:1282
 msgid "Waiting for Overpass..."
 msgstr "Overpass: várakozás..."
 
-#: src/webframe.rs:368 src/webframe.rs:1206 src/webframe.rs:1227
-#: src/wsgi.rs:1335
+#: src/webframe.rs:353 src/webframe.rs:1216 src/webframe.rs:1237
+#: src/wsgi.rs:1283
 msgid "Error from Overpass: "
 msgstr "Overpass hiba: "
 
-#: src/webframe.rs:371
+#: src/webframe.rs:356
 msgid "Creating from reference..."
 msgstr "Létrehozás referenciából..."
 
-#: src/webframe.rs:373 src/webframe.rs:1248 src/webframe.rs:1268
+#: src/webframe.rs:358 src/webframe.rs:1258
 msgid "Error from reference: "
 msgstr "Hiba a referenciától: "
 
-#: src/webframe.rs:379
+#: src/webframe.rs:364
 msgid "Overpass turbo"
 msgstr "Overpass turbo"
 
-#: src/webframe.rs:393 src/wsgi.rs:1440
+#: src/webframe.rs:378 src/wsgi.rs:1388
 msgid "Area boundary"
 msgstr "Terület határa"
 
-#: src/webframe.rs:406
+#: src/webframe.rs:391
 msgid "Statistics"
 msgstr "Statisztikák"
 
-#: src/webframe.rs:419
+#: src/webframe.rs:404
 msgid "Lints"
 msgstr "Ellenőrző eszközök"
 
-#: src/webframe.rs:425
+#: src/webframe.rs:410
 msgid "https://vmiklos.hu/osm-gimmisn"
 msgstr "https://wiki.openstreetmap.org/wiki/Hungary/osm-gimmisn"
 
-#: src/webframe.rs:426
+#: src/webframe.rs:411
 msgid "Documentation"
 msgstr "Dokumentáció"
 
-#: src/webframe.rs:501
+#: src/webframe.rs:486
 msgid "Internal error when serving {0}"
 msgstr "Belső hiba a {0} kiszolgálása során"
 
-#: src/webframe.rs:522
+#: src/webframe.rs:507
 msgid "Not Found"
 msgstr "Nem található"
 
-#: src/webframe.rs:526
+#: src/webframe.rs:511
 msgid "The requested URL was not found on this server."
 msgstr "A kért URL nem található ezen a kiszolgálón."
 
-#: src/webframe.rs:592 src/webframe.rs:931
+#: src/webframe.rs:576 src/webframe.rs:937
 msgid "City name"
 msgstr "Város neve"
 
-#: src/webframe.rs:593 src/webframe.rs:682 src/wsgi.rs:1436
+#: src/webframe.rs:577 src/webframe.rs:666 src/wsgi.rs:1384
 msgid "House number coverage"
 msgstr "Házszám lefedettség"
 
-#: src/webframe.rs:594 src/webframe.rs:683
+#: src/webframe.rs:578 src/webframe.rs:667
 msgid "OSM count"
 msgstr "OSM szám"
 
-#: src/webframe.rs:595 src/webframe.rs:684
+#: src/webframe.rs:579 src/webframe.rs:668
 msgid "Reference count"
 msgstr "Referencia szám"
 
-#: src/webframe.rs:616 src/webframe.rs:707 src/webframe.rs:1041
+#: src/webframe.rs:600 src/webframe.rs:691 src/webframe.rs:1047
 msgid "Note"
 msgstr "Megjegyzés"
 
-#: src/webframe.rs:621
+#: src/webframe.rs:605
 msgid ""
 "These statistics are estimates, not taking house number filters into "
 "account.\n"
@@ -218,11 +218,11 @@ msgstr ""
 "Ezek a statisztikák becslések, nem véve figyelembe a házszám szűrőket.\n"
 "Csak olyan városok szerepelnek benne, amiknek van az OSM-ben házszámuk."
 
-#: src/webframe.rs:681
+#: src/webframe.rs:665
 msgid "ZIP code"
 msgstr "Irányítószám"
 
-#: src/webframe.rs:712
+#: src/webframe.rs:696
 msgid ""
 "These statistics are estimates, not taking house number filters into "
 "account.\n"
@@ -232,204 +232,212 @@ msgstr ""
 "Csak olyan irányítószámok szerepelnek benne, amiknek van az OSM-ben "
 "házszámuk."
 
-#: src/webframe.rs:747 src/wsgi.rs:241 src/wsgi_additional.rs:203
+#: src/webframe.rs:731 src/wsgi.rs:267 src/wsgi_additional.rs:187
 msgid "Identifier"
 msgstr "Azonosító"
 
-#: src/webframe.rs:748 src/wsgi.rs:242 src/wsgi_additional.rs:204
+#: src/webframe.rs:732 src/wsgi.rs:268 src/wsgi_additional.rs:188
 msgid "Type"
 msgstr "Típus"
 
-#: src/webframe.rs:749
+#: src/webframe.rs:733
 msgid "Postcode"
 msgstr "Irányítószám"
 
-#: src/webframe.rs:750
+#: src/webframe.rs:734
 msgid "City"
 msgstr "Város"
 
-#: src/webframe.rs:751 src/wsgi.rs:237
+#: src/webframe.rs:735 src/wsgi.rs:263
 msgid "Street"
 msgstr "Utca"
 
-#: src/webframe.rs:752 src/wsgi.rs:239
+#: src/webframe.rs:736 src/wsgi.rs:265
 msgid "Housenumber"
 msgstr "Házszám"
 
-#: src/webframe.rs:753
+#: src/webframe.rs:737
 msgid "User"
 msgstr "Felhasználó neve"
 
-#: src/webframe.rs:754
+#: src/webframe.rs:738
 msgid "Timestamp"
 msgstr "Időbélyeg"
 
-#: src/webframe.rs:755
+#: src/webframe.rs:739
 msgid "Fixme"
 msgstr "Javíts ki (fixme)"
 
-#: src/webframe.rs:794
+#: src/webframe.rs:778
 msgid ""
 "The addr:city key of the below {0} objects probably has an invalid value."
 msgstr ""
 "Az alábbi {0} objektum addr:city kulcsának értéke valószínűleg érvénytelen."
 
-#: src/webframe.rs:899
+#: src/webframe.rs:809 src/wsgi.rs:92 src/wsgi.rs:170 src/wsgi.rs:699
+msgid "Update successful: "
+msgstr "Frissítés sikeres: "
+
+#: src/webframe.rs:812
+msgid "View updated result"
+msgstr "Frissített eredmény megtekintése"
+
+#: src/webframe.rs:905
 msgid "New house numbers, last 2 weeks, as of {}"
 msgstr "Új házszámok, utolsó 2 hét, frissítve: {}"
 
-#: src/webframe.rs:901 src/webframe.rs:966
+#: src/webframe.rs:907 src/webframe.rs:972
 msgid "During this day"
 msgstr "E nap folyamán"
 
-#: src/webframe.rs:902 src/webframe.rs:908 src/webframe.rs:975
+#: src/webframe.rs:908 src/webframe.rs:914 src/webframe.rs:981
 msgid "New house numbers"
 msgstr "Új házszámok"
 
-#: src/webframe.rs:905
+#: src/webframe.rs:911
 msgid "New house numbers, last year, as of {}"
 msgstr "Új házszámok, elmúlt év, frissítve: {}"
 
-#: src/webframe.rs:907
+#: src/webframe.rs:913
 msgid "During this month"
 msgstr "E hónap folyamán"
 
-#: src/webframe.rs:911
+#: src/webframe.rs:917
 msgid "All house numbers, last year, as of {}"
 msgstr "Összes házszám, elmúlt év, frissítve: {}"
 
-#: src/webframe.rs:913
+#: src/webframe.rs:919
 msgid "Latest for this month"
 msgstr "Legutóbbi erre a hónapra"
 
-#: src/webframe.rs:914 src/webframe.rs:920 src/webframe.rs:976
+#: src/webframe.rs:920 src/webframe.rs:926 src/webframe.rs:982
 msgid "All house numbers"
 msgstr "Minden házszám"
 
-#: src/webframe.rs:917
+#: src/webframe.rs:923
 msgid "All house numbers, last 2 weeks, as of {}"
 msgstr "Összes házszám, utolsó 2 hét, frissítve: {}"
 
-#: src/webframe.rs:919
+#: src/webframe.rs:925
 msgid "At the start of this day"
 msgstr "Ennek a napnak a kezdetén"
 
-#: src/webframe.rs:923
+#: src/webframe.rs:929
 msgid "Top house number editors, as of {}"
 msgstr "Legaktívabb házszám szerkesztők, frissítve: {}"
 
-#: src/webframe.rs:925
+#: src/webframe.rs:931
 msgid "User name"
 msgstr "Felhasználó neve"
 
-#: src/webframe.rs:928
+#: src/webframe.rs:934
 msgid "Number of house numbers last changed by this user"
 msgstr "Felhasználó által utoljára módosított házszámok száma"
 
-#: src/webframe.rs:930
+#: src/webframe.rs:936
 msgid "Top edited cities, as of {}"
 msgstr "Legaktívabb városok, frissítve: {}"
 
-#: src/webframe.rs:934
+#: src/webframe.rs:940
 msgid "Number of house numbers added in the past 30 days"
 msgstr "Az elmúlt 30 napban hozzáadott házszámok száma"
 
-#: src/webframe.rs:936
+#: src/webframe.rs:942
 msgid "(empty)"
 msgstr "(üres)"
 
-#: src/webframe.rs:937
+#: src/webframe.rs:943
 msgid "(invalid)"
 msgstr "(hibás)"
 
-#: src/webframe.rs:940
+#: src/webframe.rs:946
 msgid "Number of house number editors, as of {}"
 msgstr "Házszám szerkesztők száma, frissítve: {}"
 
-#: src/webframe.rs:942
+#: src/webframe.rs:948
 msgid "All editors"
 msgstr "Összes szerkesztő"
 
-#: src/webframe.rs:945
+#: src/webframe.rs:951
 msgid ""
 "Number of editors, at least one housenumber is last changed by these users"
 msgstr ""
 "Szerkesztők száma, legalább egy házszámot ezek a szerkesztők változtattak "
 "meg utoljára"
 
-#: src/webframe.rs:947
+#: src/webframe.rs:953
 msgid "Coverage is {1}%, as of {2}"
 msgstr "A lefedettség {1}%, frissítve: {2}"
 
-#: src/webframe.rs:950
+#: src/webframe.rs:956
 msgid "Number of house numbers in database"
 msgstr "Adatbázisban szereplő házszámok száma"
 
-#: src/webframe.rs:952
+#: src/webframe.rs:958
 msgid "Data source"
 msgstr "Adatforrás"
 
-#: src/webframe.rs:955
+#: src/webframe.rs:961
 msgid "Coverage is {1}% for the capital, as of {2}"
 msgstr "A főváros lefedettsége {1}%, frissítve: {2}"
 
-#: src/webframe.rs:959
+#: src/webframe.rs:965
 msgid "Number of house numbers in database for the capital"
 msgstr "Adatbázisban szereplő fővárosi házszámok száma"
 
-#: src/webframe.rs:961
+#: src/webframe.rs:967
 msgid "Reference"
 msgstr "Referencia"
 
-#: src/webframe.rs:964
+#: src/webframe.rs:970
 msgid "Invalid addr:city values, last 2 weeks, as of {}"
 msgstr "Érvénytelen addr:city értékek, utolsó 2 hét, frissítve: {}"
 
-#: src/webframe.rs:969 src/webframe.rs:1087
+#: src/webframe.rs:975 src/webframe.rs:1097
 msgid "Invalid addr:city values"
 msgstr "Érvénytelen addr:city értékek"
 
-#: src/webframe.rs:977
+#: src/webframe.rs:983
 msgid "New house numbers, monthly"
 msgstr "Új házszámok, havonta"
 
-#: src/webframe.rs:978
+#: src/webframe.rs:984
 msgid "All house numbers, monthly"
 msgstr "Minden házszám, havonta"
 
-#: src/webframe.rs:979
+#: src/webframe.rs:985
 msgid "Top house number editors"
 msgstr "Legaktívabb házszám szerkesztők"
 
-#: src/webframe.rs:980
+#: src/webframe.rs:986
 msgid "Top edited cities"
 msgstr "Legaktívabb városok"
 
-#: src/webframe.rs:981
+#: src/webframe.rs:987
 msgid "All house number editors"
 msgstr "Összes házszám szerkesztő"
 
-#: src/webframe.rs:982
+#: src/webframe.rs:988
 msgid "Coverage"
 msgstr "Lefedettség"
 
-#: src/webframe.rs:983
+#: src/webframe.rs:989
 msgid "Capital coverage"
 msgstr "A főváros lefedettsége"
 
-#: src/webframe.rs:984
+#: src/webframe.rs:990
 msgid "Per-city coverage"
 msgstr "Városonkénti lefedettség"
 
-#: src/webframe.rs:985
+#: src/webframe.rs:991
 msgid "Per-ZIP coverage"
 msgstr "Irányítószámonkénti lefedettség"
 
-#: src/webframe.rs:987
+#: src/webframe.rs:993
 msgid "Invalid addr:city values history"
 msgstr "Érvénytelen addr:city értékek története"
 
-#: src/webframe.rs:1046
+#: src/webframe.rs:1052
 msgid ""
 "These statistics are provided purely for interested editors, and are not\n"
 "intended to reflect quality of work done by any given editor in OSM. If you "
@@ -443,100 +451,88 @@ msgstr ""
 "használni, hogy motiváljad magad, az rendben van, de ne felejtsd, hogy "
 "kevesebb hasznos munka többet ér, mint sok haszontalan munka."
 
-#: src/webframe.rs:1086
+#: src/webframe.rs:1096
 msgid "Invalid relation settings"
 msgstr "Érvénytelen területi beállítások"
 
-#: src/webframe.rs:1187
+#: src/webframe.rs:1197
 msgid "No such relation: {0}"
 msgstr "Nincs ilyen reláció: {0}"
 
-#: src/webframe.rs:1199
+#: src/webframe.rs:1209
 msgid "No existing streets: call Overpass to create..."
 msgstr "Nincsenek meglévő utcák: létrehozás Overpass hívásával..."
 
-#: src/webframe.rs:1204
+#: src/webframe.rs:1214
 msgid "No existing streets: waiting for Overpass..."
 msgstr "Nincsenek meglévő utcák: Overpass: várakozás..."
 
-#: src/webframe.rs:1219
+#: src/webframe.rs:1229
 msgid "No existing house numbers: call Overpass to create..."
 msgstr "Nincsenek meglévő házszámok: létrehozás Overpass hívásával..."
 
-#: src/webframe.rs:1225
+#: src/webframe.rs:1235
 msgid "No existing house numbers: waiting for Overpass..."
 msgstr "Nincsenek meglévő házszámok: Overpass: várakozás..."
 
-#: src/webframe.rs:1240
+#: src/webframe.rs:1250
 msgid "No reference house numbers: create from reference..."
 msgstr "Nincsenek referencia házszámok: létrehozás referenciából..."
 
-#: src/webframe.rs:1246
+#: src/webframe.rs:1256
 msgid "No reference house numbers: creating from reference..."
 msgstr "Nincsenek referencia házszámok: létrehozás referenciából..."
 
-#: src/webframe.rs:1261
-msgid "No street list: create from reference..."
-msgstr "Nincsenek referencia utcák: létrehozás referenciából..."
-
-#: src/webframe.rs:1266
-msgid "No reference streets: creating from reference..."
-msgstr "Nincsenek referencia utcák: létrehozás referenciából..."
-
-#: src/wsgi.rs:41
+#: src/wsgi.rs:34 src/wsgi.rs:51
 msgid "{0} (osm), {1} (areas)"
 msgstr "{0} (osm), {1} (területek)"
 
-#: src/wsgi.rs:83 src/wsgi.rs:162 src/wsgi.rs:710
-msgid "Update successful: "
-msgstr "Frissítés sikeres: "
-
-#: src/wsgi.rs:87 src/wsgi.rs:165 src/wsgi.rs:713
+#: src/wsgi.rs:96 src/wsgi.rs:173 src/wsgi.rs:702
 msgid "View missing house numbers"
 msgstr "Hiányzó házszámok megtekintése"
 
-#: src/wsgi.rs:90 src/wsgi.rs:727
+#: src/wsgi.rs:99
 msgid "Update successful."
 msgstr "Frissítés sikeres."
 
-#: src/wsgi.rs:179 src/wsgi.rs:546 src/wsgi.rs:613
+#: src/wsgi.rs:184 src/wsgi.rs:549 src/wsgi.rs:610
 msgid "No existing house numbers"
 msgstr "Nincsenek meglévő házszámok"
 
-#: src/wsgi.rs:238 src/wsgi_additional.rs:205
+#: src/wsgi.rs:264 src/wsgi_additional.rs:189
 msgid "Source"
 msgstr "Forrás"
 
-#: src/wsgi.rs:240
+#: src/wsgi.rs:266
 msgid "Reason"
 msgstr "Ok"
 
-#: src/wsgi.rs:251
+#: src/wsgi.rs:277
 msgid "street ranges"
 msgstr "utca tartományok"
 
-#: src/wsgi.rs:252
+#: src/wsgi.rs:278
 msgid "invalid housenumbers"
 msgstr "érvénytelen házszámok"
 
-#: src/wsgi.rs:259
+#: src/wsgi.rs:285
 msgid "created in OSM"
 msgstr "létrehozva az OSM-ben"
 
-#: src/wsgi.rs:260
+#: src/wsgi.rs:286
 msgid "deleted from reference"
 msgstr "törölve a referenciából"
 
-#: src/wsgi.rs:261
+#: src/wsgi.rs:287
 msgid "out of range"
 msgstr "tartományon kívül"
 
-#: src/wsgi.rs:291
+#: src/wsgi.rs:317
 msgid ""
 "The below {0} filters for this relation are probably no longer necessary."
 msgstr "Az alábbi {0} szűrő ehhez a relációhoz valószínűleg már nem szükséges."
 
-#: src/wsgi.rs:315
+#: src/wsgi.rs:341
 msgid ""
 "OpenStreetMap is possibly missing the below {0} house numbers for {1} "
 "streets."
@@ -544,166 +540,171 @@ msgstr ""
 "Elképzelhető, hogy az OpenStreetMap nem tartalmazza a lenti {1} utcához "
 "tartozó {0} házszámot."
 
-#: src/wsgi.rs:321 src/wsgi.rs:474
+#: src/wsgi.rs:347 src/wsgi.rs:483
 msgid " (existing: {0}, ready: {1})."
 msgstr " (meglévő: {0}, készültség: {1})."
 
-#: src/wsgi.rs:331 src/wsgi_additional.rs:362
+#: src/wsgi.rs:357 src/wsgi_additional.rs:340
 msgid ""
 "https://vmiklos.hu/osm-gimmisn/usage.html#filtering-out-incorrect-information"
 msgstr ""
 "https://wiki.openstreetmap.org/wiki/Hungary/osm-gimmisn#T%C3%A9ves_inform"
 "%C3%A1ci%C3%B3_kisz%C5%B1r%C3%A9se"
 
-#: src/wsgi.rs:334 src/wsgi_additional.rs:366
+#: src/wsgi.rs:360 src/wsgi_additional.rs:344
 msgid "Filter incorrect information"
 msgstr "Téves információ szűrése"
 
-#: src/wsgi.rs:346 src/wsgi_additional.rs:276
+#: src/wsgi.rs:372 src/wsgi_additional.rs:260
 msgid "Overpass turbo query for the below streets"
 msgstr "Overpass lekérdezés a lenti utcákra"
 
-#: src/wsgi.rs:357 src/wsgi.rs:500 src/wsgi_additional.rs:243
+#: src/wsgi.rs:383 src/wsgi.rs:509 src/wsgi_additional.rs:227
 msgid "Plain text format"
 msgstr "Egyszerű szöveg formátum"
 
-#: src/wsgi.rs:368 src/wsgi.rs:511 src/wsgi_additional.rs:254
+#: src/wsgi.rs:394 src/wsgi.rs:520 src/wsgi_additional.rs:238
 msgid "Checklist format"
 msgstr "Csekklista formátum"
 
-#: src/wsgi.rs:379
+#: src/wsgi.rs:405
 msgid "View lints"
 msgstr "Ellenőrzések megtekintése"
 
-#: src/wsgi.rs:470
+#: src/wsgi.rs:479
 msgid "OpenStreetMap is possibly missing the below {0} streets."
 msgstr "Elképzelhető, hogy az OpenStreetMap nem tartalmazza a lenti {0} utcát."
 
-#: src/wsgi.rs:488
+#: src/wsgi.rs:497
 msgid "Overpass turbo query for streets with questionable names"
 msgstr "Overpass lekérdezés a kérdéses nevű utcákra"
 
-#: src/wsgi.rs:539 src/wsgi.rs:608 src/wsgi.rs:678 src/wsgi_additional.rs:152
+#: src/wsgi.rs:545 src/wsgi.rs:608 src/wsgi.rs:672 src/wsgi_additional.rs:149
 msgid "No existing streets"
 msgstr "Nincsenek meglévő utcák"
 
-#: src/wsgi.rs:553 src/wsgi.rs:618
+#: src/wsgi.rs:556 src/wsgi.rs:615
 msgid "No reference house numbers"
 msgstr "Nincsenek referencia házszámok"
 
-#: src/wsgi.rs:683 src/wsgi_additional.rs:157
-msgid "No reference streets"
-msgstr "Nincsenek referencia utcák"
-
-#: src/wsgi.rs:982 src/wsgi.rs:1022 src/wsgi.rs:1063 src/wsgi.rs:1121
+#: src/wsgi.rs:940 src/wsgi.rs:980 src/wsgi.rs:1020 src/wsgi.rs:1069
 msgid "updated"
 msgstr "frissítve"
 
-#: src/wsgi.rs:993
+#: src/wsgi.rs:951
 msgid "missing house numbers"
 msgstr "hiányzó házszámok"
 
-#: src/wsgi.rs:1033 src/wsgi.rs:1480
+#: src/wsgi.rs:991 src/wsgi.rs:1428
 msgid "missing streets"
 msgstr "hiányzó utcák"
 
-#: src/wsgi.rs:1066
+#: src/wsgi.rs:1023
 msgid "{} streets"
 msgstr "{} utca"
 
-#: src/wsgi.rs:1072
+#: src/wsgi.rs:1029
 msgid "additional streets"
 msgstr "további utcák"
 
-#: src/wsgi.rs:1124
+#: src/wsgi.rs:1072
 msgid "{} house numbers"
 msgstr "{} házszám"
 
-#: src/wsgi.rs:1130
+#: src/wsgi.rs:1078
 msgid "additional house numbers"
 msgstr "további házszámok"
 
-#: src/wsgi.rs:1287
+#: src/wsgi.rs:1235
 msgid "Based on position"
 msgstr "Pozíció alapján"
 
-#: src/wsgi.rs:1295
+#: src/wsgi.rs:1243
 msgid "Show complete areas"
 msgstr "Kész területek mutatása"
 
-#: src/wsgi.rs:1318 src/wsgi.rs:1501
+#: src/wsgi.rs:1266 src/wsgi.rs:1449
 msgid "Where to map?"
 msgstr "Hol térképezzek?"
 
-#: src/wsgi.rs:1322
+#: src/wsgi.rs:1270
 msgid "Filters:"
 msgstr "Szűrők:"
 
-#: src/wsgi.rs:1332
+#: src/wsgi.rs:1280
 msgid "Waiting for GPS..."
 msgstr "GPS: várakozás..."
 
-#: src/wsgi.rs:1333
+#: src/wsgi.rs:1281
 msgid "Error from GPS: "
 msgstr "GPS hiba: "
 
-#: src/wsgi.rs:1336
+#: src/wsgi.rs:1284
 msgid "Waiting for relations..."
 msgstr "Területek: várakozás..."
 
-#: src/wsgi.rs:1337
+#: src/wsgi.rs:1285
 msgid "Error from relations: "
 msgstr "Hiba a relációktól: "
 
-#: src/wsgi.rs:1338
+#: src/wsgi.rs:1286
 msgid "Waiting for redirect..."
 msgstr "Átirányítás: várakozás..."
 
-#: src/wsgi.rs:1400
+#: src/wsgi.rs:1348
 msgid "area boundary"
 msgstr "terület határa"
 
-#: src/wsgi.rs:1435
+#: src/wsgi.rs:1383
 msgid "Area"
 msgstr "Terület"
 
-#: src/wsgi.rs:1438
+#: src/wsgi.rs:1386
 msgid "Street coverage"
 msgstr "Utca lefedettség"
 
-#: src/wsgi.rs:1456
+#: src/wsgi.rs:1404
 msgid "https://vmiklos.hu/osm-gimmisn/usage.html#how-to-add-a-new-area"
 msgstr ""
 "https://wiki.openstreetmap.org/wiki/Hungary/osm-gimmisn#%C3%9Aj_rel%C3%A1ci"
 "%C3%B3_hozz%C3%A1ad%C3%A1sa"
 
-#: src/wsgi.rs:1459
+#: src/wsgi.rs:1407
 msgid "Add new area"
 msgstr "Új terület hozzáadása"
 
-#: src/wsgi.rs:1478
+#: src/wsgi.rs:1426
 msgid "{0} missing house numbers"
 msgstr "{0} hiányzó házszámok"
 
-#: src/wsgi.rs:1481
+#: src/wsgi.rs:1429
 msgid "existing house numbers"
 msgstr "meglévő házszámok"
 
-#: src/wsgi.rs:1482
+#: src/wsgi.rs:1430
 msgid "existing streets"
 msgstr "meglévő utcák"
 
-#: src/wsgi_additional.rs:231
+#: src/wsgi_additional.rs:215
 msgid "OpenStreetMap additionally has the below {0} streets."
 msgstr "Az OpenStreetMap tartalmazza a lenti {0} további utcát."
 
-#: src/wsgi_additional.rs:265
+#: src/wsgi_additional.rs:249
 msgid "GPX format"
 msgstr "GPX formátum"
 
-#: src/wsgi_additional.rs:352
+#: src/wsgi_additional.rs:330
 msgid ""
 "OpenStreetMap additionally has the below {0} house numbers for {1} streets."
 msgstr ""
 "Az OpenStreetmap tartalmazza a lenti {1} utcához tartozó további {0} "
 "házszámot."
+
+#~ msgid "No street list: create from reference..."
+#~ msgstr "Nincsenek referencia utcák: létrehozás referenciából..."
+
+#~ msgid "No reference streets: creating from reference..."
+#~ msgstr "Nincsenek referencia utcák: létrehozás referenciából..."
+
+#~ msgid "No reference streets"
+#~ msgstr "Nincsenek referencia utcák"

--- a/po/osm-gimmisn.pot
+++ b/po/osm-gimmisn.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 19:21+0000\n"
+"POT-Creation-Date: 2024-03-03 13:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,643 +17,635 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/areas.rs:582
+#: src/areas.rs:565
 msgid "street"
 msgstr ""
 
-#: src/areas.rs:1131 src/wsgi.rs:462 src/wsgi_additional.rs:206
+#: src/areas.rs:1086 src/wsgi.rs:471 src/wsgi_additional.rs:190
 msgid "Street name"
 msgstr ""
 
-#: src/areas.rs:1132
+#: src/areas.rs:1087
 msgid "Missing count"
 msgstr ""
 
-#: src/areas.rs:1133
+#: src/areas.rs:1088
 msgid "House numbers"
 msgstr ""
 
-#: src/util.rs:739
+#: src/util.rs:737
 msgid "Overpass error: {0}"
 msgstr ""
 
-#: src/util.rs:743
+#: src/util.rs:741
 msgid "Note: wait for {} seconds"
 msgstr ""
 
-#: src/util.rs:845
+#: src/util.rs:843
 msgid "Warning: broken OSM <-> reference mapping, the following OSM names are invalid:"
 msgstr ""
 
-#: src/util.rs:857
+#: src/util.rs:855
 msgid "Warning: broken OSM <-> reference mapping, the following reference names are invalid:"
 msgstr ""
 
-#: src/util.rs:868
+#: src/util.rs:866
 msgid "Note: an OSM name is invalid if it's not in the OSM database. "
 msgstr ""
 
-#: src/util.rs:871
+#: src/util.rs:869
 msgid "A reference name is invalid if it's in the OSM database or it's not in the reference."
 msgstr ""
 
-#: src/util.rs:884
+#: src/util.rs:882
 msgid "Warning: broken filter key name, the following key names are not OSM names:"
 msgstr ""
 
-#: src/util.rs:1056
+#: src/util.rs:1069
 msgid "housenumber"
 msgstr ""
 
-#: src/webframe.rs:32
+#: src/webframe.rs:33
 msgid "Version: "
 msgstr ""
 
-#: src/webframe.rs:42
+#: src/webframe.rs:43
 msgid "OSM data © OpenStreetMap contributors."
 msgstr ""
 
-#: src/webframe.rs:46
+#: src/webframe.rs:47
 msgid "Last update: "
 msgstr ""
 
-#: src/webframe.rs:89 src/webframe.rs:123
+#: src/webframe.rs:90 src/webframe.rs:124
 msgid "Update from OSM"
 msgstr ""
 
-#: src/webframe.rs:105 src/webframe.rs:139
+#: src/webframe.rs:106
 msgid "Update from reference"
 msgstr ""
 
-#: src/webframe.rs:155 src/webframe.rs:183
+#: src/webframe.rs:140 src/webframe.rs:168
 msgid "Call Overpass to update"
 msgstr ""
 
-#: src/webframe.rs:168 src/webframe.rs:196
+#: src/webframe.rs:153 src/webframe.rs:181
 msgid "View query"
 msgstr ""
 
-#: src/webframe.rs:223
+#: src/webframe.rs:208
 msgid "Missing house numbers"
 msgstr ""
 
-#: src/webframe.rs:237 src/wsgi.rs:1437
+#: src/webframe.rs:222 src/wsgi.rs:1385
 msgid "Additional house numbers"
 msgstr ""
 
-#: src/webframe.rs:252
+#: src/webframe.rs:237
 msgid "Missing streets"
 msgstr ""
 
-#: src/webframe.rs:264 src/wsgi.rs:1439
+#: src/webframe.rs:249 src/wsgi.rs:1387
 msgid "Additional streets"
 msgstr ""
 
-#: src/webframe.rs:290
+#: src/webframe.rs:275
 msgid "Existing house numbers"
 msgstr ""
 
-#: src/webframe.rs:304
+#: src/webframe.rs:289
 msgid "Existing streets"
 msgstr ""
 
-#: src/webframe.rs:344
+#: src/webframe.rs:329
 msgid "Area list"
 msgstr ""
 
-#: src/webframe.rs:367 src/wsgi.rs:1334
+#: src/webframe.rs:352 src/wsgi.rs:1282
 msgid "Waiting for Overpass..."
 msgstr ""
 
-#: src/webframe.rs:368 src/webframe.rs:1206 src/webframe.rs:1227 src/wsgi.rs:1335
+#: src/webframe.rs:353 src/webframe.rs:1216 src/webframe.rs:1237 src/wsgi.rs:1283
 msgid "Error from Overpass: "
 msgstr ""
 
-#: src/webframe.rs:371
+#: src/webframe.rs:356
 msgid "Creating from reference..."
 msgstr ""
 
-#: src/webframe.rs:373 src/webframe.rs:1248 src/webframe.rs:1268
+#: src/webframe.rs:358 src/webframe.rs:1258
 msgid "Error from reference: "
 msgstr ""
 
-#: src/webframe.rs:379
+#: src/webframe.rs:364
 msgid "Overpass turbo"
 msgstr ""
 
-#: src/webframe.rs:393 src/wsgi.rs:1440
+#: src/webframe.rs:378 src/wsgi.rs:1388
 msgid "Area boundary"
 msgstr ""
 
-#: src/webframe.rs:406
+#: src/webframe.rs:391
 msgid "Statistics"
 msgstr ""
 
-#: src/webframe.rs:419
+#: src/webframe.rs:404
 msgid "Lints"
 msgstr ""
 
-#: src/webframe.rs:425
+#: src/webframe.rs:410
 msgid "https://vmiklos.hu/osm-gimmisn"
 msgstr ""
 
-#: src/webframe.rs:426
+#: src/webframe.rs:411
 msgid "Documentation"
 msgstr ""
 
-#: src/webframe.rs:501
+#: src/webframe.rs:486
 msgid "Internal error when serving {0}"
 msgstr ""
 
-#: src/webframe.rs:522
+#: src/webframe.rs:507
 msgid "Not Found"
 msgstr ""
 
-#: src/webframe.rs:526
+#: src/webframe.rs:511
 msgid "The requested URL was not found on this server."
 msgstr ""
 
-#: src/webframe.rs:592 src/webframe.rs:931
+#: src/webframe.rs:576 src/webframe.rs:937
 msgid "City name"
 msgstr ""
 
-#: src/webframe.rs:593 src/webframe.rs:682 src/wsgi.rs:1436
+#: src/webframe.rs:577 src/webframe.rs:666 src/wsgi.rs:1384
 msgid "House number coverage"
 msgstr ""
 
-#: src/webframe.rs:594 src/webframe.rs:683
+#: src/webframe.rs:578 src/webframe.rs:667
 msgid "OSM count"
 msgstr ""
 
-#: src/webframe.rs:595 src/webframe.rs:684
+#: src/webframe.rs:579 src/webframe.rs:668
 msgid "Reference count"
 msgstr ""
 
-#: src/webframe.rs:616 src/webframe.rs:707 src/webframe.rs:1041
+#: src/webframe.rs:600 src/webframe.rs:691 src/webframe.rs:1047
 msgid "Note"
 msgstr ""
 
-#: src/webframe.rs:621
+#: src/webframe.rs:605
 msgid "These statistics are estimates, not taking house number filters into account.\n"
 "Only cities with house numbers in OSM are considered."
 msgstr ""
 
-#: src/webframe.rs:681
+#: src/webframe.rs:665
 msgid "ZIP code"
 msgstr ""
 
-#: src/webframe.rs:712
+#: src/webframe.rs:696
 msgid "These statistics are estimates, not taking house number filters into account.\n"
 "Only zip codes with house numbers in OSM are considered."
 msgstr ""
 
-#: src/webframe.rs:747 src/wsgi.rs:241 src/wsgi_additional.rs:203
+#: src/webframe.rs:731 src/wsgi.rs:267 src/wsgi_additional.rs:187
 msgid "Identifier"
 msgstr ""
 
-#: src/webframe.rs:748 src/wsgi.rs:242 src/wsgi_additional.rs:204
+#: src/webframe.rs:732 src/wsgi.rs:268 src/wsgi_additional.rs:188
 msgid "Type"
 msgstr ""
 
-#: src/webframe.rs:749
+#: src/webframe.rs:733
 msgid "Postcode"
 msgstr ""
 
-#: src/webframe.rs:750
+#: src/webframe.rs:734
 msgid "City"
 msgstr ""
 
-#: src/webframe.rs:751 src/wsgi.rs:237
+#: src/webframe.rs:735 src/wsgi.rs:263
 msgid "Street"
 msgstr ""
 
-#: src/webframe.rs:752 src/wsgi.rs:239
+#: src/webframe.rs:736 src/wsgi.rs:265
 msgid "Housenumber"
 msgstr ""
 
-#: src/webframe.rs:753
+#: src/webframe.rs:737
 msgid "User"
 msgstr ""
 
-#: src/webframe.rs:754
+#: src/webframe.rs:738
 msgid "Timestamp"
 msgstr ""
 
-#: src/webframe.rs:755
+#: src/webframe.rs:739
 msgid "Fixme"
 msgstr ""
 
-#: src/webframe.rs:794
+#: src/webframe.rs:778
 msgid "The addr:city key of the below {0} objects probably has an invalid value."
 msgstr ""
 
-#: src/webframe.rs:899
-msgid "New house numbers, last 2 weeks, as of {}"
+#: src/webframe.rs:809 src/wsgi.rs:92 src/wsgi.rs:170 src/wsgi.rs:699
+msgid "Update successful: "
 msgstr ""
 
-#: src/webframe.rs:901 src/webframe.rs:966
-msgid "During this day"
-msgstr ""
-
-#: src/webframe.rs:902 src/webframe.rs:908 src/webframe.rs:975
-msgid "New house numbers"
+#: src/webframe.rs:812
+msgid "View updated result"
 msgstr ""
 
 #: src/webframe.rs:905
-msgid "New house numbers, last year, as of {}"
+msgid "New house numbers, last 2 weeks, as of {}"
 msgstr ""
 
-#: src/webframe.rs:907
-msgid "During this month"
+#: src/webframe.rs:907 src/webframe.rs:972
+msgid "During this day"
+msgstr ""
+
+#: src/webframe.rs:908 src/webframe.rs:914 src/webframe.rs:981
+msgid "New house numbers"
 msgstr ""
 
 #: src/webframe.rs:911
-msgid "All house numbers, last year, as of {}"
+msgid "New house numbers, last year, as of {}"
 msgstr ""
 
 #: src/webframe.rs:913
-msgid "Latest for this month"
-msgstr ""
-
-#: src/webframe.rs:914 src/webframe.rs:920 src/webframe.rs:976
-msgid "All house numbers"
+msgid "During this month"
 msgstr ""
 
 #: src/webframe.rs:917
-msgid "All house numbers, last 2 weeks, as of {}"
+msgid "All house numbers, last year, as of {}"
 msgstr ""
 
 #: src/webframe.rs:919
-msgid "At the start of this day"
+msgid "Latest for this month"
+msgstr ""
+
+#: src/webframe.rs:920 src/webframe.rs:926 src/webframe.rs:982
+msgid "All house numbers"
 msgstr ""
 
 #: src/webframe.rs:923
-msgid "Top house number editors, as of {}"
+msgid "All house numbers, last 2 weeks, as of {}"
 msgstr ""
 
 #: src/webframe.rs:925
+msgid "At the start of this day"
+msgstr ""
+
+#: src/webframe.rs:929
+msgid "Top house number editors, as of {}"
+msgstr ""
+
+#: src/webframe.rs:931
 msgid "User name"
 msgstr ""
 
-#: src/webframe.rs:928
+#: src/webframe.rs:934
 msgid "Number of house numbers last changed by this user"
 msgstr ""
 
-#: src/webframe.rs:930
+#: src/webframe.rs:936
 msgid "Top edited cities, as of {}"
 msgstr ""
 
-#: src/webframe.rs:934
+#: src/webframe.rs:940
 msgid "Number of house numbers added in the past 30 days"
 msgstr ""
 
-#: src/webframe.rs:936
+#: src/webframe.rs:942
 msgid "(empty)"
 msgstr ""
 
-#: src/webframe.rs:937
+#: src/webframe.rs:943
 msgid "(invalid)"
 msgstr ""
 
-#: src/webframe.rs:940
+#: src/webframe.rs:946
 msgid "Number of house number editors, as of {}"
 msgstr ""
 
-#: src/webframe.rs:942
+#: src/webframe.rs:948
 msgid "All editors"
 msgstr ""
 
-#: src/webframe.rs:945
+#: src/webframe.rs:951
 msgid "Number of editors, at least one housenumber is last changed by these users"
 msgstr ""
 
-#: src/webframe.rs:947
+#: src/webframe.rs:953
 msgid "Coverage is {1}%, as of {2}"
 msgstr ""
 
-#: src/webframe.rs:950
+#: src/webframe.rs:956
 msgid "Number of house numbers in database"
 msgstr ""
 
-#: src/webframe.rs:952
+#: src/webframe.rs:958
 msgid "Data source"
 msgstr ""
 
-#: src/webframe.rs:955
+#: src/webframe.rs:961
 msgid "Coverage is {1}% for the capital, as of {2}"
 msgstr ""
 
-#: src/webframe.rs:959
+#: src/webframe.rs:965
 msgid "Number of house numbers in database for the capital"
 msgstr ""
 
-#: src/webframe.rs:961
+#: src/webframe.rs:967
 msgid "Reference"
 msgstr ""
 
-#: src/webframe.rs:964
+#: src/webframe.rs:970
 msgid "Invalid addr:city values, last 2 weeks, as of {}"
 msgstr ""
 
-#: src/webframe.rs:969 src/webframe.rs:1087
+#: src/webframe.rs:975 src/webframe.rs:1097
 msgid "Invalid addr:city values"
 msgstr ""
 
-#: src/webframe.rs:977
+#: src/webframe.rs:983
 msgid "New house numbers, monthly"
 msgstr ""
 
-#: src/webframe.rs:978
+#: src/webframe.rs:984
 msgid "All house numbers, monthly"
 msgstr ""
 
-#: src/webframe.rs:979
+#: src/webframe.rs:985
 msgid "Top house number editors"
 msgstr ""
 
-#: src/webframe.rs:980
+#: src/webframe.rs:986
 msgid "Top edited cities"
 msgstr ""
 
-#: src/webframe.rs:981
+#: src/webframe.rs:987
 msgid "All house number editors"
 msgstr ""
 
-#: src/webframe.rs:982
+#: src/webframe.rs:988
 msgid "Coverage"
 msgstr ""
 
-#: src/webframe.rs:983
+#: src/webframe.rs:989
 msgid "Capital coverage"
 msgstr ""
 
-#: src/webframe.rs:984
+#: src/webframe.rs:990
 msgid "Per-city coverage"
 msgstr ""
 
-#: src/webframe.rs:985
+#: src/webframe.rs:991
 msgid "Per-ZIP coverage"
 msgstr ""
 
-#: src/webframe.rs:987
+#: src/webframe.rs:993
 msgid "Invalid addr:city values history"
 msgstr ""
 
-#: src/webframe.rs:1046
+#: src/webframe.rs:1052
 msgid "These statistics are provided purely for interested editors, and are not\n"
 "intended to reflect quality of work done by any given editor in OSM. If you want to use\n"
 "them to motivate yourself, that's fine, but keep in mind that a bit of useful work is\n"
 "more meaningful than a lot of useless work."
 msgstr ""
 
-#: src/webframe.rs:1086
+#: src/webframe.rs:1096
 msgid "Invalid relation settings"
 msgstr ""
 
-#: src/webframe.rs:1187
+#: src/webframe.rs:1197
 msgid "No such relation: {0}"
 msgstr ""
 
-#: src/webframe.rs:1199
+#: src/webframe.rs:1209
 msgid "No existing streets: call Overpass to create..."
 msgstr ""
 
-#: src/webframe.rs:1204
+#: src/webframe.rs:1214
 msgid "No existing streets: waiting for Overpass..."
 msgstr ""
 
-#: src/webframe.rs:1219
+#: src/webframe.rs:1229
 msgid "No existing house numbers: call Overpass to create..."
 msgstr ""
 
-#: src/webframe.rs:1225
+#: src/webframe.rs:1235
 msgid "No existing house numbers: waiting for Overpass..."
 msgstr ""
 
-#: src/webframe.rs:1240
+#: src/webframe.rs:1250
 msgid "No reference house numbers: create from reference..."
 msgstr ""
 
-#: src/webframe.rs:1246
+#: src/webframe.rs:1256
 msgid "No reference house numbers: creating from reference..."
 msgstr ""
 
-#: src/webframe.rs:1261
-msgid "No street list: create from reference..."
-msgstr ""
-
-#: src/webframe.rs:1266
-msgid "No reference streets: creating from reference..."
-msgstr ""
-
-#: src/wsgi.rs:41
+#: src/wsgi.rs:34 src/wsgi.rs:51
 msgid "{0} (osm), {1} (areas)"
 msgstr ""
 
-#: src/wsgi.rs:83 src/wsgi.rs:162 src/wsgi.rs:710
-msgid "Update successful: "
-msgstr ""
-
-#: src/wsgi.rs:87 src/wsgi.rs:165 src/wsgi.rs:713
+#: src/wsgi.rs:96 src/wsgi.rs:173 src/wsgi.rs:702
 msgid "View missing house numbers"
 msgstr ""
 
-#: src/wsgi.rs:90 src/wsgi.rs:727
+#: src/wsgi.rs:99
 msgid "Update successful."
 msgstr ""
 
-#: src/wsgi.rs:179 src/wsgi.rs:546 src/wsgi.rs:613
+#: src/wsgi.rs:184 src/wsgi.rs:549 src/wsgi.rs:610
 msgid "No existing house numbers"
 msgstr ""
 
-#: src/wsgi.rs:238 src/wsgi_additional.rs:205
+#: src/wsgi.rs:264 src/wsgi_additional.rs:189
 msgid "Source"
 msgstr ""
 
-#: src/wsgi.rs:240
+#: src/wsgi.rs:266
 msgid "Reason"
 msgstr ""
 
-#: src/wsgi.rs:251
+#: src/wsgi.rs:277
 msgid "street ranges"
 msgstr ""
 
-#: src/wsgi.rs:252
+#: src/wsgi.rs:278
 msgid "invalid housenumbers"
 msgstr ""
 
-#: src/wsgi.rs:259
+#: src/wsgi.rs:285
 msgid "created in OSM"
 msgstr ""
 
-#: src/wsgi.rs:260
+#: src/wsgi.rs:286
 msgid "deleted from reference"
 msgstr ""
 
-#: src/wsgi.rs:261
+#: src/wsgi.rs:287
 msgid "out of range"
 msgstr ""
 
-#: src/wsgi.rs:291
+#: src/wsgi.rs:317
 msgid "The below {0} filters for this relation are probably no longer necessary."
 msgstr ""
 
-#: src/wsgi.rs:315
+#: src/wsgi.rs:341
 msgid "OpenStreetMap is possibly missing the below {0} house numbers for {1} streets."
 msgstr ""
 
-#: src/wsgi.rs:321 src/wsgi.rs:474
+#: src/wsgi.rs:347 src/wsgi.rs:483
 msgid " (existing: {0}, ready: {1})."
 msgstr ""
 
-#: src/wsgi.rs:331 src/wsgi_additional.rs:362
+#: src/wsgi.rs:357 src/wsgi_additional.rs:340
 msgid "https://vmiklos.hu/osm-gimmisn/usage.html#filtering-out-incorrect-information"
 msgstr ""
 
-#: src/wsgi.rs:334 src/wsgi_additional.rs:366
+#: src/wsgi.rs:360 src/wsgi_additional.rs:344
 msgid "Filter incorrect information"
 msgstr ""
 
-#: src/wsgi.rs:346 src/wsgi_additional.rs:276
+#: src/wsgi.rs:372 src/wsgi_additional.rs:260
 msgid "Overpass turbo query for the below streets"
 msgstr ""
 
-#: src/wsgi.rs:357 src/wsgi.rs:500 src/wsgi_additional.rs:243
+#: src/wsgi.rs:383 src/wsgi.rs:509 src/wsgi_additional.rs:227
 msgid "Plain text format"
 msgstr ""
 
-#: src/wsgi.rs:368 src/wsgi.rs:511 src/wsgi_additional.rs:254
+#: src/wsgi.rs:394 src/wsgi.rs:520 src/wsgi_additional.rs:238
 msgid "Checklist format"
 msgstr ""
 
-#: src/wsgi.rs:379
+#: src/wsgi.rs:405
 msgid "View lints"
 msgstr ""
 
-#: src/wsgi.rs:470
+#: src/wsgi.rs:479
 msgid "OpenStreetMap is possibly missing the below {0} streets."
 msgstr ""
 
-#: src/wsgi.rs:488
+#: src/wsgi.rs:497
 msgid "Overpass turbo query for streets with questionable names"
 msgstr ""
 
-#: src/wsgi.rs:539 src/wsgi.rs:608 src/wsgi.rs:678 src/wsgi_additional.rs:152
+#: src/wsgi.rs:545 src/wsgi.rs:608 src/wsgi.rs:672 src/wsgi_additional.rs:149
 msgid "No existing streets"
 msgstr ""
 
-#: src/wsgi.rs:553 src/wsgi.rs:618
+#: src/wsgi.rs:556 src/wsgi.rs:615
 msgid "No reference house numbers"
 msgstr ""
 
-#: src/wsgi.rs:683 src/wsgi_additional.rs:157
-msgid "No reference streets"
-msgstr ""
-
-#: src/wsgi.rs:982 src/wsgi.rs:1022 src/wsgi.rs:1063 src/wsgi.rs:1121
+#: src/wsgi.rs:940 src/wsgi.rs:980 src/wsgi.rs:1020 src/wsgi.rs:1069
 msgid "updated"
 msgstr ""
 
-#: src/wsgi.rs:993
+#: src/wsgi.rs:951
 msgid "missing house numbers"
 msgstr ""
 
-#: src/wsgi.rs:1033 src/wsgi.rs:1480
+#: src/wsgi.rs:991 src/wsgi.rs:1428
 msgid "missing streets"
 msgstr ""
 
-#: src/wsgi.rs:1066
+#: src/wsgi.rs:1023
 msgid "{} streets"
 msgstr ""
 
-#: src/wsgi.rs:1072
+#: src/wsgi.rs:1029
 msgid "additional streets"
 msgstr ""
 
-#: src/wsgi.rs:1124
+#: src/wsgi.rs:1072
 msgid "{} house numbers"
 msgstr ""
 
-#: src/wsgi.rs:1130
+#: src/wsgi.rs:1078
 msgid "additional house numbers"
 msgstr ""
 
-#: src/wsgi.rs:1287
+#: src/wsgi.rs:1235
 msgid "Based on position"
 msgstr ""
 
-#: src/wsgi.rs:1295
+#: src/wsgi.rs:1243
 msgid "Show complete areas"
 msgstr ""
 
-#: src/wsgi.rs:1318 src/wsgi.rs:1501
+#: src/wsgi.rs:1266 src/wsgi.rs:1449
 msgid "Where to map?"
 msgstr ""
 
-#: src/wsgi.rs:1322
+#: src/wsgi.rs:1270
 msgid "Filters:"
 msgstr ""
 
-#: src/wsgi.rs:1332
+#: src/wsgi.rs:1280
 msgid "Waiting for GPS..."
 msgstr ""
 
-#: src/wsgi.rs:1333
+#: src/wsgi.rs:1281
 msgid "Error from GPS: "
 msgstr ""
 
-#: src/wsgi.rs:1336
+#: src/wsgi.rs:1284
 msgid "Waiting for relations..."
 msgstr ""
 
-#: src/wsgi.rs:1337
+#: src/wsgi.rs:1285
 msgid "Error from relations: "
 msgstr ""
 
-#: src/wsgi.rs:1338
+#: src/wsgi.rs:1286
 msgid "Waiting for redirect..."
 msgstr ""
 
-#: src/wsgi.rs:1400
+#: src/wsgi.rs:1348
 msgid "area boundary"
 msgstr ""
 
-#: src/wsgi.rs:1435
+#: src/wsgi.rs:1383
 msgid "Area"
 msgstr ""
 
-#: src/wsgi.rs:1438
+#: src/wsgi.rs:1386
 msgid "Street coverage"
 msgstr ""
 
-#: src/wsgi.rs:1456
+#: src/wsgi.rs:1404
 msgid "https://vmiklos.hu/osm-gimmisn/usage.html#how-to-add-a-new-area"
 msgstr ""
 
-#: src/wsgi.rs:1459
+#: src/wsgi.rs:1407
 msgid "Add new area"
 msgstr ""
 
-#: src/wsgi.rs:1478
+#: src/wsgi.rs:1426
 msgid "{0} missing house numbers"
 msgstr ""
 
-#: src/wsgi.rs:1481
+#: src/wsgi.rs:1429
 msgid "existing house numbers"
 msgstr ""
 
-#: src/wsgi.rs:1482
+#: src/wsgi.rs:1430
 msgid "existing streets"
 msgstr ""
 
-#: src/wsgi_additional.rs:231
+#: src/wsgi_additional.rs:215
 msgid "OpenStreetMap additionally has the below {0} streets."
 msgstr ""
 
-#: src/wsgi_additional.rs:265
+#: src/wsgi_additional.rs:249
 msgid "GPX format"
 msgstr ""
 
-#: src/wsgi_additional.rs:352
+#: src/wsgi_additional.rs:330
 msgid "OpenStreetMap additionally has the below {0} house numbers for {1} streets."
 msgstr ""

--- a/src/webframe/tests.rs
+++ b/src/webframe/tests.rs
@@ -297,3 +297,73 @@ fn test_handle_lints() {
     // 2 lint types.
     assert_eq!(results.len(), 2);
 }
+/// Tests handle_invalid_addr_cities_update().
+#[test]
+fn test_handle_invalid_addr_cities_update() {
+    // Given a context to get /invalid-addr-cities/update-result:
+    let mut test_wsgi = wsgi::tests::TestWsgi::new();
+    let routes = vec![
+        context::tests::URLRoute::new(
+            /*url=*/ "https://overpass-api.de/api/status",
+            /*data_path=*/ "",
+            /*result_path=*/ "src/fixtures/network/overpass-status-happy.txt",
+        ),
+        context::tests::URLRoute::new(
+            /*url=*/ "https://overpass-api.de/api/interpreter",
+            /*data_path=*/ "",
+            /*result_path=*/ "src/fixtures/network/overpass-stats.csv",
+        ),
+    ];
+    let network = context::tests::TestNetwork::new(&routes);
+    let network_rc: Rc<dyn context::Network> = Rc::new(network);
+    test_wsgi.get_ctx().set_network(network_rc);
+    let csv_value = context::tests::TestFileSystem::make_file();
+    let overpass_template = context::tests::TestFileSystem::make_file();
+    let files = context::tests::TestFileSystem::make_files(
+        &test_wsgi.get_ctx(),
+        &[
+            ("workdir/stats/whole-country.csv", &csv_value),
+            (
+                "data/street-housenumbers-hungary.overpassql",
+                &overpass_template,
+            ),
+        ],
+    );
+    let mut file_system = context::tests::TestFileSystem::new();
+    file_system.set_files(&files);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.get_ctx().set_file_system(&file_system_rc);
+
+    // When getting that page:
+    let root = test_wsgi.get_dom_for_path("/lints/whole-country/invalid-addr-cities/update-result");
+
+    // Then make sure the whole-country.csv is updated:
+    let path = test_wsgi
+        .get_ctx()
+        .get_abspath(&format!("workdir/stats/whole-country.csv"));
+    let actual = test_wsgi
+        .get_ctx()
+        .get_file_system()
+        .read_to_string(&path)
+        .unwrap();
+    assert_eq!(
+        actual,
+        String::from_utf8(std::fs::read("src/fixtures/network/overpass-stats.csv").unwrap())
+            .unwrap()
+    );
+    // SQL is updated:
+    {
+        let conn = test_wsgi.get_ctx().get_database_connection().unwrap();
+        let last_modified: String = conn
+            .query_row(
+                "select last_modified from mtimes where page = ?1",
+                ["stats/invalid-addr-cities"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!last_modified.is_empty());
+    }
+    // Output is well-formed:
+    let results = wsgi::tests::TestWsgi::find_all(&root, "body");
+    assert_eq!(results.len(), 1);
+}


### PR DESCRIPTION
So one doesn't have to wait till the next cronjob to see a newer
/lints/whole-country/invalid-addr-cities output.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/3768>.

Change-Id: Idf621e4b30b6c2509646308618f0a66249bb980d
