### PR TITLE
areas, tests: move gh296 housenumbers ref to sql

### DIFF
--- a/tests/workdir/street-housenumbers-reference-gh296.lst
+++ b/tests/workdir/street-housenumbers-reference-gh296.lst
@@ -1,4 +1,0 @@
-Rétköz utca	9
-Rétköz utca	9/A
-Rétköz utca	9 A 1
-Rétköz utca	47/49D


### PR DESCRIPTION
Towards tests not asserting internal details of get_ref_housenumbers(),
6 more to go.

Change-Id: If39bcc5e53065ba01d2fce47c11cc8477e53335a
