### PR TITLE
areas, tests: move gh303 housenumbers ref to sql

### DIFF
--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -1920,21 +1920,31 @@ fn test_relation_get_missing_housenumbers_letter_suffix_normalize_semicolon() {
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gh303": {
+                "refcounty": "0",
+                "refsettlement": "0",
                 "osmrelation": 42,
             },
         },
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let ref_file = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
-        &[("data/yamls.cache", &yamls_cache_value)],
+        &[
+            ("data/yamls.cache", &yamls_cache_value),
+            ("workdir/street-housenumbers-reference-gh303.lst", &ref_file),
+        ],
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
     {
         let conn = ctx.get_database_connection().unwrap();
         conn.execute_batch(
-            "insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values ('gh303', '6852648009', 'Albert utca', '43/B;43/C', '1119', '', '', '', '', '', '', '', '', 'node');
+            "insert into ref_housenumbers (county_code, settlement_code, street, housenumber, comment) values ('0', '0', 'Albert utca', '43/A', '');
+             insert into ref_housenumbers (county_code, settlement_code, street, housenumber, comment) values ('0', '0', 'Albert utca', '43/B', '');
+             insert into ref_housenumbers (county_code, settlement_code, street, housenumber, comment) values ('0', '0', 'Albert utca', '43/C', '');
+             insert into ref_housenumbers (county_code, settlement_code, street, housenumber, comment) values ('0', '0', 'Albert utca', '43/D', '');
+             insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values ('gh303', '6852648009', 'Albert utca', '43/B;43/C', '1119', '', '', '', '', '', '', '', '', 'node');
              insert into mtimes (page, last_modified) values ('housenumbers/gh303', '0');",
         )
         .unwrap();
@@ -1942,6 +1952,7 @@ fn test_relation_get_missing_housenumbers_letter_suffix_normalize_semicolon() {
     let mut relations = Relations::new(&ctx).unwrap();
     let relation_name = "gh303";
     let mut relation = relations.get_relation(relation_name).unwrap();
+    relation.write_ref_housenumbers().unwrap();
     // Opt-in, this is not the default behavior.
     let mut config = relation.get_config().clone();
     set_config_housenumber_letters(&mut config, true);

--- a/tests/workdir/street-housenumbers-reference-gh303.lst
+++ b/tests/workdir/street-housenumbers-reference-gh303.lst
@@ -1,4 +1,0 @@
-Albert utca	43/A
-Albert utca	43/B
-Albert utca	43/C
-Albert utca	43/D


### PR DESCRIPTION
Towards tests not asserting internal details of get_ref_housenumbers(),
8 more to go.

Change-Id: I852f334c5ff57e3e6863c09e19e1a026666ee8cf
