### PR TITLE
util::build_street_reference_index: just take a ctx, no need to take a connection

### DIFF
--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -1210,9 +1210,8 @@ way{color:blue; width:4;}
 fn test_relation_get_ref_streets() {
     let mut ctx = context::tests::make_test_context().unwrap();
     {
-        let mut conn = ctx.get_database_connection().unwrap();
         let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
-        util::build_street_reference_index(&ctx, &mut conn, &ref_streets).unwrap();
+        util::build_street_reference_index(&ctx, &ref_streets).unwrap();
     }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
@@ -1922,9 +1921,8 @@ fn test_relation_get_missing_housenumbers_letter_suffix_normalize_semicolon() {
 fn test_relation_get_missing_streets() {
     let mut ctx = context::tests::make_test_context().unwrap();
     {
-        let mut conn = ctx.get_database_connection().unwrap();
         let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
-        util::build_street_reference_index(&ctx, &mut conn, &ref_streets).unwrap();
+        util::build_street_reference_index(&ctx, &ref_streets).unwrap();
     }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
@@ -1981,9 +1979,8 @@ fn test_relation_get_missing_streets() {
 fn test_relation_get_additional_streets() {
     let mut ctx = context::tests::make_test_context().unwrap();
     {
-        let mut conn = ctx.get_database_connection().unwrap();
         let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
-        util::build_street_reference_index(&ctx, &mut conn, &ref_streets).unwrap();
+        util::build_street_reference_index(&ctx, &ref_streets).unwrap();
     }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
@@ -2343,9 +2340,8 @@ fn test_relation_write_missing_housenumbers_sorting() {
 fn test_write_missing_streets() {
     let mut ctx = context::tests::make_test_context().unwrap();
     {
-        let mut conn = ctx.get_database_connection().unwrap();
         let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
-        util::build_street_reference_index(&ctx, &mut conn, &ref_streets).unwrap();
+        util::build_street_reference_index(&ctx, &ref_streets).unwrap();
     }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -299,9 +299,8 @@ fn test_update_missing_housenumbers() {
 fn test_update_missing_streets() {
     let mut ctx = context::tests::make_test_context().unwrap();
     {
-        let mut conn = ctx.get_database_connection().unwrap();
         let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
-        util::build_street_reference_index(&ctx, &mut conn, &ref_streets).unwrap();
+        util::build_street_reference_index(&ctx, &ref_streets).unwrap();
     }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
@@ -379,9 +378,8 @@ fn test_update_missing_streets() {
 fn test_update_additional_streets() {
     let mut ctx = context::tests::make_test_context().unwrap();
     {
-        let mut conn = ctx.get_database_connection().unwrap();
         let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
-        util::build_street_reference_index(&ctx, &mut conn, &ref_streets).unwrap();
+        util::build_street_reference_index(&ctx, &ref_streets).unwrap();
     }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
@@ -1116,9 +1114,8 @@ fn test_update_stats_no_overpass() {
 fn test_our_main() {
     let mut ctx = context::tests::make_test_context().unwrap();
     {
-        let mut conn = ctx.get_database_connection().unwrap();
         let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
-        util::build_street_reference_index(&ctx, &mut conn, &ref_streets).unwrap();
+        util::build_street_reference_index(&ctx, &ref_streets).unwrap();
     }
     let routes = vec![
         context::tests::URLRoute::new(

--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -74,13 +74,16 @@ pub fn download(
     }
 
     stream.write_all("sync-ref: removing old index...\n".as_bytes())?;
-    let mut conn = ctx.get_database_connection()?;
-    conn.execute("delete from ref_housenumbers", [])?;
-    conn.execute("delete from ref_streets", [])?;
+    {
+        let conn = ctx.get_database_connection()?;
+        conn.execute("delete from ref_housenumbers", [])?;
+        conn.execute("delete from ref_streets", [])?;
+    }
     let ref_streets = ctx.get_ini().get_reference_street_path()?;
-    util::build_street_reference_index(ctx, &mut conn, &ref_streets)?;
+    util::build_street_reference_index(ctx, &ref_streets)?;
 
     // These caches have explicit dependencies only on OSM data, so empty them now.
+    let conn = ctx.get_database_connection()?;
     conn.execute_batch("delete from missing_housenumbers_cache")?;
     conn.execute_batch("delete from mtimes where page like 'missing-housenumbers-cache/%'")?;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -663,11 +663,8 @@ pub fn build_reference_index(
 }
 
 /// Builds an in-database index from the reference TSV (street version).
-pub fn build_street_reference_index(
-    ctx: &context::Context,
-    conn: &mut rusqlite::Connection,
-    path: &str,
-) -> anyhow::Result<()> {
+pub fn build_street_reference_index(ctx: &context::Context, path: &str) -> anyhow::Result<()> {
+    let mut conn = ctx.get_database_connection()?;
     {
         // Check if the TSV is imported already.
         let mut stmt = conn.prepare("select count(*) from (select 0 from ref_streets limit 1)")?;

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -133,11 +133,14 @@ fn test_build_reference_index() {
 #[test]
 fn test_build_street_reference_index() {
     let ctx = context::tests::make_test_context().unwrap();
-    let mut conn = ctx.get_database_connection().unwrap();
-    conn.execute("delete from ref_streets", []).unwrap();
-    let refpath = ctx.get_abspath("workdir/refs/utcak_20190514.tsv");
-    build_street_reference_index(&ctx, &mut conn, &refpath).unwrap();
     {
+        let conn = ctx.get_database_connection().unwrap();
+        conn.execute("delete from ref_streets", []).unwrap();
+    }
+    let refpath = ctx.get_abspath("workdir/refs/utcak_20190514.tsv");
+    build_street_reference_index(&ctx, &refpath).unwrap();
+    {
+        let conn = ctx.get_database_connection().unwrap();
         let mut stmt = conn.prepare("select count(*) from ref_streets").unwrap();
         let mut rows = stmt.query([]).unwrap();
         while let Some(row) = rows.next().unwrap() {
@@ -147,8 +150,9 @@ fn test_build_street_reference_index() {
         }
     }
 
-    build_street_reference_index(&ctx, &mut conn, &refpath).unwrap();
+    build_street_reference_index(&ctx, &refpath).unwrap();
     {
+        let conn = ctx.get_database_connection().unwrap();
         let mut stmt = conn.prepare("select count(*) from ref_streets").unwrap();
         let mut rows = stmt.query([]).unwrap();
         while let Some(row) = rows.next().unwrap() {

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -810,9 +810,9 @@ fn handle_missing_streets(
         doc.append_value(missing_streets_view_turbo(relations, request_uri)?.get_value());
     } else if action == "view-query" {
         let pre = doc.tag("pre", &[]);
-        let mut conn = ctx.get_database_connection()?;
         let reference = ctx.get_ini().get_reference_street_path()?;
-        util::build_street_reference_index(ctx, &mut conn, &reference)?;
+        util::build_street_reference_index(ctx, &reference)?;
+        let conn = ctx.get_database_connection()?;
         let mut lst: Vec<String> = Vec::new();
         let mut stmt = conn.prepare(
             "select distinct street from ref_streets where county_code = ?1 and settlement_code = ?2 order by street",

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -2054,9 +2054,8 @@ fn test_missing_streets_well_formed() {
 fn test_missing_streets_well_formed_compat() {
     let mut test_wsgi = TestWsgi::new();
     {
-        let mut conn = test_wsgi.ctx.get_database_connection().unwrap();
         let ref_streets = test_wsgi.ctx.get_ini().get_reference_street_path().unwrap();
-        util::build_street_reference_index(&test_wsgi.ctx, &mut conn, &ref_streets).unwrap();
+        util::build_street_reference_index(&test_wsgi.ctx, &ref_streets).unwrap();
     }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
@@ -2143,9 +2142,8 @@ fn test_missing_streets_no_osm_streets_well_formed() {
 fn test_missing_streets_view_result_txt() {
     let mut test_wsgi = TestWsgi::new();
     {
-        let mut conn = test_wsgi.ctx.get_database_connection().unwrap();
         let ref_streets = test_wsgi.ctx.get_ini().get_reference_street_path().unwrap();
-        util::build_street_reference_index(&test_wsgi.ctx, &mut conn, &ref_streets).unwrap();
+        util::build_street_reference_index(&test_wsgi.ctx, &ref_streets).unwrap();
     }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
@@ -2208,9 +2206,8 @@ fn test_missing_streets_view_result_txt() {
 fn test_missing_streets_view_result_chkl() {
     let mut test_wsgi = TestWsgi::new();
     {
-        let mut conn = test_wsgi.ctx.get_database_connection().unwrap();
         let ref_streets = test_wsgi.ctx.get_ini().get_reference_street_path().unwrap();
-        util::build_street_reference_index(&test_wsgi.ctx, &mut conn, &ref_streets).unwrap();
+        util::build_street_reference_index(&test_wsgi.ctx, &ref_streets).unwrap();
     }
     let yamls_cache = serde_json::json!({
         "relations.yaml": {


### PR DESCRIPTION
It's less code and does the same.

Change-Id: I7cc4328e7e4ae7c059c0790754b394729caaff69
