### PR TITLE
sync-ref: empty missing-housenumbers cache on ref update

### DIFF
--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -76,6 +76,11 @@ pub fn download(
     let conn = ctx.get_database_connection()?;
     conn.execute("delete from ref_housenumbers", [])?;
     conn.execute("delete from ref_streets", [])?;
+
+    // These caches have explicit dependencies only on OSM data, so empty them now.
+    conn.execute_batch("delete from missing_housenumbers_cache")?;
+    conn.execute_batch("delete from mtimes where page like 'missing-housenumbers-cache/%'")?;
+
     // Garbage collect other unused data.
     // 2024-03-24
     conn.execute_batch("delete from mtimes where page = 'stats/invalid-addr-cities'")?;


### PR DESCRIPTION
See cache::is_missing_housenumbers_json_cached(), this cache doesn't
depend on the ref streets, so best to empty it on ref update.

Change-Id: I9ab303f5b4f6f0a9ec611f782da206d3c6e78d47
