### PR TITLE
areas, tests: move gh414 housenumbers ref to sql

### DIFF
--- a/tests/workdir/street-housenumbers-reference-gh414.lst
+++ b/tests/workdir/street-housenumbers-reference-gh414.lst
@@ -1,3 +1,0 @@
-A utca	2-10
-B utca	1
-B utca	3


### PR DESCRIPTION
Towards tests not asserting internal details of get_ref_housenumbers(),
12 more to go.

Change-Id: I81671ec83f76e6ba7682b5a094b5eba3de4010ed
