### PR TITLE
wsgi tests: fix test_housenumbers_view_result_update_result_link()

### DIFF
--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -1277,10 +1277,10 @@ fn test_housenumbers_view_result_update_result_link() {
     let root = test_wsgi.get_dom_for_path("/street-housenumbers/gazdagret/view-result");
 
     let uri = format!(
-        "{}/missing-housenumbers/gazdagret/view-result",
+        "{}/street-housenumbers/gazdagret/update-result",
         test_wsgi.ctx.get_ini().get_uri_prefix()
     );
-    let results = TestWsgi::find_all(&root, &format!("body/div[@id='toolbar']/a[@href='{uri}']"));
+    let results = TestWsgi::find_all(&root, &format!("body/div[@id='toolbar']//a[@href='{uri}']"));
     assert_eq!(results.len(), 1);
 }
 


### PR DESCRIPTION
This went wrong in commit 05e322ff642eb2e5871636939b9b093b41edbd4b
(Improve the wsgi test, 2019-10-26), from:

	self.assertTrue(parser.toolbar_overpass_link, "/osm/street-housenumbers/gazdagret/update-result")

to

	results = root.findall("body/div[@id='toolbar']/a[@href='/osm/suspicious-streets/gazdagret/view-result']")

Change-Id: Ie743a3690d7ac402de77863e2bacc621309ecf44
