### PR TITLE
areas, tests: move budafok housenumbers ref to sql

### DIFF
--- a/tests/workdir/street-housenumbers-reference-budafok.lst
+++ b/tests/workdir/street-housenumbers-reference-budafok.lst
@@ -1,4 +1,0 @@
-Vöröskúti határsor	34
-Vöröskúti határsor	36*
-Vöröskúti határsor	12
-Vöröskúti határsor	2


### PR DESCRIPTION
With this, no tests assert the internal details of get_ref_housenumbers().

Change-Id: Ifa5b95c34b19e2c277d82be989bc0f1dccc4e498
