### PR TITLE
webframe: improve error reporting in the JSON case

### DIFF
--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -492,6 +492,12 @@ pub fn handle_static(
 
 /// Displays an unhandled error on the page.
 pub fn handle_error(request: &rouille::Request, error: &str) -> rouille::Response {
+    if request.url().ends_with(".json") {
+        let mut ret: HashMap<String, String> = HashMap::new();
+        ret.insert("error".into(), error.into());
+        return rouille::Response::json(&ret);
+    }
+
     let doc = yattag::Doc::new();
     util::write_html_header(&doc);
     {

--- a/src/webframe/tests.rs
+++ b/src/webframe/tests.rs
@@ -406,3 +406,18 @@ fn test_handle_invalid_addr_cities_update_json() {
         assert!(!last_modified.is_empty());
     }
 }
+
+/// Tests the generic error handler for the json case.
+#[test]
+fn test_handle_error_json() {
+    let request = rouille::Request::fake_http("GET", "/test.json", vec![], vec![]);
+
+    let response = handle_error(&request, "myerror");
+
+    let mut data = Vec::new();
+    let (mut reader, _size) = response.data.into_reader_and_size();
+    reader.read_to_end(&mut data).unwrap();
+    let output = String::from_utf8(data).unwrap();
+    let value: HashMap<String, String> = serde_json::from_str(&output).unwrap();
+    assert_eq!(value["error"], "myerror");
+}


### PR DESCRIPTION
The intention was to still return a valid json in the error case, with
a non-empty "error" key. We returned

```
<!DOCTYPE html>
<pre>Internal error when serving ...
```

instead, fix this.

Change-Id: I15a17287bc1abd33380e83f691b5cfe88c76361a
