### PR TITLE
housenumberless-settlements, cron: fetch list of settlements in country once

### DIFF
--- a/src/fixtures/network/overpass-settlement-stats.json
+++ b/src/fixtures/network/overpass-settlement-stats.json
@@ -1,0 +1,17 @@
+{
+    "osm3s": {
+        "timestamp_osm_base": "2025-02-07T21:11:12Z",
+        "timestamp_areas_base": "2025-02-06T02:17:44Z"
+    },
+    "elements": [
+        {
+            "type": "node",
+            "id": 12353447948,
+            "lat": 46.8016087,
+            "lon": 16.3840838,
+            "tags": {
+                "name": "Baj\u00e1nsenye"
+            }
+        }
+    ]
+}

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -349,7 +349,16 @@ pub fn init(conn: &mut rusqlite::Connection) -> anyhow::Result<()> {
         )?;
     }
 
-    tx.execute("pragma user_version = 20", [])?;
+    if user_version < 21 {
+        // Speeds up access on whole_country.city.
+        tx.execute(
+            "create index idx_whole_country_cities
+                 on whole_country(city);",
+            [],
+        )?;
+    }
+
+    tx.execute("pragma user_version = 21", [])?;
     tx.commit()?;
     Ok(())
 }


### PR DESCRIPTION
And add an sql index.

Before:
sqlite> select count(*) from stats_settlements s where not exists ( select 1 from whole_country c where c.city = s.name );
486
Run Time: real 25.977 (seconds)

After:
sqlite> select count(*) from stats_settlements s where not exists ( select 1 from whole_country c where c.city = s.name );
486
Run Time: real 0.007 (seconds)

Change-Id: I247dc9b861851750d6c186e6fec2410e73507338
