### PR TITLE
areas, osm housenumbers, addr:unit: add relation flag & disable by default

### DIFF
--- a/data/relation-szabadbattyan.yaml
+++ b/data/relation-szabadbattyan.yaml
@@ -32,3 +32,4 @@ osm-street-filters:
 source: survey
 housenumber-letters: true
 inactive: true
+addr-unit: true

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -3610,6 +3610,7 @@ fn test_relation_get_osm_housenumber_unit() {
         },
         "relation-myrelation.yaml": {
             "housenumber-letters": true,
+            "addr-unit": true,
         },
     });
     let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);


### PR DESCRIPTION
Turns out this (in general) does more harm than good, so add a flag to
turn it on per relation and disable it by default.

Enable it for the one relation that triggered the initial request.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/4710>.

Change-Id: I7ae9d2bb4e3b3c72852806c65cc6aad2a96b83bf
