### PR TITLE
wsgi_json: take relations.json from sql

### DIFF
--- a/src/wsgi_json.rs
+++ b/src/wsgi_json.rs
@@ -110,6 +110,14 @@ pub fn our_application_json(
         == format!("{prefix}/lints/whole-country/invalid-addr-cities/update-result.json")
     {
         output = webframe::handle_invalid_addr_cities_update_json(ctx)?;
+    } else if request_uri == format!("{prefix}/api/relations.json") {
+        let conn = ctx.get_database_connection()?;
+        let mut stmt = conn.prepare("select json from stats_jsons where category = 'relations'")?;
+        let mut rows = stmt.query([])?;
+        output = match rows.next()? {
+            Some(row) => row.get(0)?,
+            None => String::from("[]"),
+        };
     } else {
         // Assume /additional-housenumbers/<relation>/view-result.json.
         output = additional_housenumbers_view_result_json(relations, request_uri)?;

--- a/src/wsgi_json/tests.rs
+++ b/src/wsgi_json/tests.rs
@@ -313,3 +313,34 @@ fn test_additional_housenumbers_view_result_json() {
     let additional_housenumbers: util::NumberedStreets = serde_json::from_value(result).unwrap();
     assert_eq!(additional_housenumbers.len(), 0);
 }
+
+/// Tests the /api part of our_application_json(), the relations + some case.
+#[test]
+fn test_our_application_json_api_relations_some() {
+    let mut test_wsgi = wsgi::tests::TestWsgi::new();
+    {
+        let conn = test_wsgi.get_ctx().get_database_connection().unwrap();
+        conn.execute_batch(
+            "insert into stats_jsons (category, json) values ('relations', '[1, 2]');",
+        )
+        .unwrap();
+    }
+
+    let result = test_wsgi.get_json_for_path("/api/relations.json");
+
+    let relations: Vec<u64> = serde_json::from_value(result).unwrap();
+    assert_eq!(relations.len(), 2);
+    assert_eq!(relations[0], 1);
+    assert_eq!(relations[1], 2);
+}
+
+/// Tests the /api part of our_application_json(), the relations + none case.
+#[test]
+fn test_our_application_json_api_relations_none() {
+    let mut test_wsgi = wsgi::tests::TestWsgi::new();
+
+    let result = test_wsgi.get_json_for_path("/api/relations.json");
+
+    let relations: Vec<u64> = serde_json::from_value(result).unwrap();
+    assert_eq!(relations.len(), 0);
+}


### PR DESCRIPTION
This was in sql since commit 14e2f1b6d43350c787bdc78882fc2acc4e0d4328
(cache_yamls: write workdir/stats/relations.json to sql as well,
2024-11-30), add a new non-static endpoint to expose it, so the JS code
can switch to it.

Change-Id: If6d8fd5a1f020a4c6ddef293183631838a4aabec
