### PR TITLE
Use variables directly in the format string

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.87.0
+          toolchain: 1.88.0
           components: rustfmt, clippy, llvm-tools-preview
       - name: Rust Cache
         uses: actions/cache@v4.2.3
@@ -25,7 +25,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-1.87.0-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-1.88.0-${{ hashFiles('**/Cargo.toml') }}
       - name: Setup Node
         uses: actions/setup-node@v4.4.0
         with:

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1245,7 +1245,7 @@ impl<'a> Relation<'a> {
                 return Ok(Vec::new());
             }
         };
-        let keys: Vec<String> = filters.iter().map(|(key, _value)| key.clone()).collect();
+        let keys: Vec<String> = filters.keys().cloned().collect();
         let osm_streets: Vec<String> = self
             .get_osm_streets(/*sorted_result=*/ true)?
             .iter()
@@ -1620,7 +1620,7 @@ impl<'a> Relations<'a> {
                 return Vec::new();
             }
         };
-        let mut ret: Vec<String> = refcounty.iter().map(|(key, _value)| key.clone()).collect();
+        let mut ret: Vec<String> = refcounty.keys().cloned().collect();
         ret.sort();
         ret
     }
@@ -1914,7 +1914,7 @@ pub fn make_turbo_query_for_housenumberless(ctx: &context::Context) -> anyhow::R
     while let Some(row) = rows.next()? {
         let osm_type: String = row.get(0).unwrap();
         let osm_id: String = row.get(1).unwrap();
-        query += &format!("{}({});\n", osm_type, osm_id);
+        query += &format!("{osm_type}({osm_id});\n");
     }
     query += r#");
 out body;

