### PR TITLE
cache: drop references to get_ref_housenumbers_path()

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -55,10 +55,7 @@ fn is_sql_cache_current(
 fn is_missing_housenumbers_json_cached(relation: &mut areas::Relation<'_>) -> anyhow::Result<bool> {
     let datadir = relation.get_ctx().get_abspath("data");
     let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
-    let dependencies = vec![
-        relation.get_files().get_ref_housenumbers_path(),
-        relation_path,
-    ];
+    let dependencies = vec![relation_path];
     let sql_dependencies = vec![
         format!("streets/{}", relation.get_name()),
         format!("housenumbers/{}", relation.get_name()),
@@ -111,10 +108,7 @@ fn is_additional_housenumbers_json_cached(
 ) -> anyhow::Result<bool> {
     let datadir = relation.get_ctx().get_abspath("data");
     let relation_path = format!("{}/relation-{}.yaml", datadir, relation.get_name());
-    let dependencies = vec![
-        relation.get_files().get_ref_housenumbers_path(),
-        relation_path,
-    ];
+    let dependencies = vec![relation_path];
     let sql_dependencies = vec![
         format!("streets/{}", relation.get_name()),
         format!("housenumbers/{}", relation.get_name()),


### PR DESCRIPTION
And add a test that get_missing_housenumbers_json() doesn't use the
cache when data/relation-<name>.yaml is newer.

Change-Id: I014316cd8d4ae2dd62e024bb24f3833c5a9e61a4
