### PR TITLE
Split out serde types into a new file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ RS_OBJECTS = \
 	src/parse_access_log/tests.rs \
 	src/ranges.rs \
 	src/ranges/tests.rs \
+	src/serde.rs \
 	src/sql.rs \
 	src/stats.rs \
 	src/stats/tests.rs \
@@ -107,7 +108,7 @@ target/${TARGET_PATH}/osm-gimmisn: $(RS_OBJECTS) Cargo.toml Makefile
 
 # Without coverage: cargo test --lib
 check-unit: Cargo.toml $(RS_OBJECTS) locale/hu/LC_MESSAGES/osm-gimmisn.mo data/yamls.cache
-	cargo llvm-cov --lib -q --ignore-filename-regex system.rs --show-missing-lines --fail-under-lines 100 ${CARGO_OPTIONS} -- --test-threads=1
+	cargo llvm-cov --lib -q --ignore-filename-regex '(serde|system).rs' --show-missing-lines --fail-under-lines 100 ${CARGO_OPTIONS} -- --test-threads=1
 
 src/browser/config.ts: workdir/wsgi.ini Makefile
 	printf 'const uriPrefix = "%s";\nexport { uriPrefix };\n' $(shell (grep uri_prefix workdir/wsgi.ini || echo "/osm") |sed 's/uri_prefix = //') > $@

--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -20,68 +20,6 @@ use log::info;
 #[cfg(test)]
 use std::println as info;
 
