### PR TITLE
areas, tests: move 'empty' housenumbers ref to sql

### DIFF
--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -2469,9 +2469,13 @@ fn test_relation_write_missing_housenumbers() {
 fn test_relation_write_missing_housenumbers_empty() {
     let mut ctx = context::tests::make_test_context().unwrap();
     let json_value = context::tests::TestFileSystem::make_file();
+    let ref_file = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
-        &[("workdir/cache-empty.json", &json_value)],
+        &[
+            ("workdir/cache-empty.json", &json_value),
+            ("workdir/street-housenumbers-reference-empty.lst", &ref_file),
+        ],
     );
     let mut file_system = context::tests::TestFileSystem::new();
     file_system.set_files(&files);


### PR DESCRIPTION
Towards tests not asserting internal details of get_ref_housenumbers(),
1 more to go.

Change-Id: I57e2a3a289109002fccc944d3b8703e83a2b776d
