### PR TITLE
areas, hyphen in invalid: fix usage tracking

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -331,7 +331,7 @@ pub struct MissingHousenumbers {
     pub done_streets: util::NumberedStreets,
 }
 
-#[derive(Clone, Ord, PartialOrd, derivative::Derivative)]
+#[derive(Clone, Debug, Ord, PartialOrd, derivative::Derivative)]
 #[derivative(Eq, PartialEq)]
 pub struct RelationLint {
     pub relation_name: String,
@@ -803,7 +803,13 @@ impl<'a> Relation<'a> {
                     .filter(|i| {
                         let mut it = i.split('\t');
                         let i = it.next().expect("token list should not be empty");
-                        !invalid_ranges.contains(&i.replace("/", "").to_lowercase())
+                        let hn = i.replace("/", "").to_lowercase();
+                        let contains = invalid_ranges.contains(&hn);
+                        if contains {
+                            // Mark this 'invalid' item as used.
+                            used_invalids.push(hn.to_string());
+                        }
+                        !contains
                     })
                     .collect();
 

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -1421,7 +1421,9 @@ fn test_relation_get_missing_housenumbers_invalid_hyphens() {
     let mut relations = Relations::new(&ctx).unwrap();
     let relation_name = "myrelation";
     let mut relation = relations.get_relation(relation_name).unwrap();
+
     let missing_housenumbers = relation.get_missing_housenumbers().unwrap();
+
     let ongoing_streets = numbered_streets_to_array(&missing_housenumbers.ongoing_streets);
     assert_eq!(
         ongoing_streets,
@@ -1435,6 +1437,11 @@ fn test_relation_get_missing_housenumbers_invalid_hyphens() {
             ]
         ),]
     );
+
+    let lints = relation.get_lints();
+
+    // Assert that invalid items containing hyphens are considered used.
+    assert_eq!(lints.len(), 0);
 }
 
 /// Tests Relation::get_lints().


### PR DESCRIPTION
/missing-housenumbers/.../view-lints listed the new range invalids as
unused, when they were used, fixed that.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/3892>.

Change-Id: Iafa0a351145c26a1acf75c22dc4457ee385b177e
