### PR TITLE
wsgi_json tests: no need to mock ref housenumbers files anymore

### DIFF
--- a/src/wsgi_json/tests.rs
+++ b/src/wsgi_json/tests.rs
@@ -243,16 +243,11 @@ fn test_missing_housenumbers_view_result_json() {
         },
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
-    let ref_file = context::tests::TestFileSystem::make_file();
     let json_cache = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         test_wsgi.get_ctx(),
         &[
             ("data/yamls.cache", &yamls_cache_value),
-            (
-                "workdir/street-housenumbers-reference-budafok.lst",
-                &ref_file,
-            ),
             ("workdir/cache-budafok.json", &json_cache),
         ],
     );
@@ -308,17 +303,12 @@ fn test_additional_housenumbers_view_result_json() {
         },
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
-    let ref_file = context::tests::TestFileSystem::make_file();
     let cache_value = context::tests::TestFileSystem::make_file();
     let files = context::tests::TestFileSystem::make_files(
         test_wsgi.get_ctx(),
         &[
             ("data/yamls.cache", &yamls_cache_value),
             ("workdir/additional-cache-budafok.json", &cache_value),
-            (
-                "workdir/street-housenumbers-reference-budafok.lst",
-                &ref_file,
-            ),
         ],
     );
     file_system.set_files(&files);
@@ -327,12 +317,6 @@ fn test_additional_housenumbers_view_result_json() {
         test_wsgi
             .get_ctx()
             .get_abspath("workdir/additional-cache-budafok.json"),
-        Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
-    );
-    mtimes.insert(
-        test_wsgi
-            .get_ctx()
-            .get_abspath("workdir/street-housenumbers-reference-budafok.lst"),
         Rc::new(RefCell::new(time::OffsetDateTime::UNIX_EPOCH)),
     );
     file_system.set_mtimes(&mtimes);


### PR DESCRIPTION
Which was the last trace of
workdir/street-housenumbers-reference-<relation>.lst files, obsoleted by
SQL originally in commit 455a6992c0b2a815968da537923f5806bff5258e
(sync-ref: insert housenumbers / ext housenumbers into indexed sql,
2023-04-06).

Change-Id: I98093a59f43361ebf974934f59fcba77e4ab3e7b
