### PR TITLE
Implement graceful shutdown

### DIFF
--- a/src/context/system.rs
+++ b/src/context/system.rs
@@ -146,10 +146,6 @@ impl Subprocess for StdSubprocess {
         Ok(std::str::from_utf8(&output.stdout)?.to_string())
     }
 
-    fn exit(&self, code: i32) {
-        std::process::exit(code);
-    }
-
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -331,29 +331,18 @@ impl Unit for TestUnit {
 pub struct TestSubprocess {
     outputs: HashMap<String, String>,
     runs: Rc<RefCell<Vec<String>>>,
-    exits: Rc<RefCell<Vec<i32>>>,
 }
 
 impl TestSubprocess {
     pub fn new(outputs: &HashMap<String, String>) -> Self {
         let outputs = outputs.clone();
         let runs: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
-        let exits: Rc<RefCell<Vec<i32>>> = Rc::new(RefCell::new(Vec::new()));
-        TestSubprocess {
-            outputs,
-            runs,
-            exits,
-        }
+        TestSubprocess { outputs, runs }
     }
 
     /// Gets a list of invoked commands.
     pub fn get_runs(&self) -> Vec<String> {
         self.runs.borrow_mut().clone()
-    }
-
-    /// Gets a list of exit codes.
-    pub fn get_exits(&self) -> Vec<i32> {
-        self.exits.borrow_mut().clone()
     }
 }
 
@@ -362,10 +351,6 @@ impl Subprocess for TestSubprocess {
         let key = args.join(" ");
         self.runs.borrow_mut().push(key.clone());
         Ok(self.outputs[&key].clone())
-    }
-
-    fn exit(&self, code: i32) {
-        self.exits.borrow_mut().push(code);
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -1294,9 +1294,7 @@ pub fn handle_github_webhook(
             ctx.get_abspath(""),
             "deploy".into(),
         ])?;
-        // Nominally a failure, so the service gets restarted.
-        println!("Stopping the server after deploy.");
-        ctx.get_subprocess().exit(1);
+        ctx.set_shutdown();
     }
 
     Ok(yattag::Doc::from_text(""))

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -1996,7 +1996,7 @@ fn test_webhooks_github() {
         .downcast_ref::<context::tests::TestSubprocess>()
         .unwrap();
     assert_eq!(subprocess.get_runs().is_empty(), false);
-    assert_eq!(subprocess.get_exits(), &[1]);
+    assert_eq!(test_wsgi.ctx.get_shutdown(), true);
 }
 
 /// Tests /osm/webhooks/: /osm/webhooks/github, the case when a non-master branch is updated.


### PR DESCRIPTION
curl -d 'payload=%7B%22ref%22%3A%22refs%2Fheads%2Fmaster%22%7D' http://127.0.0.1:8000/osm/webhooks/github

used to fail with:

curl: (52) Empty reply from server

because exit() was performed before sending the HTTP response.

Set up a channel instead to be able to request a shutdown, this gives us
a clean shutdown path.

Change-Id: Ic654bf4a65a051b4d9876eb4b4c47782f5814d1a
