### PR TITLE
wsgi: allow browsers to apply dark mode

### DIFF
--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1394,6 +1394,10 @@ fn write_html_head(ctx: &context::Context, doc: &yattag::Tag, title: &str) -> an
             ("content", "width=device-width, initial-scale=1"),
         ],
     );
+    head.stag(
+        "meta",
+        &[("name", "color-scheme"), ("content", "light dark")],
+    );
     {
         let title_tag = head.tag("title", &[]);
         title_tag.text(&format!("{}{}", tr("Where to map?"), title))


### PR DESCRIPTION
We specify almost no colors in CSS, so just allow browsers to handle
this.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/4671>.

Change-Id: Ib09f515254b531f78b23d2cda172c82605a51689
