### PR TITLE
sync-ref: add a '--mode local' switch

### DIFF
--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -20,48 +20,56 @@ pub fn download(
     stream: &mut dyn Write,
     ctx: &context::Context,
     config_file: &str,
-    url: &str,
+    url: &Option<&String>,
+    mode: &str,
 ) -> anyhow::Result<()> {
-    let config_data = ctx.get_file_system().read_to_string(config_file)?;
-    let config: context::IniConfig = toml::from_str(&config_data)?;
-    let mut paths: Vec<String> = Vec::new();
-    let values = config.wsgi.reference_housenumbers;
-    paths.append(
-        &mut values
-            .split(' ')
-            .map(|value| value.strip_prefix("workdir/refs/").unwrap().to_string())
-            .collect(),
-    );
-    let value = config.wsgi.reference_street;
-    paths.push(value.strip_prefix("workdir/refs/").unwrap().to_string());
-    let value = config.wsgi.reference_citycounts;
-    paths.push(value.strip_prefix("workdir/refs/").unwrap().to_string());
-    let value = config.wsgi.reference_zipcounts;
-    paths.push(value.strip_prefix("workdir/refs/").unwrap().to_string());
+    if mode == "download" {
+        let url = url.context("missing url")?;
+        // mode is not "local", so download & write the config first.
+        let config_data = ctx.get_file_system().read_to_string(config_file)?;
+        let config: context::IniConfig = toml::from_str(&config_data)?;
+        let mut paths: Vec<String> = Vec::new();
+        let values = config.wsgi.reference_housenumbers;
+        paths.append(
+            &mut values
+                .split(' ')
+                .map(|value| value.strip_prefix("workdir/refs/").unwrap().to_string())
+                .collect(),
+        );
+        let value = config.wsgi.reference_street;
+        paths.push(value.strip_prefix("workdir/refs/").unwrap().to_string());
+        let value = config.wsgi.reference_citycounts;
+        paths.push(value.strip_prefix("workdir/refs/").unwrap().to_string());
+        let value = config.wsgi.reference_zipcounts;
+        paths.push(value.strip_prefix("workdir/refs/").unwrap().to_string());
 
-    let mut dests: Vec<String> = Vec::new();
-    for path in &paths {
-        let url = format!("{url}{path}");
-        let dest = ctx.get_abspath(&format!("workdir/refs/{path}"));
-        dests.push(dest.to_string());
-        if ctx.get_file_system().path_exists(&dest) {
-            continue;
+        let mut dests: Vec<String> = Vec::new();
+        for path in &paths {
+            let url = format!("{url}{path}");
+            let dest = ctx.get_abspath(&format!("workdir/refs/{path}"));
+            dests.push(dest.to_string());
+            if ctx.get_file_system().path_exists(&dest) {
+                continue;
+            }
+
+            stream.write_all(format!("sync-ref: downloading '{url}'...\n").as_bytes())?;
+            let buf = ctx.get_network().urlopen(&url, "")?;
+            ctx.get_file_system().write_from_string(&buf, &dest)?;
+        }
+        for path in ctx
+            .get_file_system()
+            .listdir(&ctx.get_abspath("workdir/refs"))?
+        {
+            if dests.contains(&path) {
+                continue;
+            }
+            let relpath = path.strip_prefix(&ctx.get_abspath("")).unwrap();
+            stream.write_all(format!("sync-ref: removing '{relpath}'...\n").as_bytes())?;
+            ctx.get_file_system().unlink(&path)?;
         }
 
-        stream.write_all(format!("sync-ref: downloading '{url}'...\n").as_bytes())?;
-        let buf = ctx.get_network().urlopen(&url, "")?;
-        ctx.get_file_system().write_from_string(&buf, &dest)?;
-    }
-    for path in ctx
-        .get_file_system()
-        .listdir(&ctx.get_abspath("workdir/refs"))?
-    {
-        if dests.contains(&path) {
-            continue;
-        }
-        let relpath = path.strip_prefix(&ctx.get_abspath("")).unwrap();
-        stream.write_all(format!("sync-ref: removing '{relpath}'...\n").as_bytes())?;
-        ctx.get_file_system().unlink(&path)?;
+        ctx.get_file_system()
+            .write_from_string(&config_data, &ctx.get_abspath("workdir/wsgi.ini"))?;
     }
 
     stream.write_all("sync-ref: removing old index...\n".as_bytes())?;
@@ -72,8 +80,6 @@ pub fn download(
     // 2024-03-24
     conn.execute_batch("delete from mtimes where page = 'stats/invalid-addr-cities'")?;
 
-    ctx.get_file_system()
-        .write_from_string(&config_data, &ctx.get_abspath("workdir/wsgi.ini"))?;
     stream.write_all("sync-ref: ok\n".as_bytes())?;
     Ok(())
 }
@@ -86,29 +92,27 @@ pub fn our_main(
 ) -> anyhow::Result<()> {
     let url = clap::Arg::new("url")
         .long("url")
-        .required(true)
         .help("public instance URL");
     let mode = clap::Arg::new("mode")
         .long("mode")
         .default_value("config")
-        .help("update the config or download based on config [config or download]");
+        .help("update the config or download based on config [config, download or local; default: config]");
     let args = [url, mode];
     let app = clap::Command::new("osm-gimmisn").override_usage(
         "osm-gimmisn sync-ref [--mode download] --url https://osm.example.com/data/",
     );
     let args = app.args(&args).try_get_matches_from(argv)?;
-    let url = args
-        .get_one::<String>("url")
-        .context("missing url")?
-        .to_string();
+    let url = args.get_one::<String>("url");
 
     let config_file = ctx.get_abspath("data/wsgi.ini.template");
-    if args.get_one::<String>("mode").unwrap() == "download" {
-        return download(stream, ctx, &config_file, &url);
+    let mode = args.get_one::<String>("mode").unwrap();
+    if mode == "download" || mode == "local" {
+        return download(stream, ctx, &config_file, &url, mode);
     }
 
     // Download HTML.
-    let mut html = ctx.get_network().urlopen(&url, "")?;
+    let url = url.context("missing url")?;
+    let mut html = ctx.get_network().urlopen(url, "")?;
     // Work around 'expected attribute key' failure.
     html = html.replace(
         r#"<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">"#,

--- a/src/sync_ref/tests.rs
+++ b/src/sync_ref/tests.rs
@@ -128,6 +128,25 @@ sync-ref: ok
     assert_eq!(ret, 0);
 }
 
+/// Tests main(), the local mode.
+#[test]
+fn test_main_local() {
+    let argv = vec!["".to_string(), "--mode".to_string(), "local".to_string()];
+    let mut buf: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
+    let mut ctx = context::tests::make_test_context().unwrap();
+
+    let ret = main(&argv, &mut buf, &mut ctx);
+
+    assert_eq!(ret, 0);
+    let buf = String::from_utf8(buf.into_inner()).unwrap();
+    assert_eq!(
+        buf,
+        r#"sync-ref: removing old index...
+sync-ref: ok
+"#
+    );
+}
+
 /// Tests main(), missing URL.
 #[test]
 fn test_main_no_url() {


### PR DESCRIPTION
This is similar to '--mode download', but doesn't download anything and
doesn't touch the config, either.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/3826>.

Change-Id: I3f4d77638c665d8e3af3ee05945c85072976c1ae
