### PR TITLE
areas, tests: move gh964 housenumbers ref to sql

### DIFF
--- a/tests/workdir/street-housenumbers-reference-gh964.lst
+++ b/tests/workdir/street-housenumbers-reference-gh964.lst
@@ -1,1 +1,0 @@
-Tolvajos tanya	52/b	


### PR DESCRIPTION
Towards tests not asserting internal details of get_ref_housenumbers(),
12 more to go.

Change-Id: I79f84e4e752a9347a6e8d9519f789c64bd74459d
