### PR TITLE
areas: avoid directly depending on rusqlite in RelationLintReason

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -394,15 +394,6 @@ impl TryFrom<&str> for RelationLintReason {
     }
 }
 
-impl rusqlite::types::FromSql for RelationLintReason {
-    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
-        let i = String::column_result(value)?;
-        i.as_str()
-            .try_into()
-            .map_err(|_| rusqlite::types::FromSqlError::InvalidType)
-    }
-}
-
 impl std::fmt::Display for RelationLintReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -11,7 +11,6 @@
 //! Tests for the areas module.
 
 use super::*;
-use rusqlite::types::FromSql as _;
 use std::io::Write;
 use std::rc::Rc;
 
@@ -3449,16 +3448,6 @@ fn test_relation_lint_source_try_from() {
 #[test]
 fn test_relation_lint_reason_try_from() {
     let result = RelationLintReason::try_from("test");
-    assert_eq!(result.is_err(), true);
-}
-
-/// Tests RelationLintReason::column_result().
-#[test]
-fn test_relation_lint_reason_column_result() {
-    let value_ref = rusqlite::types::ValueRef::from("test");
-
-    let result = RelationLintReason::column_result(value_ref);
-
     assert_eq!(result.is_err(), true);
 }
 

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -280,7 +280,8 @@ fn missing_housenumbers_view_lints(
                 areas::RelationLintSource::Invalid => tr("invalid housenumbers"),
             };
             let housenumber: String = lint.get(2).unwrap();
-            let reason: areas::RelationLintReason = lint.get(3).unwrap();
+            let reason =
+                areas::RelationLintReason::try_from(lint.get::<_, String>(3).unwrap().as_str())?;
             let id: String = lint.get(4).unwrap();
             let object_type: String = lint.get(5).unwrap();
             let reason_string = match reason {


### PR DESCRIPTION
Going via a String is good enough, and it's less code.

With this, we have a direct dependency on rusqlite only in the sql and
context modules.

Change-Id: Ief9d540801bfb9a7290c78b46f2380ccbd0e7360