-/// OverpassTags contains various tags about one Overpass element.
-#[derive(serde::Deserialize)]
-struct OverpassTags {
-    name: Option<String>,
-    highway: Option<String>,
-    service: Option<String>,
-    surface: Option<String>,
-    leisure: Option<String>,
-
-    // region: housenumbers
-    #[serde(rename(deserialize = "addr:street"))]
-    street: Option<String>,
-    #[serde(rename(deserialize = "addr:housenumber"))]
-    housenumber: Option<String>,
-    #[serde(rename(deserialize = "addr:postcode"))]
-    postcode: Option<String>,
-    #[serde(rename(deserialize = "addr:place"))]
-    place: Option<String>,
-    #[serde(rename(deserialize = "addr:housename"))]
-    housename: Option<String>,
-    #[serde(rename(deserialize = "addr:conscriptionnumber"))]
-    conscriptionnumber: Option<String>,
-    #[serde(rename(deserialize = "addr:flats"))]
-    flats: Option<String>,
-    #[serde(rename(deserialize = "addr:floor"))]
-    floor: Option<String>,
-    #[serde(rename(deserialize = "addr:door"))]
-    door: Option<String>,
-    #[serde(rename(deserialize = "addr:unit"))]
-    unit: Option<String>,
-    #[serde(rename(deserialize = "addr:city"))]
-    city: Option<String>,
-    // endregion housenumbers
-    fixme: Option<String>,
-}
-
-/// OverpassElement represents one result from Overpass.
-#[derive(serde::Deserialize)]
-struct OverpassElement {
-    id: u64,
-    #[serde(rename(deserialize = "type"))]
-    osm_type: String,
-    pub user: Option<String>,
-    pub timestamp: Option<String>,
-    tags: OverpassTags,
-}
-
-#[derive(serde::Deserialize)]
-struct OverpassTimes {
-    #[serde(with = "time::serde::rfc3339")]
-    timestamp_osm_base: time::OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    timestamp_areas_base: time::OffsetDateTime,
-}
-
-/// OverpassResult is the result from Overpass.
-#[derive(serde::Deserialize)]
-struct OverpassResult {
-    osm3s: OverpassTimes,
-    elements: Vec<OverpassElement>,
-}
-
 /// One row in the `osm_streets` SQL table for a relation. Keep this in sync with data/streets-template.overpassql.
 pub struct OsmStreet {
     /// Object ID.
@@ -166,7 +104,7 @@ impl RelationFiles {
         ctx: &context::Context,
         result: &str,
     ) -> anyhow::Result<()> {
-        let overpass: OverpassResult = match serde_json::from_str(result) {
+        let overpass: crate::serde::OverpassResult = match serde_json::from_str(result) {
             Ok(value) => value,
             // Not a JSON, ignore.
             Err(_) => {
@@ -227,7 +165,7 @@ impl RelationFiles {
         ctx: &context::Context,
         result: &str,
     ) -> anyhow::Result<()> {
-        let overpass: OverpassResult = match serde_json::from_str(result) {
+        let overpass: crate::serde::OverpassResult = match serde_json::from_str(result) {
             Ok(value) => value,
             // Not a JSON, ignore.
             Err(_) => {
@@ -290,7 +228,7 @@ impl RelationFiles {
 }
 
 pub fn write_whole_country(ctx: &context::Context, result: &str) -> anyhow::Result<()> {
-    let overpass: OverpassResult = match serde_json::from_str(result) {
+    let overpass: crate::serde::OverpassResult = match serde_json::from_str(result) {
         Ok(value) => value,
         // Not a JSON, ignore.
         Err(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod missing_housenumbers;
 mod overpass_query;
 pub mod parse_access_log;
 mod ranges;
+mod serde;
 mod sql;
 mod stats;
 pub mod sync_ref;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#![deny(warnings)]
+#![warn(clippy::all)]
+#![warn(missing_docs)]
+
+//! The serde module contains structs used while parsing data using the serde crate.
+
+/// OverpassTags contains various tags about one Overpass element.
+#[derive(serde::Deserialize)]
+pub struct OverpassTags {
+    pub name: Option<String>,
+    pub highway: Option<String>,
+    pub service: Option<String>,
+    pub surface: Option<String>,
+    pub leisure: Option<String>,
+
+    // region: housenumbers
+    #[serde(rename(deserialize = "addr:street"))]
+    pub street: Option<String>,
+    #[serde(rename(deserialize = "addr:housenumber"))]
+    pub housenumber: Option<String>,
+    #[serde(rename(deserialize = "addr:postcode"))]
+    pub postcode: Option<String>,
+    #[serde(rename(deserialize = "addr:place"))]
+    pub place: Option<String>,
+    #[serde(rename(deserialize = "addr:housename"))]
+    pub housename: Option<String>,
+    #[serde(rename(deserialize = "addr:conscriptionnumber"))]
+    pub conscriptionnumber: Option<String>,
+    #[serde(rename(deserialize = "addr:flats"))]
+    pub flats: Option<String>,
+    #[serde(rename(deserialize = "addr:floor"))]
+    pub floor: Option<String>,
+    #[serde(rename(deserialize = "addr:door"))]
+    pub door: Option<String>,
+    #[serde(rename(deserialize = "addr:unit"))]
+    pub unit: Option<String>,
+    #[serde(rename(deserialize = "addr:city"))]
+    pub city: Option<String>,
+    // endregion housenumbers
+    pub fixme: Option<String>,
+}
+
+/// OverpassElement represents one result from Overpass.
+#[derive(serde::Deserialize)]
+pub struct OverpassElement {
+    pub id: u64,
+    #[serde(rename(deserialize = "type"))]
+    pub osm_type: String,
+    pub user: Option<String>,
+    pub timestamp: Option<String>,
+    pub tags: OverpassTags,
+}
+
+#[derive(serde::Deserialize)]
+pub struct OverpassTimes {
+    #[serde(with = "time::serde::rfc3339")]
+    pub timestamp_osm_base: time::OffsetDateTime,
+    #[serde(with = "time::serde::rfc3339")]
+    pub timestamp_areas_base: time::OffsetDateTime,
+}
+
+/// OverpassResult is the result from Overpass.
+#[derive(serde::Deserialize)]
+pub struct OverpassResult {
+    pub osm3s: OverpassTimes,
+    pub elements: Vec<OverpassElement>,
+}


### PR DESCRIPTION
serde::Deserialize generates a lot of code, and test coverage of that is
not interesting, so ignore it.

Change-Id: I4031eba2fdfd6196e4f69debdbba6c8717cbf9b5
