### PR TITLE
areas: allow hyphens in invalid items

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -790,7 +790,24 @@ impl<'a> Relation<'a> {
 
             let mut used_invalids: Vec<String> = Vec::new();
             if let Some(value) = lines.get(&ref_street_name) {
-                for house_number in value {
+                // Find 'invalid' items which are ranges.
+                let invalid_ranges: Vec<String> = street_invalid
+                    .iter()
+                    .filter(|i| i.contains('-'))
+                    .map(|i| i.replace("/", "").to_lowercase())
+                    .collect();
+
+                // Filter out ref items which match such invalid items.
+                let hns: Vec<_> = value
+                    .iter()
+                    .filter(|i| {
+                        let mut it = i.split('\t');
+                        let i = it.next().expect("token list should not be empty");
+                        !invalid_ranges.contains(&i.replace("/", "").to_lowercase())
+                    })
+                    .collect();
+
+                for house_number in hns {
                     let normalized = normalize(
                         self,
                         house_number,

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -98,6 +98,14 @@ fn validate_filter_invalid_valid(
         if regex::Regex::new(r"^[0-9]+/[0-9]$")?.is_match(invalid_data) {
             continue;
         }
+
+        // 40-60 or 50a-b: OK, but won't be parsed.
+        if regex::Regex::new(r"^[0-9]+-[0-9]+$")?.is_match(invalid_data) {
+            continue;
+        }
+        if regex::Regex::new(r"^[0-9]+[a-z]-[a-z]$")?.is_match(invalid_data) {
+            continue;
+        }
         errors.push(format!(
             "expected format for '{parent}[{index}]' is '42', '42a' or '42/1'"
         ));

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -223,6 +223,26 @@ fn test_validate_filter_invalid_valid2() {
     assert_success(content);
 }
 
+/// Tests validate_filter_invalid_valid(): 40-60 is a valid filter item.
+#[test]
+fn test_validate_filter_invalid_valid3() {
+    let content = r#"filters:
+  'mystreet':
+    invalid: ['40-60']
+"#;
+    assert_success(content);
+}
+
+/// Tests validate_filter_invalid_valid(): 50a-b is a valid filter item.
+#[test]
+fn test_validate_filter_invalid_valid4() {
+    let content = r#"filters:
+  'mystreet':
+    invalid: ['50a-b']
+"#;
+    assert_success(content);
+}
+
 /// Tests the relation path: bad source type.
 #[test]
 fn test_relation_source_bad_type() {


### PR DESCRIPTION
These are not parsed, they are used as a filter as-is, apart from
dropping slashes and converting to lowercase before comparison.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/3892>.

Change-Id: I6d907cbb2afabd6169c576d96ea12ab5dc7a090e
