### PR TITLE
missing_housenumbers tests: no need to mock ref housenumbers files anymore

### DIFF
--- a/src/missing_housenumbers/tests.rs
+++ b/src/missing_housenumbers/tests.rs
@@ -31,13 +31,9 @@ fn test_main() {
         },
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
-    let ref_file = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         &ctx,
-        &[
-            ("data/yamls.cache", &yamls_cache_value),
-            ("workdir/street-housenumbers-reference-gh195.lst", &ref_file),
-        ],
+        &[("data/yamls.cache", &yamls_cache_value)],
     );
     let file_system = context::tests::TestFileSystem::from_files(&files);
     ctx.set_file_system(&file_system);


### PR DESCRIPTION
Change-Id: Icf3e4343a692e11af55979248d9b231c0de1ae1d
