### PR TITLE
sync-ref: load the ref streets into sql right after getting them

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -605,9 +605,7 @@ impl<'a> Relation<'a> {
 
     /// Gets streets from reference.
     fn get_ref_streets(&self) -> anyhow::Result<Vec<String>> {
-        let mut conn = self.ctx.get_database_connection()?;
-        let reference = self.ctx.get_ini().get_reference_street_path()?;
-        util::build_street_reference_index(self.ctx, &mut conn, &reference)?;
+        let conn = self.ctx.get_database_connection()?;
 
         let mut streets: Vec<String> = Vec::new();
         let mut stmt = conn.prepare(

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -1209,6 +1209,11 @@ way{color:blue; width:4;}
 #[test]
 fn test_relation_get_ref_streets() {
     let mut ctx = context::tests::make_test_context().unwrap();
+    {
+        let mut conn = ctx.get_database_connection().unwrap();
+        let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
+        util::build_street_reference_index(&ctx, &mut conn, &ref_streets).unwrap();
+    }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
         },
@@ -1916,6 +1921,11 @@ fn test_relation_get_missing_housenumbers_letter_suffix_normalize_semicolon() {
 #[test]
 fn test_relation_get_missing_streets() {
     let mut ctx = context::tests::make_test_context().unwrap();
+    {
+        let mut conn = ctx.get_database_connection().unwrap();
+        let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
+        util::build_street_reference_index(&ctx, &mut conn, &ref_streets).unwrap();
+    }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
         },
@@ -1970,6 +1980,11 @@ fn test_relation_get_missing_streets() {
 #[test]
 fn test_relation_get_additional_streets() {
     let mut ctx = context::tests::make_test_context().unwrap();
+    {
+        let mut conn = ctx.get_database_connection().unwrap();
+        let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
+        util::build_street_reference_index(&ctx, &mut conn, &ref_streets).unwrap();
+    }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
@@ -2327,6 +2342,11 @@ fn test_relation_write_missing_housenumbers_sorting() {
 #[test]
 fn test_write_missing_streets() {
     let mut ctx = context::tests::make_test_context().unwrap();
+    {
+        let mut conn = ctx.get_database_connection().unwrap();
+        let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
+        util::build_street_reference_index(&ctx, &mut conn, &ref_streets).unwrap();
+    }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -298,6 +298,11 @@ fn test_update_missing_housenumbers() {
 #[test]
 fn test_update_missing_streets() {
     let mut ctx = context::tests::make_test_context().unwrap();
+    {
+        let mut conn = ctx.get_database_connection().unwrap();
+        let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
+        util::build_street_reference_index(&ctx, &mut conn, &ref_streets).unwrap();
+    }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
@@ -373,6 +378,11 @@ fn test_update_missing_streets() {
 #[test]
 fn test_update_additional_streets() {
     let mut ctx = context::tests::make_test_context().unwrap();
+    {
+        let mut conn = ctx.get_database_connection().unwrap();
+        let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
+        util::build_street_reference_index(&ctx, &mut conn, &ref_streets).unwrap();
+    }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
@@ -1105,6 +1115,11 @@ fn test_update_stats_no_overpass() {
 #[test]
 fn test_our_main() {
     let mut ctx = context::tests::make_test_context().unwrap();
+    {
+        let mut conn = ctx.get_database_connection().unwrap();
+        let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
+        util::build_street_reference_index(&ctx, &mut conn, &ref_streets).unwrap();
+    }
     let routes = vec![
         context::tests::URLRoute::new(
             /*url=*/ "https://overpass-api.de/api/interpreter",

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -2053,6 +2053,11 @@ fn test_missing_streets_well_formed() {
 #[test]
 fn test_missing_streets_well_formed_compat() {
     let mut test_wsgi = TestWsgi::new();
+    {
+        let mut conn = test_wsgi.ctx.get_database_connection().unwrap();
+        let ref_streets = test_wsgi.ctx.get_ini().get_reference_street_path().unwrap();
+        util::build_street_reference_index(&test_wsgi.ctx, &mut conn, &ref_streets).unwrap();
+    }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
@@ -2137,6 +2142,11 @@ fn test_missing_streets_no_osm_streets_well_formed() {
 #[test]
 fn test_missing_streets_view_result_txt() {
     let mut test_wsgi = TestWsgi::new();
+    {
+        let mut conn = test_wsgi.ctx.get_database_connection().unwrap();
+        let ref_streets = test_wsgi.ctx.get_ini().get_reference_street_path().unwrap();
+        util::build_street_reference_index(&test_wsgi.ctx, &mut conn, &ref_streets).unwrap();
+    }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {
@@ -2197,6 +2207,11 @@ fn test_missing_streets_view_result_txt() {
 #[test]
 fn test_missing_streets_view_result_chkl() {
     let mut test_wsgi = TestWsgi::new();
+    {
+        let mut conn = test_wsgi.ctx.get_database_connection().unwrap();
+        let ref_streets = test_wsgi.ctx.get_ini().get_reference_street_path().unwrap();
+        util::build_street_reference_index(&test_wsgi.ctx, &mut conn, &ref_streets).unwrap();
+    }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gazdagret": {

--- a/src/wsgi_additional/tests.rs
+++ b/src/wsgi_additional/tests.rs
@@ -47,6 +47,36 @@ fn test_streets_view_result_txt() {
     test_wsgi.get_ctx().set_file_system(&file_system);
     {
         let conn = test_wsgi.get_ctx().get_database_connection().unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Törökugrató utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Tűzkő utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Ref Name 1"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Only In Ref utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Only In Ref Nonsense utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Hamzsabégi út"],
+        )
+        .unwrap();
         conn.execute_batch(
             "insert into osm_streets (relation, osm_id, name, highway, service, surface, leisure, osm_type) values ('gazdagret', '1', 'Tűzkő utca', '', '', '', '', '');
             insert into osm_streets (relation, osm_id, name, highway, service, surface, leisure, osm_type) values ('gazdagret', '2', 'Törökugrató utca', '', '', '', '', '');
@@ -108,6 +138,36 @@ fn test_streets_view_result_gpx() {
     let mtime = test_wsgi.get_ctx().get_time().now_string();
     {
         let conn = test_wsgi.get_ctx().get_database_connection().unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Törökugrató utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Tűzkő utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Ref Name 1"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Only In Ref utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Only In Ref Nonsense utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Hamzsabégi út"],
+        )
+        .unwrap();
         conn.execute(
             "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
             ["gazdagret", "1", "Törökugrató utca", "1", "", "", "", "", "", "", "", "", "", "node"],
@@ -189,6 +249,36 @@ fn test_streets_view_result_chkl() {
     let mtime = test_wsgi.get_ctx().get_time().now_string();
     {
         let conn = test_wsgi.get_ctx().get_database_connection().unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Törökugrató utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Tűzkő utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Ref Name 1"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Only In Ref utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Only In Ref Nonsense utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Hamzsabégi út"],
+        )
+        .unwrap();
         conn.execute(
             r#"insert into osm_streets (relation, osm_id, name, highway, service, surface, leisure, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"#,
             ["gazdagret", "1", "Tűzkő utca", "", "", "", "", ""],
@@ -605,6 +695,36 @@ fn test_streets_well_formed() {
     let mtime = test_wsgi.get_ctx().get_time().now_string();
     {
         let conn = test_wsgi.get_ctx().get_database_connection().unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Törökugrató utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Tűzkő utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Ref Name 1"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Only In Ref utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Only In Ref Nonsense utca"],
+        )
+        .unwrap();
+        conn.execute(
+            r#"insert into ref_streets (county_code, settlement_code, street) values (?1, ?2, ?3)"#,
+            ["01", "011", "Hamzsabégi út"],
+        )
+        .unwrap();
         conn.execute(
             r#"insert into osm_streets (relation, osm_id, name, highway, service, surface, leisure, osm_type) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)"#,
             ["gazdagret", "1", "Tűzkő utca", "", "", "", "", ""],


### PR DESCRIPTION
Once the same is done for housenumbers, can start to migrate away from
workdir/street-housenumbers-reference-<relation>.lst files.

Change-Id: I1b46875cb88b34156f9de06ef22b6ddec29606f3
