### PR TITLE
validator: flag osm=ref in refstreets

### DIFF
--- a/src/validator.rs
+++ b/src/validator.rs
@@ -164,6 +164,9 @@ fn validate_refstreets(
         if value.contains('\'') || value.contains('"') {
             errors.push(format!("expected no quotes in value of '{context}{key}'"));
         }
+        if key == value {
+            errors.push(format!("expected value != key for '{context}{key}'"));
+        }
     }
     let mut reverse: Vec<_> = refstreets
         .iter()

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -274,6 +274,18 @@ failed to validate {0}
     assert_failure_msg(content, expected);
 }
 
+/// Tests the relation path: bad refstreets value, osm=ref.
+#[test]
+fn test_relation_refstreets_bad_value() {
+    let content = r#"refstreets:
+  'OSM Name 1': 'OSM Name 1'
+"#;
+    let expected = r#"expected value != key for 'refstreets.OSM Name 1'
+failed to validate {0}
+"#;
+    assert_failure_msg(content, expected);
+}
+
 /// Tests the relation path: bad filters -> ... -> invalid subkey.
 #[test]
 fn test_relation_filters_invalid_bad2() {


### PR DESCRIPTION
The whole point of refstreets is to map between ref and osm, so if it's
the same, then the entry should be just removed.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/3850>.

Change-Id: Ie69dbcd024bfd159a5835b3890efe4c17ecebcf0
