### PR TITLE
areas, tests: move gh299 housenumbers ref to sql

### DIFF
--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -1890,20 +1890,34 @@ fn test_relation_get_missing_housenumbers_letter_suffix_source_suffix() {
     let yamls_cache = serde_json::json!({
         "relations.yaml": {
             "gh299": {
+                "refcounty": "0",
+                "refsettlement": "0",
                 "osmrelation": 42,
             },
         },
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let ref_file = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
-        &[("data/yamls.cache", &yamls_cache_value)],
+        &[
+            ("data/yamls.cache", &yamls_cache_value),
+            ("workdir/street-housenumbers-reference-gh299.lst", &ref_file),
+        ],
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);
+    {
+        let conn = ctx.get_database_connection().unwrap();
+        conn.execute_batch(
+            "insert into ref_housenumbers (county_code, settlement_code, street, housenumber, comment) values ('0', '0', 'Bártfai utca', '52/B', '');",
+        )
+        .unwrap();
+    }
     let mut relations = Relations::new(&ctx).unwrap();
     let relation_name = "gh299";
     let mut relation = relations.get_relation(relation_name).unwrap();
+    relation.write_ref_housenumbers().unwrap();
     // Opt-in, this is not the default behavior.
     let mut config = relation.get_config().clone();
     set_config_housenumber_letters(&mut config, true);

--- a/tests/workdir/street-housenumbers-reference-gh299.lst
+++ b/tests/workdir/street-housenumbers-reference-gh299.lst
@@ -1,1 +1,0 @@
-Bártfai utca	52/B*


### PR DESCRIPTION
Towards tests not asserting internal details of get_ref_housenumbers(),
7 more to go.

Change-Id: Ia772f83f970acd9199cdbb66794ccfc06b2b9837
