### PR TITLE
Fix 'make guide'

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -3,6 +3,7 @@ accepted = [
     "MIT",
     "BSD-3-Clause",
     "Unicode-DFS-2016",
+    "Unicode-3.0",
     "ISC",
     "BSD-2-Clause",
     "CC0-1.0",


### PR DESCRIPTION
Accept one more version of the unicode license, the point is to avoid
copyleft.

Change-Id: I9b492ef01e7ebdd25d2af6ae52af92a13e6ad7dd
