### PR TITLE
lints, invalid-addr-cities: fix ignoring unique constraint failure

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -288,15 +288,15 @@ pub fn init(conn: &rusqlite::Connection) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Ignores a unique constraint violation error, but not other errors.
-pub fn ignore_unique_constraint(
+/// Ignores a primary key constraint violation error, but not other errors.
+pub fn ignore_primary_key_constraint(
     result: Result<usize, rusqlite::Error>,
 ) -> Result<(), rusqlite::Error> {
     match result {
         Err(rusqlite::Error::SqliteFailure(
             rusqlite::ffi::Error {
                 code: rusqlite::ErrorCode::ConstraintViolation,
-                extended_code: rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE,
+                extended_code: rusqlite::ffi::SQLITE_CONSTRAINT_PRIMARYKEY,
             },
             _,
         )) => Ok(()),

--- a/src/sql/tests.rs
+++ b/src/sql/tests.rs
@@ -23,10 +23,10 @@ fn test_init() {
     init(&conn).unwrap();
 }
 
-/// Tests ignore_unique_constraint(), when the error is a unique constraint violation.
+/// Tests ignore_primary_key_constraint(), when the error is a primary key constraint violation.
 #[test]
-fn test_ignore_unique_constraint_mapped_to_ok() {
-    let ret = ignore_unique_constraint(Err(rusqlite::Error::SqliteFailure(
+fn test_ignore_primary_key_constraint_mapped_to_ok() {
+    let ret = ignore_primary_key_constraint(Err(rusqlite::Error::SqliteFailure(
         rusqlite::ffi::Error {
             code: rusqlite::ErrorCode::Unknown,
             extended_code: 0,
@@ -37,13 +37,13 @@ fn test_ignore_unique_constraint_mapped_to_ok() {
     assert!(ret.is_err());
 }
 
-/// Tests ignore_unique_constraint(), when the error is something else.
+/// Tests ignore_primary_key_constraint(), when the error is something else.
 #[test]
-fn test_ignore_unique_constraint_err() {
-    let ret = ignore_unique_constraint(Err(rusqlite::Error::SqliteFailure(
+fn test_ignore_primary_key_constraint_err() {
+    let ret = ignore_primary_key_constraint(Err(rusqlite::Error::SqliteFailure(
         rusqlite::ffi::Error {
             code: rusqlite::ErrorCode::ConstraintViolation,
-            extended_code: rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE,
+            extended_code: rusqlite::ffi::SQLITE_CONSTRAINT_PRIMARYKEY,
         },
         None,
     )));

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -594,10 +594,11 @@ pub fn update_invalid_addr_cities(ctx: &context::Context) -> anyhow::Result<()> 
             [&row.osm_id, &row.osm_type, &row.postcode, &row.city, &row.street, &row.housenumber, &row.user, &row.timestamp, &row.fixme])?;
     }
     // It's OK to not overwrite previous count from the same day.
-    sql::ignore_unique_constraint(tx.execute(
+    sql::ignore_primary_key_constraint(tx.execute(
         "insert into stats_invalid_addr_cities_counts (date, count) values (?1, ?2)",
         [today, invalids.len().to_string()],
-    ))?;
+    ))
+    .context("insert into stats_invalid_addr_cities_counts failed")?;
     tx.commit()?;
 
     Ok(())

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -809,14 +809,14 @@ fn handle_invalid_addr_cities(
 }
 
 fn handle_invalid_addr_cities_update(ctx: &context::Context) -> anyhow::Result<()> {
-    cron::update_stats_overpass(ctx)?;
-    stats::update_invalid_addr_cities(ctx)?;
+    cron::update_stats_overpass(ctx).context("update_stats_overpass failed")?;
+    stats::update_invalid_addr_cities(ctx).context("update_invalid_addr_cities failed")?;
     Ok(())
 }
 
 /// Expected request uri: /lints/whole-country/invalid-addr-cities/update-result.json.
 pub fn handle_invalid_addr_cities_update_json(ctx: &context::Context) -> anyhow::Result<String> {
-    handle_invalid_addr_cities_update(ctx)?;
+    handle_invalid_addr_cities_update(ctx).context("handle_invalid_addr_cities_update failed")?;
     let mut ret: HashMap<String, String> = HashMap::new();
     ret.insert("error".into(), "".into());
     Ok(serde_json::to_string(&ret)?)


### PR DESCRIPTION
Getting the
/osm/lints/whole-country/invalid-addr-cities/update-result.json worked
the first time on a day, but later updates failed.

These non-first updates mostly worked, except that the non-update of the
stats chart resulted in an error. The non-update is intentional, but the
expected behavior is to not singal an error, either.  A problem since
commit c2cd175565c61d591fd83ee0a34aaa8ff1b46637 (stats: only ignore
SQLITE_CONSTRAINT_UNIQUE errors and still handle the rest, 2024-04-06),
which started to not ignore all error, but the constraint violated here
is a primary key one, but directly a unique one.

Fix the problem by ignoring SQLITE_CONSTRAINT_PRIMARYKEY instead of
SQLITE_CONSTRAINT_UNIQUE, which means a manual update of the stats won't
affect the recorded data for charts, and this lack of update is not
returned as an error, either.

In addition, the failure is not reported as a well-formed error, either;
that's not yet fixed here.

Change-Id: I329ffa76714ff6b0fdbe1cfe14fe5bdc8001ed2a
