### PR TITLE
context, network: consider non-success HTTP error codes a failure

### DIFF
--- a/src/context/system.rs
+++ b/src/context/system.rs
@@ -95,21 +95,29 @@ pub struct StdNetwork {}
 impl Network for StdNetwork {
     fn urlopen(&self, url: &str, data: &str) -> anyhow::Result<String> {
         if !data.is_empty() {
-            let mut buf = isahc::Request::post(url)
+            let mut response = isahc::Request::post(url)
                 .redirect_policy(isahc::config::RedirectPolicy::Limit(1))
                 .timeout(Duration::from_secs(425))
                 .body(data)?
                 .send()?;
-            let ret = buf.text()?;
+            let status = response.status();
+            if !status.is_success() {
+                return Err(anyhow::anyhow!("status is not success: {status}"));
+            }
+            let ret = response.text()?;
             return Ok(ret);
         }
 
-        let mut buf = isahc::Request::get(url)
+        let mut response = isahc::Request::get(url)
             .redirect_policy(isahc::config::RedirectPolicy::Limit(1))
             .timeout(Duration::from_secs(425))
             .body(())?
             .send()?;
-        let ret = buf.text()?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(anyhow::anyhow!("status is not success: {status}"));
+        }
+        let ret = response.text()?;
         Ok(ret)
     }
 }


### PR DESCRIPTION
Saw this in the cron log:

2025-12-05 03:05:01 [INFO] update_stats_overpass: talking to overpass
area::files::write_whole_country: failed to parse '<?xml...' as json

Turns out overpass gives us a HTTP 504, but isahc doesn't consider that
as an error by default, so opt in to discard the response body and retry
instead.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/4811>.

Change-Id: I108de2dac91bf46ed990b16b8131842dbe28c68b
