### PR TITLE
util::build_reference_index: simplify this, don't require an sql connection

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -728,10 +728,7 @@ impl<'a> Relation<'a> {
     /// from OSM. Uses build_reference_cache() to build an indexed reference, the result will be
     /// used by get_ref_housenumbers().
     pub fn write_ref_housenumbers(&self, references: &[String]) -> anyhow::Result<()> {
-        {
-            let mut conn = self.ctx.get_database_connection()?;
-            util::build_reference_index(self.ctx, &mut conn, references)?;
-        }
+        util::build_reference_index(self.ctx, references)?;
 
         let streets: Vec<String> = self
             .get_osm_streets(/*sorted_results=*/ true)?

--- a/src/util.rs
+++ b/src/util.rs
@@ -600,11 +600,8 @@ pub struct RefHouseNumber {
 }
 
 /// Builds an in-database index from the reference TSV (house number version).
-pub fn build_reference_index(
-    ctx: &context::Context,
-    conn: &mut rusqlite::Connection,
-    paths: &[String],
-) -> anyhow::Result<()> {
+pub fn build_reference_index(ctx: &context::Context, paths: &[String]) -> anyhow::Result<()> {
+    let mut conn = ctx.get_database_connection()?;
     {
         // Check if the TSV is imported already.
         let mut stmt =

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -99,11 +99,14 @@ fn test_format_even_odd_html_multi_odd() {
 #[test]
 fn test_build_reference_index() {
     let ctx = context::tests::make_test_context().unwrap();
-    let mut conn = ctx.get_database_connection().unwrap();
-    conn.execute("delete from ref_housenumbers", []).unwrap();
-    let refpath = ctx.get_abspath("workdir/refs/hazszamok_20190511.tsv");
-    build_reference_index(&ctx, &mut conn, &[refpath.clone()]).unwrap();
     {
+        let conn = ctx.get_database_connection().unwrap();
+        conn.execute("delete from ref_housenumbers", []).unwrap();
+    }
+    let refpath = ctx.get_abspath("workdir/refs/hazszamok_20190511.tsv");
+    build_reference_index(&ctx, &[refpath.clone()]).unwrap();
+    {
+        let conn = ctx.get_database_connection().unwrap();
         let mut stmt = conn
             .prepare("select count(*) from ref_housenumbers")
             .unwrap();
@@ -115,8 +118,9 @@ fn test_build_reference_index() {
         }
     }
 
-    build_reference_index(&ctx, &mut conn, &[refpath]).unwrap();
+    build_reference_index(&ctx, &[refpath]).unwrap();
     {
+        let conn = ctx.get_database_connection().unwrap();
         let mut stmt = conn
             .prepare("select count(*) from ref_housenumbers")
             .unwrap();


### PR DESCRIPTION
It's less code this way.

Change-Id: I0b9db53d09468bd0f39f2d5ae1aec69aa415d6b3
