### PR TITLE
areas: sort housenumbers in Relation::get_ref_housenumbers()

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -797,7 +797,7 @@ impl<'a> Relation<'a> {
         let mut lines: HashMap<String, Vec<String>> = HashMap::new();
         let conn = self.ctx.get_database_connection()?;
         let mut stmt = conn.prepare(
-            "select housenumber, comment from ref_housenumbers where county_code = ?1 and settlement_code = ?2 and street = ?3")?;
+            "select housenumber, comment from ref_housenumbers where county_code = ?1 and settlement_code = ?2 and street = ?3 order by housenumber")?;
         for street in osm_street_names {
             let street = self
                 .config


### PR DESCRIPTION
E.g. 17/B, 17, 17/D should show up as '17', not something random when
housenumber letters are disabled.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/4088>.

Change-Id: I3964f3afd4dd4f1c4d358029bffec63ebe50403c
