### PR TITLE
util: make colored house numbers lighter in dark mode

### DIFF
--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -2458,7 +2458,7 @@ fn test_relation_write_missing_housenumbers_interpolation_all() {
             [
                 "Vöröskúti határsor",
                 "4",
-                "2, 12, 34, <span style=\"color: blue;\">36</span>"
+                "2, 12, 34, <span style=\"color: light-dark(blue, turquoise);\">36</span>"
             ]
         ]
     );

--- a/src/util.rs
+++ b/src/util.rs
@@ -552,7 +552,7 @@ pub fn color_house_number(house_number: &HouseNumberRange) -> yattag::Doc {
     chars.next_back();
     let number = chars.as_str();
     let title = house_number.get_comment().replace("&#013;", "\n");
-    let span = doc.tag("span", &[("style", "color: blue;")]);
+    let span = doc.tag("span", &[("style", "light-dark(blue, turquoise);")]);
     if !title.is_empty() {
         {
             let abbr = doc.tag("abbr", &[("title", title.as_str()), ("tabindex", "0")]);

--- a/src/util.rs
+++ b/src/util.rs
@@ -552,7 +552,7 @@ pub fn color_house_number(house_number: &HouseNumberRange) -> yattag::Doc {
     chars.next_back();
     let number = chars.as_str();
     let title = house_number.get_comment().replace("&#013;", "\n");
-    let span = doc.tag("span", &[("style", "light-dark(blue, turquoise);")]);
+    let span = doc.tag("span", &[("style", "color: light-dark(blue, turquoise);")]);
     if !title.is_empty() {
         {
             let abbr = doc.tag("abbr", &[("title", title.as_str()), ("tabindex", "0")]);

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -83,7 +83,7 @@ fn test_format_even_odd_html_comment() {
         HouseNumberRange::new("4", ""),
     ];
     let doc = format_even_odd_html(&house_numbers);
-    let expected = r#"<span style="color: light-dark(blue, turquoise)"><abbr title="foo" tabindex="0">2</abbr></span>, 4"#;
+    let expected = r#"<span style="color: light-dark(blue, turquoise);"><abbr title="foo" tabindex="0">2</abbr></span>, 4"#;
     assert_eq!(doc.get_value(), expected);
 }
 

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -71,7 +71,7 @@ fn test_format_even_odd_only_even() {
 #[test]
 fn test_format_even_odd_html() {
     let doc = format_even_odd_html(&hnr_list(vec!["2*", "4"]));
-    let expected = r#"<span style="color: blue;">2</span>, 4"#;
+    let expected = r#"<span style="color: light-dark(blue, turquoise);">2</span>, 4"#;
     assert_eq!(doc.get_value(), expected)
 }
 
@@ -84,7 +84,7 @@ fn test_format_even_odd_html_comment() {
     ];
     let doc = format_even_odd_html(&house_numbers);
     let expected =
-        r#"<span style="color: blue;"><abbr title="foo" tabindex="0">2</abbr></span>, 4"#;
+        r#"<span style="color: light-dark(blue, turquoise)"><abbr title="foo" tabindex="0">2</abbr></span>, 4"#;
     assert_eq!(doc.get_value(), expected);
 }
 

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -83,8 +83,7 @@ fn test_format_even_odd_html_comment() {
         HouseNumberRange::new("4", ""),
     ];
     let doc = format_even_odd_html(&house_numbers);
-    let expected =
-        r#"<span style="color: light-dark(blue, turquoise)"><abbr title="foo" tabindex="0">2</abbr></span>, 4"#;
+    let expected = r#"<span style="color: light-dark(blue, turquoise)"><abbr title="foo" tabindex="0">2</abbr></span>, 4"#;
     assert_eq!(doc.get_value(), expected);
 }
 


### PR DESCRIPTION
Improves #4671.

Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark