### PR TITLE
sync-ref: load the ref housenumbers into sql right after getting them

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -727,9 +727,7 @@ impl<'a> Relation<'a> {
     /// Writes known house numbers (not their coordinates) from a reference, based on street names
     /// from OSM. Uses build_reference_cache() to build an indexed reference, the result will be
     /// used by get_ref_housenumbers().
-    pub fn write_ref_housenumbers(&self, references: &[String]) -> anyhow::Result<()> {
-        util::build_reference_index(self.ctx, references)?;
-
+    pub fn write_ref_housenumbers(&self) -> anyhow::Result<()> {
         let streets: Vec<String> = self
             .get_osm_streets(/*sorted_results=*/ true)?
             .iter()

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -2440,9 +2440,6 @@ fn test_relation_writer_ref_housenumbers() {
         },
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
-    let refdir = ctx.get_abspath("workdir/refs");
-    let refpath = format!("{refdir}/hazszamok_20190511.tsv");
-    let refpath2 = format!("{refdir}/hazszamok_kieg_20190808.tsv");
     let ref_value = context::tests::TestFileSystem::make_file();
     let ref_housenumbers2 = context::tests::TestFileSystem::make_file();
     ref_housenumbers2
@@ -2471,6 +2468,8 @@ fn test_relation_writer_ref_housenumbers() {
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
+    let references = ctx.get_ini().get_reference_housenumber_paths().unwrap();
+    util::build_reference_index(&ctx, &references).unwrap();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute_batch(
@@ -2502,9 +2501,7 @@ Tűzkő utca	9
 "#;
     let relation = relations.get_relation(relation_name).unwrap();
 
-    relation
-        .write_ref_housenumbers(&[refpath, refpath2])
-        .unwrap();
+    relation.write_ref_housenumbers().unwrap();
 
     let mut guard = ref_value.borrow_mut();
     guard.seek(SeekFrom::Start(0)).unwrap();
@@ -2527,8 +2524,6 @@ fn test_relation_writer_ref_housenumbers_nosuchrefcounty() {
         },
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
-    let refdir = ctx.get_abspath("workdir/refs");
-    let refpath = format!("{refdir}/hazszamok_20190511.tsv");
     let ref_value = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
@@ -2546,7 +2541,7 @@ fn test_relation_writer_ref_housenumbers_nosuchrefcounty() {
     let relation_name = "nosuchrefcounty";
     let relation = relations.get_relation(relation_name).unwrap();
 
-    relation.write_ref_housenumbers(&[refpath]).unwrap();
+    relation.write_ref_housenumbers().unwrap();
 }
 
 /// Tests Relation::write_ref_housenumbers(): the case when the refsettlement code is missing in the reference.
@@ -2562,8 +2557,6 @@ fn test_relation_writer_ref_housenumbers_nosuchrefsettlement() {
         },
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
-    let refdir = ctx.get_abspath("workdir/refs");
-    let refpath = format!("{refdir}/hazszamok_20190511.tsv");
     let ref_value = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
@@ -2581,7 +2574,7 @@ fn test_relation_writer_ref_housenumbers_nosuchrefsettlement() {
     let relation_name = "nosuchrefsettlement";
     let relation = relations.get_relation(relation_name).unwrap();
 
-    relation.write_ref_housenumbers(&[refpath]).unwrap();
+    relation.write_ref_housenumbers().unwrap();
 }
 
 /// Tests the Relations struct.

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -140,14 +140,13 @@ fn update_ref_housenumbers(
         {
             continue;
         }
-        let references = ctx.get_ini().get_reference_housenumber_paths()?;
         let streets = relation.get_config().should_check_missing_streets();
         if streets == "only" {
             continue;
         }
 
         info!("update_ref_housenumbers: start: {relation_name}");
-        relation.write_ref_housenumbers(&references)?;
+        relation.write_ref_housenumbers()?;
         info!("update_ref_housenumbers: end: {relation_name}");
     }
 

--- a/src/cron/tests.rs
+++ b/src/cron/tests.rs
@@ -122,6 +122,8 @@ fn test_update_ref_housenumbers() {
     file_system.set_mtimes(&mtimes);
     let file_system_rc: Rc<dyn FileSystem> = Rc::new(file_system);
     ctx.set_file_system(&file_system_rc);
+    let references = ctx.get_ini().get_reference_housenumber_paths().unwrap();
+    util::build_reference_index(&ctx, &references).unwrap();
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute(
@@ -1113,10 +1115,10 @@ fn test_update_stats_no_overpass() {
 #[test]
 fn test_our_main() {
     let mut ctx = context::tests::make_test_context().unwrap();
-    {
-        let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
-        util::build_street_reference_index(&ctx, &ref_streets).unwrap();
-    }
+    let ref_streets = ctx.get_ini().get_reference_street_path().unwrap();
+    util::build_street_reference_index(&ctx, &ref_streets).unwrap();
+    let references = ctx.get_ini().get_reference_housenumber_paths().unwrap();
+    util::build_reference_index(&ctx, &references).unwrap();
     let routes = vec![
         context::tests::URLRoute::new(
             /*url=*/ "https://overpass-api.de/api/interpreter",

--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -81,6 +81,8 @@ pub fn download(
     }
     let ref_streets = ctx.get_ini().get_reference_street_path()?;
     util::build_street_reference_index(ctx, &ref_streets)?;
+    let references = ctx.get_ini().get_reference_housenumber_paths()?;
+    util::build_reference_index(ctx, &references)?;
 
     // These caches have explicit dependencies only on OSM data, so empty them now.
     let conn = ctx.get_database_connection()?;

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -692,9 +692,8 @@ fn missing_housenumbers_update(
     relations: &mut areas::Relations<'_>,
     relation_name: &str,
 ) -> anyhow::Result<yattag::Doc> {
-    let references = ctx.get_ini().get_reference_housenumber_paths()?;
     let relation = relations.get_relation(relation_name)?;
-    relation.write_ref_housenumbers(&references)?;
+    relation.write_ref_housenumbers()?;
     let doc = yattag::Doc::new();
     doc.text(&tr("Update successful: "));
     let prefix = ctx.get_ini().get_uri_prefix();

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -1645,6 +1645,12 @@ fn test_missing_housenumbers_update_result_link() {
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     test_wsgi.ctx.set_file_system(&file_system);
+    let references = test_wsgi
+        .ctx
+        .get_ini()
+        .get_reference_housenumber_paths()
+        .unwrap();
+    util::build_reference_index(&test_wsgi.ctx, &references).unwrap();
     let mtime = test_wsgi.get_ctx().get_time().now_string();
     {
         let conn = test_wsgi.get_ctx().get_database_connection().unwrap();

--- a/src/wsgi_json.rs
+++ b/src/wsgi_json.rs
@@ -68,17 +68,15 @@ fn street_housenumbers_update_result_json(
 
 /// Expected request_uri: e.g. /osm/missing-housenumbers/ormezo/update-result.json.
 fn missing_housenumbers_update_result_json(
-    ctx: &context::Context,
     relations: &mut areas::Relations<'_>,
     request_uri: &str,
 ) -> anyhow::Result<String> {
     let mut tokens = request_uri.split('/');
     tokens.next_back();
     let relation_name = tokens.next_back().context("short tokens")?;
-    let references = ctx.get_ini().get_reference_housenumber_paths()?;
     let relation = relations.get_relation(relation_name)?;
     let mut ret: HashMap<String, String> = HashMap::new();
-    relation.write_ref_housenumbers(&references)?;
+    relation.write_ref_housenumbers()?;
     ret.insert("error".into(), "".into());
     Ok(serde_json::to_string(&ret)?)
 }
@@ -122,7 +120,7 @@ pub fn our_application_json(
         output = street_housenumbers_update_result_json(ctx, relations, request_uri)?;
     } else if request_uri.starts_with(&format!("{prefix}/missing-housenumbers/")) {
         if request_uri.ends_with("/update-result.json") {
-            output = missing_housenumbers_update_result_json(ctx, relations, request_uri)?;
+            output = missing_housenumbers_update_result_json(relations, request_uri)?;
         } else {
             // Assume view-result.json.
             output = missing_housenumbers_view_result_json(relations, request_uri)?;

--- a/src/wsgi_json/tests.rs
+++ b/src/wsgi_json/tests.rs
@@ -258,6 +258,12 @@ fn test_missing_housenumbers_update_result_json() {
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     test_wsgi.get_ctx().set_file_system(&file_system);
+    let references = test_wsgi
+        .get_ctx()
+        .get_ini()
+        .get_reference_housenumber_paths()
+        .unwrap();
+    util::build_reference_index(test_wsgi.get_ctx(), &references).unwrap();
     {
         let conn = test_wsgi.get_ctx().get_database_connection().unwrap();
         conn.execute_batch(


### PR DESCRIPTION
Towards migrating away from
workdir/street-housenumbers-reference-<relation>.lst files.

Change-Id: I667cbee2b22d203c42ea73ffffe6de4722be62c1
