### PR TITLE
stats: only ignore SQLITE_CONSTRAINT_UNIQUE errors and still handle the rest

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -288,5 +288,22 @@ pub fn init(conn: &rusqlite::Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Ignores a unique constraint violation error, but not other errors.
+pub fn ignore_unique_constraint(
+    result: Result<usize, rusqlite::Error>,
+) -> Result<(), rusqlite::Error> {
+    match result {
+        Err(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ErrorCode::ConstraintViolation,
+                extended_code: rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE,
+            },
+            _,
+        )) => Ok(()),
+        Err(err) => Err(err),
+        Ok(_) => Ok(()),
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/sql/tests.rs
+++ b/src/sql/tests.rs
@@ -22,3 +22,31 @@ fn test_init() {
     // Check that init() for an already up to date schema results in no errors.
     init(&conn).unwrap();
 }
+
+/// Tests ignore_unique_constraint(), when the error is a unique constraint violation.
+#[test]
+fn test_ignore_unique_constraint_mapped_to_ok() {
+    let ret = ignore_unique_constraint(Err(rusqlite::Error::SqliteFailure(
+        rusqlite::ffi::Error {
+            code: rusqlite::ErrorCode::Unknown,
+            extended_code: 0,
+        },
+        None,
+    )));
+
+    assert!(ret.is_err());
+}
+
+/// Tests ignore_unique_constraint(), when the error is something else.
+#[test]
+fn test_ignore_unique_constraint_err() {
+    let ret = ignore_unique_constraint(Err(rusqlite::Error::SqliteFailure(
+        rusqlite::ffi::Error {
+            code: rusqlite::ErrorCode::ConstraintViolation,
+            extended_code: rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE,
+        },
+        None,
+    )));
+
+    assert!(ret.is_ok());
+}


### PR DESCRIPTION
Commit 33c5c51a87e1648094b2cb6813f610ebddbe2556 (stats: it's OK to not
overwrite previous count from the same day, 2024-03-31) went a bit too
far, it's enough to ignore just one specific error here.

Change-Id: Ic5ddc0dbfda9f2a27363c9f8f703de20e26fb54e
