### PR TITLE
Store missing housenumbers json cache in sql

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -132,11 +132,6 @@ impl RelationFiles {
         )
     }
 
-    /// Builds the file name of the house number json cache file of a relation.
-    pub fn get_housenumbers_jsoncache_path(&self) -> String {
-        format!("{}/cache-{}.json", self.workdir, self.name)
-    }
-
     /// Builds the file name of the additional house number json cache file of a relation.
     pub fn get_additional_housenumbers_jsoncache_path(&self) -> String {
         format!("{}/additional-cache-{}.json", self.workdir, self.name)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -46,9 +46,40 @@ fn is_cache_current(
     Ok(true)
 }
 
+/// Decides if we have an up to date cache entry or not.
+fn is_sql_cache_current(
+    ctx: &context::Context,
+    cache_key: &str,
+    dependencies: &[String],
+    sql_dependencies: &[String],
+) -> anyhow::Result<bool> {
+    if !stats::has_sql_mtime(ctx, cache_key)? {
+        return Ok(false);
+    }
+
+    let cache_mtime = stats::get_sql_mtime(ctx, cache_key)?;
+
+    for dependency in dependencies {
+        if ctx.get_file_system().path_exists(dependency)
+            && ctx.get_file_system().getmtime(dependency)? > cache_mtime
+        {
+            return Ok(false);
+        }
+    }
+
+    for dependency in sql_dependencies {
+        if stats::has_sql_mtime(ctx, dependency)?
+            && stats::get_sql_mtime(ctx, dependency)? > cache_mtime
+        {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
 /// Decides if we have an up to date json cache entry or not.
 fn is_missing_housenumbers_json_cached(relation: &mut areas::Relation<'_>) -> anyhow::Result<bool> {
-    let cache_path = relation.get_files().get_housenumbers_jsoncache_path();
     let datadir = relation.get_ctx().get_abspath("data");
     let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
     let dependencies = vec![
@@ -59,9 +90,9 @@ fn is_missing_housenumbers_json_cached(relation: &mut areas::Relation<'_>) -> an
         format!("streets/{}", relation.get_name()),
         format!("housenumbers/{}", relation.get_name()),
     ];
-    is_cache_current(
+    is_sql_cache_current(
         relation.get_ctx(),
-        &cache_path,
+        &format!("missing-housenumbers-cache/{}", relation.get_name()),
         &dependencies,
         &sql_dependencies,
     )
@@ -70,22 +101,28 @@ fn is_missing_housenumbers_json_cached(relation: &mut areas::Relation<'_>) -> an
 /// Gets the cached json of the missing housenumbers for a relation.
 pub fn get_missing_housenumbers_json(relation: &mut areas::Relation<'_>) -> anyhow::Result<String> {
     let output: String;
-    let jsoncache_path = relation.get_files().get_housenumbers_jsoncache_path();
     if is_missing_housenumbers_json_cached(relation)? {
-        output = relation
-            .get_ctx()
-            .get_file_system()
-            .read_to_string(&jsoncache_path)?;
+        output = stats::get_sql_json(
+            relation.get_ctx(),
+            "missing_housenumbers_cache",
+            &relation.get_name(),
+        )?;
         return Ok(output);
     }
 
     let missing_housenumbers = relation.get_missing_housenumbers()?;
     output = serde_json::to_string(&missing_housenumbers)?;
 
-    relation
-        .get_ctx()
-        .get_file_system()
-        .write_from_string(&output, &jsoncache_path)?;
+    stats::set_sql_json(
+        relation.get_ctx(),
+        "missing_housenumbers_cache",
+        &relation.get_name(),
+        &output,
+    )?;
+    stats::set_sql_mtime(
+        relation.get_ctx(),
+        &format!("missing-housenumbers-cache/{}", &relation.get_name()),
+    )?;
 
     relation.write_lints()?;
 

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -203,13 +203,11 @@ fn test_update_missing_housenumbers() {
         },
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
-    let json_cache = context::tests::TestFileSystem::make_file();
     let ref_housenumbers = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
         &[
             ("data/yamls.cache", &yamls_cache_value),
-            ("workdir/cache-gazdagret.json", &json_cache),
             (
                 "workdir/street-housenumbers-reference-gazdagret.lst",
                 &ref_housenumbers,
@@ -224,12 +222,6 @@ fn test_update_missing_housenumbers() {
             &ctx.get_abspath("workdir/street-housenumbers-reference-gazdagret.lst"),
         )
         .unwrap();
-    let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
-    mtimes.insert(
-        ctx.get_abspath("workdir/cache-gazdagret.json"),
-        Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
-    );
-    file_system.set_mtimes(&mtimes);
     let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
     ctx.set_file_system(&file_system_rc);
     let mtime = ctx.get_time().now_string();
@@ -1140,7 +1132,6 @@ fn test_our_main() {
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
     let ref_housenumbers_value = context::tests::TestFileSystem::make_file();
-    let missing_housenumbers_json = context::tests::TestFileSystem::make_file();
     let template_value = context::tests::TestFileSystem::make_file();
     template_value
         .borrow_mut()
@@ -1159,7 +1150,6 @@ fn test_our_main() {
                 "workdir/street-housenumbers-reference-gazdagret.lst",
                 &ref_housenumbers_value,
             ),
-            ("workdir/cache-gazdagret.json", &missing_housenumbers_json),
             ("data/streets-template.overpassql", &template_value),
             (
                 "data/street-housenumbers-template.overpassql",
@@ -1169,13 +1159,6 @@ fn test_our_main() {
     );
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);
-    let mut mtimes: HashMap<String, Rc<RefCell<time::OffsetDateTime>>> = HashMap::new();
-    let path = ctx.get_abspath("workdir/cache-gazdagret.json");
-    mtimes.insert(
-        path,
-        Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
-    );
-    file_system.set_mtimes(&mtimes);
     let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
     ctx.set_file_system(&file_system_rc);
     let mtime = ctx.get_time().now_string();

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -284,7 +284,20 @@ pub fn init(conn: &rusqlite::Connection) -> anyhow::Result<()> {
         )?;
     }
 
-    conn.execute("pragma user_version = 15", [])?;
+    if user_version < 16 {
+        // Per-relation cache for the missing-housenumbers analysis.
+        conn.execute_batch(
+            "create table missing_housenumbers_cache (
+                    relation text not null,
+                    json text not null,
+                    unique(relation)
+                );
+            create index idx_missing_housenumbers_cache
+                on missing_housenumbers_cache(relation);",
+        )?;
+    }
+
+    conn.execute("pragma user_version = 16", [])?;
     Ok(())
 }
 


### PR DESCRIPTION
- new missing-housenumbers-cache/<relation> key in the mtimes table

- new missing_housenumbers_cache table

Towards emptying these when the reference is updated.

Change-Id: I76b412cf9122d8430976151a8c19c3a9c7df0750
