### PR TITLE
areas, range in invalid items: fix handling of extended housenumbers

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -803,7 +803,13 @@ impl<'a> Relation<'a> {
                     .filter(|i| {
                         let mut it = i.split('\t');
                         let i = it.next().expect("token list should not be empty");
-                        let hn = i.replace("/", "").to_lowercase();
+                        let mut hn = i.replace("/", "").to_lowercase();
+                        if hn.ends_with('*') {
+                            // a-b filters out both a-b and a-b*, so ignore the trailing *.
+                            let mut chars = hn.chars();
+                            chars.next_back();
+                            hn = chars.as_str().into();
+                        }
                         let contains = invalid_ranges.contains(&hn);
                         if contains {
                             // Mark this 'invalid' item as used.


### PR DESCRIPTION
a-b didn't filter out a-b*, but it should.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/3892#issuecomment-2366926826>.

Change-Id: I029c17250922c3dbe190586a8d21c9c0d67dbf47
