### PR TITLE
areas, osm housenumbers: handle the addr:unit tag

### DIFF
--- a/src/area_files.rs
+++ b/src/area_files.rs
@@ -77,7 +77,7 @@ impl RelationFiles {
         let mut ret: Vec<util::OsmHouseNumber> = Vec::new();
         let conn = ctx.get_database_connection()?;
         let mut stmt =
-            conn.prepare("select osm_id, housenumber, conscriptionnumber, street, place, osm_type from osm_housenumbers where relation = ?1")?;
+            conn.prepare("select osm_id, housenumber, conscriptionnumber, street, place, osm_type, unit from osm_housenumbers where relation = ?1")?;
         let mut rows = stmt.query([&self.name])?;
         while let Some(row) = rows.next()? {
             let id: String = row.get(0).unwrap();
@@ -86,6 +86,7 @@ impl RelationFiles {
             let street: String = row.get(3).unwrap();
             let place: String = row.get(4).unwrap();
             let object_type: String = row.get(5).unwrap();
+            let unit: String = row.get(6).unwrap();
             ret.push(util::OsmHouseNumber::new(
                 id.parse()?,
                 &housenumber,
@@ -93,6 +94,7 @@ impl RelationFiles {
                 &street,
                 &Some(place),
                 &object_type,
+                &unit,
             ));
         }
         Ok(ret)

--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1787,6 +1787,18 @@ fn normalize<'a>(
 ) -> anyhow::Result<Vec<util::HouseNumber>> {
     let mut comment: String = "".into();
     let mut house_numbers: String = house_numbers.into();
+
+    if let Some(housenumber) = osm_housenumber
+        && !housenumber.unit.is_empty()
+    {
+        // If addr:unit is available then assume that housenumber is addr:housenumber + / +
+        // addr:unit.
+        let mut it = housenumber.unit.split(" ");
+        if let Some(token) = it.next() {
+            house_numbers += &("/".to_string() + token);
+        }
+    }
+
     if house_numbers.contains('\t') {
         let tokens = house_numbers;
         let mut iter = tokens.split('\t');

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -3600,6 +3600,45 @@ fn test_relation_get_osm_housenumber_split() {
     assert_eq!(housenumbers[1].get_number(), "12/B");
 }
 
+#[test]
+fn test_relation_get_osm_housenumber_unit() {
+    // Given a housenumber where addr:unit is not empty:
+    let mut ctx = context::tests::make_test_context().unwrap();
+    // Enable housenumber-letters, otherwise ignoring addr:unit is not a problem.
+    let yamls_cache = serde_json::json!({
+        "relations.yaml": {
+        },
+        "relation-myrelation.yaml": {
+            "housenumber-letters": true,
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let files = context::tests::TestFileSystem::make_files(
+        &ctx,
+        &[("data/yamls.cache", &yamls_cache_value)],
+    );
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    ctx.set_file_system(&file_system);
+    {
+        let conn = ctx.get_database_connection().unwrap();
+        conn.execute_batch(
+            "insert into osm_streets (relation, osm_id, name, highway, service, surface, leisure, osm_type) values ('myrelation', '1', 'mystreet', '', '', '', '', '');
+             insert into mtimes (page, last_modified) values ('streets/myrelation', '0');
+             insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values ('myrelation', '1', 'mystreet', '42', '', '', '', '', '', '', '', 'B junk', '', 'node');
+             insert into mtimes (page, last_modified) values ('housenumbers/myrelation', '0');"
+        ).unwrap();
+    }
+    let mut relations = Relations::new(&ctx).unwrap();
+    let mut relation = relations.get_relation("myrelation").unwrap();
+
+    // When getting the osm housenumbers:
+    let housenumbers = relation.get_osm_housenumbers("mystreet").unwrap();
+
+    // Then make sure addr:unit is not ignored:
+    assert_eq!(housenumbers.len(), 1);
+    assert_eq!(housenumbers[0].get_number(), "42/B");
+}
+
 /// Tests Relation::get_missing_housenumbers(), the case when 'invalid' contains hyphens, the case
 /// when housenumber-letters is (implicitly) no.
 #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -974,6 +974,8 @@ pub struct OsmHouseNumber {
     pub place: Option<String>,
     /// Object type.
     pub object_type: String,
+    /// House number suffix.
+    pub unit: String,
 }
 
 impl OsmHouseNumber {
@@ -985,12 +987,14 @@ impl OsmHouseNumber {
         street: &str,
         place: &Option<String>,
         object_type: &str,
+        unit: &str,
     ) -> Self {
         let housenumber = housenumber.to_string();
         let conscriptionnumber = conscriptionnumber.to_string();
         let street = street.to_string();
         let place = place.clone();
         let object_type = object_type.to_string();
+        let unit = unit.to_string();
         OsmHouseNumber {
             id,
             housenumber,
@@ -998,6 +1002,7 @@ impl OsmHouseNumber {
             street,
             place,
             object_type,
+            unit,
         }
     }
 }

--- a/src/util/tests.rs
+++ b/src/util/tests.rs
@@ -597,6 +597,7 @@ fn test_get_street_from_housenumber_addr_place() {
     let street = "";
     let place = &Some("Tolvajos tanya".to_string());
     let object_type = "node";
+    let unit = "";
     let housenumber = OsmHouseNumber::new(
         id,
         housenumber,
@@ -604,6 +605,7 @@ fn test_get_street_from_housenumber_addr_place() {
         street,
         place,
         object_type,
+        unit,
     );
 
     let actual = get_street_from_housenumber(&[housenumber]).unwrap();


### PR DESCRIPTION
Get OSM housenumbers of a relation where the housenumber is not in a
42/b style, but addr:housenumber is 42, and addr:unit is "b". If the
reference has 42/b, then we mark 42/b as missing, which is incorrect.

The reason for this is that the overpass query gets the addr:unit tag,
but otherwise this tag is ignored.

Fix this by appending addr:unit in normalize(), so when the higher level
get_osm_housenumbers() is called for a relation, 42/b is reported to be
present in the OSM database.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/4710>.

Change-Id: I00a3abf12ef6f2e8132f7d8069393261d90a1388
