### PR TITLE
cron: write workdir/stats/ref.count to sql as well

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -313,7 +313,19 @@ pub fn init(conn: &mut rusqlite::Connection) -> anyhow::Result<()> {
         )?;
     }
 
-    tx.execute("pragma user_version = 17", [])?;
+    if user_version < 18 {
+        // Tracks various counters.
+        tx.execute(
+            "create table counts (
+                    category text not null,
+                    count text not null,
+                    unique(category)
+                );",
+            [],
+        )?;
+    }
+
+    tx.execute("pragma user_version = 18", [])?;
     tx.commit()?;
     Ok(())
 }


### PR DESCRIPTION
No need to have this in a separate file. Various code still reads the
old place, so don't remove that yet.

Change-Id: Ibddae335d9445e482bb374ebbf7ab9f0ed0ef0ef
