### PR TITLE
container: split to a builder and a final one

### DIFF
--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -137,7 +137,7 @@ Note that the comparison results are not only affected by changes in the OSM dat
 positives are also silenced by osm-gimmisn filters. To update those filters, run:
 
 ```
-podman exec -t -i osm-gimmisn bash -c 'cd /opt/osm-gimmisn && git pull -r && make data/yamls.cache'
+podman exec -t -i osm-gimmisn bash -c 'cd /opt/osm-gimmisn && git pull -r && target/release/osm-gimmisn cache-yamls data workdir'
 ```
 
 from time to time.

--- a/tools/container/Containerfile
+++ b/tools/container/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:41
+FROM fedora:41 AS builder
 
 RUN dnf install -y \
     cargo \
@@ -12,9 +12,31 @@ RUN dnf install -y \
     sqlite-devel \
     openssl-devel
 
+WORKDIR /opt
+
 RUN git -C /opt clone https://github.com/vmiklos/osm-gimmisn
 
 RUN make -C /opt/osm-gimmisn
+
+FROM fedora:41
+
+RUN dnf install -y \
+    git \
+    libicu
+
+WORKDIR /opt
+
+RUN git clone https://github.com/vmiklos/osm-gimmisn
+
+WORKDIR /opt/osm-gimmisn
+
+RUN mkdir -p target/release/ target/browser/
+
+COPY --from=builder /opt/osm-gimmisn/target/release/osm-gimmisn target/release/osm-gimmisn
+COPY --from=builder /opt/osm-gimmisn/target/browser/bundle.js target/browser/bundle.js
+COPY --from=builder /opt/osm-gimmisn/target/browser/osm.min.css target/browser/osm.min.css
+
+RUN target/release/osm-gimmisn cache-yamls data workdir
 
 COPY /init.sh /
 


### PR DESCRIPTION
If the toolchain is needed only in the builder, then the final image
size is reduced from 2.91 GB to 365 MB.

Change-Id: I9326709664bcb05d62b29311084f4177aabfa6b1
