### PR TITLE
cron: avoid osm street/housenumber cache cleanup when the relation list is limited

### DIFF
--- a/src/cron.rs
+++ b/src/cron.rs
@@ -538,12 +538,15 @@ fn our_main_inner(
     mode: &String,
     update: bool,
     overpass: bool,
+    limited: bool,
 ) -> anyhow::Result<()> {
     if mode == "all" || mode == "stats" {
         update_stats(ctx, overpass).context("update_stats failed")?;
     }
     if mode == "all" || mode == "relations" {
-        clean_osm_data(ctx, relations)?;
+        if !limited {
+            clean_osm_data(ctx, relations)?;
+        }
         update_osm_streets(ctx, relations, update)?;
         update_osm_housenumbers(ctx, relations, update)?;
         update_missing_streets(relations, update)?;
@@ -623,12 +626,14 @@ pub fn our_main(
     relations.limit_to_refarea(&refarea)?;
     let update = !args.get_one::<bool>("no-update").unwrap();
     let overpass = !args.get_one::<bool>("no-overpass").unwrap();
+    let limited = refcounty.is_some() || refsettlement.is_some() || refarea.is_some();
     our_main_inner(
         ctx,
         &mut relations,
         args.get_one("mode").unwrap(),
         update,
         overpass,
+        limited,
     )
     .context("our_main_inner failed")?;
     let duration = ctx.get_time().now() - start;


### PR DESCRIPTION
refcounty, refsettlement or refarea would be a filter triggering cleanup
of still used relations, fix that.

See
<https://github.com/vmiklos/osm-gimmisn/issues/4594#issuecomment-2925710761>.

Change-Id: I1d71cd93e4c2f472706b667a3f1b633fe2ee1ae4