--- a/src/cron.rs
+++ b/src/cron.rs
@@ -56,7 +56,7 @@ fn update_osm_streets(
     let active_names = relations.get_active_names();
     for relation_name in active_names.context("get_active_names() failed")? {
         let relation = relations.get_relation(&relation_name)?;
-        if !update && stats::has_sql_mtime(ctx, &format!("streets/{}", relation_name))? {
+        if !update && stats::has_sql_mtime(ctx, &format!("streets/{relation_name}"))? {
             continue;
         }
         info!("update_osm_streets, json: start: {relation_name}");
@@ -95,7 +95,7 @@ fn update_osm_housenumbers(
 ) -> anyhow::Result<()> {
     for relation_name in relations.get_active_names()? {
         let relation = relations.get_relation(&relation_name)?;
-        if !update && stats::has_sql_mtime(ctx, &format!("housenumbers/{}", relation_name))? {
+        if !update && stats::has_sql_mtime(ctx, &format!("housenumbers/{relation_name}"))? {
             continue;
         }
         info!("update_osm_housenumbers, json: start: {relation_name}");

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -496,9 +496,8 @@ pub fn set_sql_count(
     let conn = ctx.get_database_connection()?;
     conn.execute(
         &format!(
-            r#"insert into {} (relation, count) values (?1, ?2)
-             on conflict(relation) do update set count = excluded.count"#,
-            table
+            r#"insert into {table} (relation, count) values (?1, ?2)
+             on conflict(relation) do update set count = excluded.count"#
         ),
         [relation, &count.to_string()],
     )?;
@@ -511,7 +510,7 @@ pub fn get_sql_count(
     relation: &str,
 ) -> anyhow::Result<String> {
     let conn = ctx.get_database_connection()?;
-    let mut stmt = conn.prepare(&format!("select count from {} where relation = ?1", table))?;
+    let mut stmt = conn.prepare(&format!("select count from {table} where relation = ?1"))?;
     let mut rows = stmt.query([relation])?;
     let row = rows.next()?.context("no count")?;
     let count: String = row.get(0)?;
@@ -520,7 +519,7 @@ pub fn get_sql_count(
 
 pub fn has_sql_count(ctx: &context::Context, table: &str, relation: &str) -> anyhow::Result<bool> {
     let conn = ctx.get_database_connection()?;
-    let mut stmt = conn.prepare(&format!("select count from {} where relation = ?1", table))?;
+    let mut stmt = conn.prepare(&format!("select count from {table} where relation = ?1"))?;
     let mut rows = stmt.query([relation])?;
     Ok(rows.next()?.is_some())
 }
@@ -534,9 +533,8 @@ pub fn set_sql_json(
     let conn = ctx.get_database_connection()?;
     conn.execute(
         &format!(
-            r#"insert into {} (relation, json) values (?1, ?2)
+            r#"insert into {table} (relation, json) values (?1, ?2)
              on conflict(relation) do update set json = excluded.json"#,
-            table
         ),
         [relation, json],
     )?;
@@ -545,7 +543,7 @@ pub fn set_sql_json(
 
 pub fn get_sql_json(ctx: &context::Context, table: &str, relation: &str) -> anyhow::Result<String> {
     let conn = ctx.get_database_connection()?;
-    let mut stmt = conn.prepare(&format!("select json from {} where relation = ?1", table))?;
+    let mut stmt = conn.prepare(&format!("select json from {table} where relation = ?1"))?;
     let mut rows = stmt.query([relation])?;
     let row = rows.next()?.context("no json")?;
     let json: String = row.get(0)?;

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -173,10 +173,7 @@ fn validate_refstreets(
             errors.push(format!("expected value != key for '{context}{key}'"));
         }
     }
-    let mut reverse: Vec<_> = refstreets
-        .iter()
-        .map(|(_key, value)| value.as_str())
-        .collect();
+    let mut reverse: Vec<_> = refstreets.values().map(|value| value.as_str()).collect();
     reverse.sort_unstable();
     reverse.dedup();
     if refstreets.keys().len() != reverse.len() {

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -164,7 +164,7 @@ fn handle_street_housenumbers(
         }
     } else {
         // assume view-result
-        if !stats::has_sql_mtime(ctx, &format!("housenumbers/{}", relation_name))? {
+        if !stats::has_sql_mtime(ctx, &format!("housenumbers/{relation_name}"))? {
             let div = doc.tag("div", &[("id", "no-osm-housenumbers")]);
             div.text(&tr("No existing house numbers"));
         } else {
@@ -286,7 +286,7 @@ fn missing_housenumbers_view_lints(
             }
             if id != "0" {
                 let cell = yattag::Doc::new();
-                let href = format!("https://www.openstreetmap.org/{}/{}", object_type, id,);
+                let href = format!("https://www.openstreetmap.org/{object_type}/{id}");
                 {
                     let a = cell.tag("a", &[("href", &href), ("target", "_blank")]);
                     a.text(&id.to_string());
@@ -421,9 +421,9 @@ fn missing_housenumbers_view_res(
     let doc: yattag::Doc;
     let mut relation = relations.get_relation(relation_name)?;
     let prefix = ctx.get_ini().get_uri_prefix();
-    if !stats::has_sql_mtime(ctx, &format!("streets/{}", relation_name))? {
+    if !stats::has_sql_mtime(ctx, &format!("streets/{relation_name}"))? {
         doc = webframe::handle_no_osm_streets(&prefix, relation_name);
-    } else if !stats::has_sql_mtime(ctx, &format!("housenumbers/{}", relation_name))? {
+    } else if !stats::has_sql_mtime(ctx, &format!("housenumbers/{relation_name}"))? {
         doc = webframe::handle_no_osm_housenumbers(&prefix, relation_name);
     } else {
         let ret = missing_housenumbers_view_res_html(ctx, &mut relation);
@@ -527,11 +527,11 @@ fn missing_housenumbers_view_txt(
     let relation_name = tokens.next_back().context("no relation_name")?;
     let mut relation = relations.get_relation(relation_name)?;
 
-    if !stats::has_sql_mtime(ctx, &format!("streets/{}", relation_name))? {
+    if !stats::has_sql_mtime(ctx, &format!("streets/{relation_name}"))? {
         return Ok(tr("No existing streets"));
     }
 
-    if !stats::has_sql_mtime(ctx, &format!("housenumbers/{}", relation_name))? {
+    if !stats::has_sql_mtime(ctx, &format!("housenumbers/{relation_name}"))? {
         return Ok(tr("No existing house numbers"));
     }
 
@@ -583,9 +583,9 @@ fn missing_housenumbers_view_chkl(
     let mut relation = relations.get_relation(relation_name)?;
 
     let output: String;
-    if !stats::has_sql_mtime(ctx, &format!("streets/{}", relation_name))? {
+    if !stats::has_sql_mtime(ctx, &format!("streets/{relation_name}"))? {
         output = tr("No existing streets");
-    } else if !stats::has_sql_mtime(ctx, &format!("housenumbers/{}", relation_name))? {
+    } else if !stats::has_sql_mtime(ctx, &format!("housenumbers/{relation_name}"))? {
         output = tr("No existing house numbers");
     } else {
         let ongoing_streets = relation.get_missing_housenumbers()?.ongoing_streets;

--- a/src/wsgi_additional.rs
+++ b/src/wsgi_additional.rs
@@ -145,7 +145,7 @@ pub fn additional_streets_view_txt(
         .get_relation(relation_name)
         .context("get_relation() failed")?;
 
-    let output: String = if !stats::has_sql_mtime(ctx, &format!("streets/{}", relation_name))? {
+    let output: String = if !stats::has_sql_mtime(ctx, &format!("streets/{relation_name}"))? {
         tr("No existing streets")
     } else {
         let mut streets = relation.get_additional_streets(/*sorted_result=*/ true)?;
@@ -176,7 +176,7 @@ pub fn additional_streets_view_result(
 
     let doc = yattag::Doc::new();
     let prefix = ctx.get_ini().get_uri_prefix();
-    if !stats::has_sql_mtime(ctx, &format!("streets/{}", relation_name))? {
+    if !stats::has_sql_mtime(ctx, &format!("streets/{relation_name}"))? {
         doc.append_value(webframe::handle_no_osm_streets(&prefix, relation_name).get_value());
     } else {
         // Get "only in OSM" streets.
@@ -283,9 +283,9 @@ pub fn additional_housenumbers_view_result(
 
     let doc: yattag::Doc;
     let prefix = ctx.get_ini().get_uri_prefix();
-    if !stats::has_sql_mtime(ctx, &format!("streets/{}", relation_name))? {
+    if !stats::has_sql_mtime(ctx, &format!("streets/{relation_name}"))? {
         doc = webframe::handle_no_osm_streets(&prefix, relation_name);
-    } else if !stats::has_sql_mtime(ctx, &format!("housenumbers/{}", relation_name))? {
+    } else if !stats::has_sql_mtime(ctx, &format!("housenumbers/{relation_name}"))? {
         doc = webframe::handle_no_osm_housenumbers(&prefix, relation_name);
     } else {
         doc = additional_housenumbers_view_result_html(&mut relation)?;


### PR DESCRIPTION
Which means we're warning-free with Rust 1.88 again.

Change-Id: I122a1d794fba197c71541e92a5ead3636e5a5e51
