### PR TITLE
CI: update deprecated actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,15 +10,14 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.1
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: 1.76.0
           components: rustfmt, clippy, llvm-tools-preview
-          default: true
       - name: Rust Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4.0.1
         with:
           path: |
             ~/.cargo/bin/
@@ -28,7 +27,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-1.76.0-${{ hashFiles('**/Cargo.toml') }}
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4.0.2
         with:
           node-version: 18
       - name: Run make check


### PR DESCRIPTION
E.g. <https://github.com/vmiklos/osm-gimmisn/actions/runs/8208591684>
shows 6 warnings, this is meant to fix those.

Change-Id: I249a3f0c4e12a75d4ed1cc4ce115cb02e37facf3
