### PR TITLE
GC unused stats/invalid-addr-cities

### DIFF
--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -68,6 +68,9 @@ pub fn download(
     let conn = ctx.get_database_connection()?;
     conn.execute("delete from ref_housenumbers", [])?;
     conn.execute("delete from ref_streets", [])?;
+    // Garbage collect other unused data.
+    // 2024-03-24
+    conn.execute_batch("delete from mtimes where page = 'stats/invalid-addr-cities'")?;
 
     ctx.get_file_system()
         .write_from_string(&config_data, &ctx.get_abspath("workdir/wsgi.ini"))?;


### PR DESCRIPTION
This would be the date of the analysis itself, not the date of the
source OSM data.

Change-Id: I127a80c29037790be2e66a9e0d9b03b411a4397b
