### PR TITLE
wsgi_json: auto-retry in street_housenumbers_update_result_json()

### DIFF
--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -303,6 +303,7 @@ impl Network for TestNetwork {
             }
 
             if route.result_path.is_empty() {
+                locked_routes.remove(index);
                 return Err(anyhow::anyhow!("empty result_path for url '{}'", url));
             }
             ret = std::fs::read_to_string(&route.result_path)?;

--- a/src/wsgi_json/tests.rs
+++ b/src/wsgi_json/tests.rs
@@ -227,6 +227,58 @@ fn test_json_housenumbers_update_result_error() {
     assert_eq!(error.is_empty(), false);
 }
 
+/// Tests street_housenumbers_update_result_json(): the case when it has to re-try the network
+/// request to succeed.
+#[test]
+fn test_street_housenumbers_update_result_json_retry() {
+    let mut test_wsgi = wsgi::tests::TestWsgi::new();
+    let routes = vec![
+        context::tests::URLRoute::new(
+            /*url=*/ "https://overpass-api.de/api/interpreter",
+            /*data_path=*/ "",
+            /*result_path=*/ "",
+        ),
+        context::tests::URLRoute::new(
+            /*url=*/ "https://overpass-api.de/api/interpreter",
+            /*data_path=*/ "",
+            /*result_path=*/ "src/fixtures/network/overpass-housenumbers-duplicate.json",
+        ),
+    ];
+    let network = context::tests::TestNetwork::new(&routes);
+    let network_rc: Rc<dyn context::Network> = Rc::new(network);
+    test_wsgi.get_ctx().set_network(network_rc);
+    let yamls_cache = serde_json::json!({
+        "relations.yaml": {
+            "myrelation": {
+                "osmrelation": 42,
+            },
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let overpass_template = context::tests::TestFileSystem::make_file();
+    overpass_template
+        .borrow_mut()
+        .write_all(b"housenr aaa @RELATION@ bbb @AREA@ ccc\n")
+        .unwrap();
+    let files = context::tests::TestFileSystem::make_files(
+        test_wsgi.get_ctx(),
+        &[
+            ("data/yamls.cache", &yamls_cache_value),
+            (
+                "data/street-housenumbers-template.overpassql",
+                &overpass_template,
+            ),
+        ],
+    );
+    let file_system = context::tests::TestFileSystem::from_files(&files);
+    test_wsgi.get_ctx().set_file_system(&file_system);
+    let root = test_wsgi.get_json_for_path("/street-housenumbers/myrelation/update-result.json");
+
+    // Without the fix, this was:
+    // String("empty result_path for url 'https://overpass-api.de/api/interpreter'")
+    assert_eq!(root.as_object().unwrap()["error"], "");
+}
+
 /// Tests missing_housenumbers_view_result_json().
 #[test]
 fn test_missing_housenumbers_view_result_json() {


### PR DESCRIPTION
In case the overpass server failed with a non-200 error code, this error
was presented to the user as-is; while cron knows how to retry.

Given that it's likely we can retry before the API request would time
out, just re-try silently without informing the client that a retry is
being made.

This also uncovered a problem in the test network code, where you could
not have a bad and later a good URL route for the same URL, fix that,
too.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/4831>.

Change-Id: I3566f6240fdb9a9734aae98553037323cb1ab4fa
