### PR TITLE
container: further reduce the final container

### DIFF
--- a/tools/container/Containerfile
+++ b/tools/container/Containerfile
@@ -21,8 +21,9 @@ RUN make -C /opt/osm-gimmisn
 FROM fedora:41
 
 RUN dnf install -y \
-    git \
-    libicu
+    git-core \
+    libicu \
+    && dnf clean all
 
 WORKDIR /opt
 


### PR DESCRIPTION
365 MB -> 257 MB, 70% of original by installing less of git ('git pull'
is enough) + cleaning the dnf cache which won't be needed later.

Change-Id: I680f21e96a7eded0522eb4ee28d75e0a723967d4
