### PR TITLE
sync-ref: empty additional-housenumbers cache on ref update

### DIFF
--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -88,6 +88,8 @@ pub fn download(
     let conn = ctx.get_database_connection()?;
     conn.execute_batch("delete from missing_housenumbers_cache")?;
     conn.execute_batch("delete from mtimes where page like 'missing-housenumbers-cache/%'")?;
+    conn.execute_batch("delete from additional_housenumbers_cache")?;
+    conn.execute_batch("delete from mtimes where page like 'additional-housenumbers-cache/%'")?;
 
     // Garbage collect other unused data.
     // 2024-03-24


### PR DESCRIPTION
Similar to how it's done for missing housenumbers.

Change-Id: I7925be182d1ccbdfb29052273128e1abee714177
