### PR TITLE
areas: test range items in invalid lists with extended housenumbers

### DIFF
--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -1391,7 +1391,7 @@ fn test_relation_get_missing_housenumbers_invalid_hyphens() {
             "housenumber-letters": true,
             "filters": {
                 "mystreet": {
-                    "invalid": ["42", "40-60", "48", "50a-b"],
+                    "invalid": ["42", "40-60", "48", "50a-b", "1-2"],
                 }
             },
         },
@@ -1414,6 +1414,7 @@ fn test_relation_get_missing_housenumbers_invalid_hyphens() {
              insert into ref_housenumbers (county_code, settlement_code, street, housenumber, comment) values ('0', '0', 'mystreet', '40-60', '');
              insert into ref_housenumbers (county_code, settlement_code, street, housenumber, comment) values ('0', '0', 'mystreet', '50/A', '');
              insert into ref_housenumbers (county_code, settlement_code, street, housenumber, comment) values ('0', '0', 'mystreet', '50/A-B', '');
+             insert into ref_housenumbers (county_code, settlement_code, street, housenumber, comment) values ('0', '0', 'mystreet', '1-2', ' ');
              insert into osm_streets (relation, osm_id, name, highway, service, surface, leisure, osm_type) values ('myrelation', '2', 'mystreet', '', '', '', '', '');",
         )
         .unwrap();


### PR DESCRIPTION
Fails with 2a5c361833364666ee252a1d5d638d232be7544f (areas, range in
invalid items: fix handling of extended housenumbers, 2024-09-25)
reverted:

thread 'areas::tests::test_relation_get_missing_housenumbers_invalid_hyphens' panicked at src/areas/tests.rs:1429:5:
assertion `left == right` failed
  left: [("mystreet", ["1*", "2*", "44", "46", "48/A", "50/A"])]
 right: [("mystreet", ["44", "46", "48/A", "50/A"])]

I.e. the trailing '*' was not stripped off, so 1-2 didn't filter out
anything.

Change-Id: I42776ad32a21f239768f62cd59f6529a98d56a29
