### PR TITLE
sql: run schema upgrades in transaction

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -68,8 +68,8 @@ pub trait Database {
 
     /// Opens and initializes a new database connection.
     fn create(&self) -> anyhow::Result<rusqlite::Connection> {
-        let conn = self.open()?;
-        sql::init(&conn)?;
+        let mut conn = self.open()?;
+        sql::init(&mut conn)?;
         Ok(conn)
     }
 }

--- a/src/sql/tests.rs
+++ b/src/sql/tests.rs
@@ -17,10 +17,10 @@ use crate::context;
 #[test]
 fn test_init() {
     let ctx = context::tests::make_test_context().unwrap();
-    let conn = ctx.get_database_connection().unwrap();
+    let mut conn = ctx.get_database_connection().unwrap();
 
     // Check that init() for an already up to date schema results in no errors.
-    init(&conn).unwrap();
+    init(&mut conn).unwrap();
 }
 
 /// Tests ignore_primary_key_constraint(), when the error is a primary key constraint violation.


### PR DESCRIPTION
Reportedly we ended up in a situation where the version was still 15,
but 16's table / index was created already.

Change-Id: I9342be8e8f04775c9c47dd6fb1900606c6f6b213
