### PR TITLE
areas, osm housenumbers, addr:unit: ignore unit if it contains a hyphen

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1800,6 +1800,7 @@ fn normalize<'a>(
     if relation.get_config().should_check_addr_unit()
         && let Some(housenumber) = osm_housenumber
         && !housenumber.unit.is_empty()
+        && !housenumber.unit.contains("-")
         && !house_numbers.contains("/")
     {
         // If addr:unit is available then assume that housenumber is addr:housenumber + / +

--- a/src/areas/tests.rs
+++ b/src/areas/tests.rs
@@ -3627,6 +3627,7 @@ fn test_relation_get_osm_housenumber_unit() {
              insert into mtimes (page, last_modified) values ('streets/myrelation', '0');
              insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values ('myrelation', '1', 'mystreet', '42', '', '', '', '', '', '', '', 'B junk', '', 'node');
              insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values ('myrelation', '2', 'mystreet', '42/A', '', '', '', '', '', '', '', 'C', '', 'node');
+             insert into osm_housenumbers (relation, osm_id, street, housenumber, postcode, place, housename, conscriptionnumber, flats, floor, door, unit, name, osm_type) values ('myrelation', '3', 'mystreet', '43-47', '', '', '', '', '', '', '', 'A-B', '', 'node');
              insert into mtimes (page, last_modified) values ('housenumbers/myrelation', '0');"
         ).unwrap();
     }
@@ -3637,9 +3638,13 @@ fn test_relation_get_osm_housenumber_unit() {
     let housenumbers = relation.get_osm_housenumbers("mystreet").unwrap();
 
     // Then make sure addr:unit is not ignored:
-    assert_eq!(housenumbers.len(), 2);
+    assert_eq!(housenumbers.len(), 5);
     assert_eq!(housenumbers[0].get_number(), "42/A");
     assert_eq!(housenumbers[1].get_number(), "42/B");
+    // 43-47 was not expanded into 43, 45 and 47:
+    assert_eq!(housenumbers[2].get_number(), "43");
+    assert_eq!(housenumbers[3].get_number(), "45");
+    assert_eq!(housenumbers[4].get_number(), "47");
 }
 
 /// Tests Relation::get_missing_housenumbers(), the case when 'invalid' contains hyphens, the case


### PR DESCRIPTION
1-7/A-B was parsed as 1+7/A+B, which was turned into 1+7+0, so 1-7
didn't expand into 1+3+5+7 anymore since we started to consider
addr:unit.

The original need was to parse addr:housenumber=7 and addr:unit=C into
7/C.

Fix the problem by ignoring addr:unit if it contains a hyphen.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/4710>.

Change-Id: Ie2dfc59d25404a5d3ac1dee2c34db1996caa1bed
