### PR TITLE
tools, container: mark Fedora 41 as working now

### DIFF
--- a/tools/container/Containerfile
+++ b/tools/container/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:40
+FROM fedora:41
 
 RUN dnf install -y \
     cargo \


### PR DESCRIPTION
After the trouble with clang 19 was fixed.

Change-Id: I843056dced29b0c108210cc962960e507430fb32
