### PR TITLE
data: bakonykuti: add Ady Endre utca filter

### DIFF
--- a/data/relation-bakonykuti.yaml
+++ b/data/relation-bakonykuti.yaml
@@ -1,4 +1,9 @@
 missing-streets: 'yes'
+filters:
+  Ady Endre utca:
+    invalid:
+      # 1-8
+      - '11'
 refstreets:
   'Jókai Mór utca': 'Jókai út'
   'Petőfi Sándor utca': 'Petőfi utca'


### PR DESCRIPTION
This single one was the last missing housenumber.

Change-Id: I03abc37b8ec0eadbe51b4bdadabaed22089586f9
