### PR TITLE
cache_yamls: write workdir/stats/relations.json to sql as well

### DIFF
--- a/src/cache_yamls.rs
+++ b/src/cache_yamls.rs
@@ -71,6 +71,11 @@ pub fn our_main(argv: &[String], ctx: &context::Context) -> anyhow::Result<()> {
         let mut guard = write_stream.borrow_mut();
         let write = guard.deref_mut();
         serde_json::to_writer(write, &relation_ids)?;
+
+        let conn = ctx.get_database_connection()?;
+        let sql = r#"insert into stats_jsons (category, json) values ('relations', ?1)
+                     on conflict(category) do update set json = excluded.json"#;
+        conn.execute(sql, [serde_json::to_string(&relation_ids)?])?;
     }
 
     ctx.get_unit().make_error()

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -325,7 +325,19 @@ pub fn init(conn: &mut rusqlite::Connection) -> anyhow::Result<()> {
         )?;
     }
 
-    tx.execute("pragma user_version = 18", [])?;
+    if user_version < 19 {
+        // Tracks various stat JSON data.
+        tx.execute(
+            "create table stats_jsons (
+                    category text not null,
+                    json text not null,
+                    unique(category)
+                );",
+            [],
+        )?;
+    }
+
+    tx.execute("pragma user_version = 19", [])?;
     tx.commit()?;
     Ok(())
 }


### PR DESCRIPTION
No need to have this in a separate file. Various code still reads the
old place, so don't remove that yet.

Change-Id: Iec7a06f0b5d40fe70124b4e922d5ec5e43487cbf
