### PR TITLE
validator: accept 192-216d in an invalid list

### DIFF
--- a/src/validator.rs
+++ b/src/validator.rs
@@ -91,8 +91,7 @@ fn validate_filter_invalid_valid(
     let is_number = regex::Regex::new(r"^[0-9]+$")?;
     let is_number_and_letter = regex::Regex::new(r"^[0-9]+[a-z]$")?;
     let is_number_per_letter = regex::Regex::new(r"^[0-9]+/[0-9]$")?;
-    let is_range = regex::Regex::new(r"^[0-9]+-[0-9]+$")?;
-    let is_letter_range = regex::Regex::new(r"^[0-9]+[a-z]-[a-z]$")?;
+    let is_range = regex::Regex::new(r"^[0-9]+[a-z]?-[0-9]*[a-z]?$")?;
     for (index, invalid_data) in invalid.iter().enumerate() {
         if is_number.is_match(invalid_data) {
             continue;
@@ -104,11 +103,8 @@ fn validate_filter_invalid_valid(
             continue;
         }
 
-        // 40-60 or 50a-b: OK, but won't be parsed.
+        // 40-60 or 50a-b or 70-80a: OK, but won't be parsed.
         if is_range.is_match(invalid_data) {
-            continue;
-        }
-        if is_letter_range.is_match(invalid_data) {
             continue;
         }
         errors.push(format!(

--- a/src/validator/tests.rs
+++ b/src/validator/tests.rs
@@ -243,6 +243,16 @@ fn test_validate_filter_invalid_valid4() {
     assert_success(content);
 }
 
+/// Tests validate_filter_invalid_valid(): 70-80a is a valid filter item.
+#[test]
+fn test_validate_filter_invalid_valid5() {
+    let content = r#"filters:
+  'mystreet':
+    invalid: ['70-80a']
+"#;
+    assert_success(content);
+}
+
 /// Tests the relation path: bad source type.
 #[test]
 fn test_relation_source_bad_type() {


### PR DESCRIPTION
Previously only 40-60 or 50a-b was accepted, but having a letter only on
the right hand side is OK, too.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/4586>.

Change-Id: I8f3ef1a5563bbb676cc12e718dff38acb19b644e
