### PR TITLE
areas, osm housenumbers, addr:unit: ignore when housenumber contains slash

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1790,9 +1790,10 @@ fn normalize<'a>(
 
     if let Some(housenumber) = osm_housenumber
         && !housenumber.unit.is_empty()
+        && !house_numbers.contains("/")
     {
         // If addr:unit is available then assume that housenumber is addr:housenumber + / +
-        // addr:unit.
+        // addr:unit, unless addr:housenumber contains a slash already.
         let mut it = housenumber.unit.split(" ");
         if let Some(token) = it.next() {
             house_numbers += &("/".to_string() + token);

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -3625,6 +3625,7 @@ fn test_relation_get_osm_housenumber_unit() {
             "insert into osm_streets (relation, osm_id, name, highway, service, surface, leisure, osm_type) values ('myrelation', '1', 'mystreet', '', '', '', '', '');
              insert into mtimes (page, last_modified) values ('streets/myrelation', '0');
              insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values ('myrelation', '1', 'mystreet', '42', '', '', '', '', '', '', '', 'B junk', '', 'node');
+             insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values ('myrelation', '2', 'mystreet', '42/A', '', '', '', '', '', '', '', 'C', '', 'node');
              insert into mtimes (page, last_modified) values ('housenumbers/myrelation', '0');"
         ).unwrap();
     }
@@ -3635,8 +3636,9 @@ fn test_relation_get_osm_housenumber_unit() {
     let housenumbers = relation.get_osm_housenumbers("mystreet").unwrap();
 
     // Then make sure addr:unit is not ignored:
-    assert_eq!(housenumbers.len(), 1);
-    assert_eq!(housenumbers[0].get_number(), "42/B");
+    assert_eq!(housenumbers.len(), 2);
+    assert_eq!(housenumbers[0].get_number(), "42/A");
+    assert_eq!(housenumbers[1].get_number(), "42/B");
 }
 
 /// Tests Relation::get_missing_housenumbers(), the case when 'invalid' contains hyphens, the case


### PR DESCRIPTION
42/a/b would be parsed as 42, which is not useful, ignore addr:unit in
this case so 42/a is kept as in the past.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/4710>.

Change-Id: I083bb3d1d1ec0698985fdfe69e8f92aced129e95
