### PR TITLE
areas: avoid directly depending on rusqlite in RelationLintSource

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -365,15 +365,6 @@ impl TryFrom<&str> for RelationLintSource {
     }
 }
 
-impl rusqlite::types::FromSql for RelationLintSource {
-    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
-        let i = String::column_result(value)?;
-        i.as_str()
-            .try_into()
-            .map_err(|_| rusqlite::types::FromSqlError::InvalidType)
-    }
-}
-
 impl std::fmt::Display for RelationLintSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -3445,16 +3445,6 @@ fn test_relation_lint_source_try_from() {
     assert_eq!(result.is_err(), true);
 }
 
-/// Tests RelationLintSource::column_result().
-#[test]
-fn test_relation_lint_source_column_result() {
-    let value_ref = rusqlite::types::ValueRef::from("test");
-
-    let result = RelationLintSource::column_result(value_ref);
-
-    assert_eq!(result.is_err(), true);
-}
-
 /// Tests RelationLintReason::try_from().
 #[test]
 fn test_relation_lint_reason_try_from() {

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -273,7 +273,8 @@ fn missing_housenumbers_view_lints(
         while let Some(lint) = lints.next()? {
             let mut cells: Vec<yattag::Doc> = Vec::new();
             let street: String = lint.get(0).unwrap();
-            let source: areas::RelationLintSource = lint.get(1).unwrap();
+            let source =
+                areas::RelationLintSource::try_from(lint.get::<_, String>(1).unwrap().as_str())?;
             let source_string = match source {
                 areas::RelationLintSource::Range => tr("street ranges"),
                 areas::RelationLintSource::Invalid => tr("invalid housenumbers"),


### PR DESCRIPTION
Going via a String is good enough, and it's less code.

Change-Id: I83c3f57a0140892bb3bc2e9b5933629e6c77b4ad
