### PR TITLE
util: avoid ... in gen_link()

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -766,7 +766,7 @@ pub fn setup_localization(ctx: &context::Context, headers: rouille::HeadersIter<
 pub fn gen_link(url: &str, label: &str) -> yattag::Doc {
     let doc = yattag::Doc::new();
     let a = doc.tag("a", &[("href", url)]);
-    a.text(&(label.to_string() + "..."));
+    a.text(label);
     doc
 }
 

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -293,7 +293,7 @@ fn test_setup_localization_parse_error() {
 #[test]
 fn test_gen_link() {
     let doc = gen_link("http://www.example.com", "label");
-    let expected = r#"<a href="http://www.example.com">label...</a>"#;
+    let expected = r#"<a href="http://www.example.com">label</a>"#;
     assert_eq!(doc.get_value(), expected);
 }
 


### PR DESCRIPTION
This was a leftover from times where gen_link() also did an automatic
redirect so the "..." signalled the reload is in progress. We don't load
anything automatically: if JS is enabled, then gen_link() is typically
not visible as we do a json request instead from JS.

Change-Id: I6dd267e554c3adef606e6d8d1bbaa7dc61a54318
