### PR TITLE
Use overpass_query_with_retry() in street_housenumbers_update_result_json()

### DIFF
--- a/src/overpass_query.rs
+++ b/src/overpass_query.rs
@@ -12,6 +12,12 @@
 
 use crate::context;
 
+#[cfg(not(test))]
+use log::info;
+
+#[cfg(test)]
+use std::println as info;
+
 /// Posts the query string to the overpass API and returns the result string.
 pub fn overpass_query(ctx: &context::Context, query: &str) -> anyhow::Result<String> {
     let url = ctx.get_ini().get_overpass_uri() + "/api/interpreter";
@@ -52,6 +58,46 @@ pub fn overpass_query_need_sleep(ctx: &context::Context) -> i32 {
         return 0;
     }
     sleep
+}
+
+/// Sleeps to respect overpass rate limit.
+pub fn overpass_sleep(ctx: &context::Context) {
+    loop {
+        let sleep = overpass_query_need_sleep(ctx);
+        if sleep == 0 {
+            break;
+        }
+        info!("overpass_sleep: waiting for {sleep} seconds");
+        ctx.get_time().sleep(sleep as u64);
+    }
+}
+
+/// Decides if we should retry a query or not.
+pub fn should_retry(retry: i32) -> bool {
+    retry < 20
+}
+
+pub fn overpass_query_with_retry(ctx: &context::Context, query: &str) -> anyhow::Result<String> {
+    let mut retry = 0;
+    let mut ret: anyhow::Result<String> = Ok("".to_string());
+    while should_retry(retry) {
+        if retry > 0 {
+            info!("overpass_query_with_retry: try #{retry}");
+        }
+        retry += 1;
+        overpass_sleep(ctx);
+        let response = match overpass_query(ctx, query) {
+            Ok(value) => value,
+            Err(err) => {
+                info!("overpass_query_with_retry: http error: {err}");
+                ret = Err(err);
+                continue;
+            }
+        };
+
+        return Ok(response);
+    }
+    ret
 }
 
 #[cfg(test)]

--- a/src/wsgi_json.rs
+++ b/src/wsgi_json.rs
@@ -54,24 +54,17 @@ fn street_housenumbers_update_result_json(
     let relation = relations.get_relation(relation_name)?;
     let mut ret: HashMap<String, String> = HashMap::new();
     let query = relation.get_osm_housenumbers_json_query()?;
-    let mut retry = 0;
-    while retry < 20 {
-        retry += 1;
-
-        match overpass_query::overpass_query(ctx, &query) {
-            Ok(buf) => {
-                relation
-                    .get_files()
-                    .write_osm_json_housenumbers(ctx, &buf)?;
-                ret.insert("error".into(), "".into());
-                break;
-            }
-            Err(err) => {
-                ret.insert("error".into(), err.to_string());
-                ctx.get_time().sleep(1);
-            }
-        };
-    }
+    match overpass_query::overpass_query_with_retry(ctx, &query) {
+        Ok(buf) => {
+            relation
+                .get_files()
+                .write_osm_json_housenumbers(ctx, &buf)?;
+            ret.insert("error".into(), "".into());
+        }
+        Err(err) => {
+            ret.insert("error".into(), err.to_string());
+        }
+    };
     Ok(serde_json::to_string(&ret)?)
 }
 

--- a/src/wsgi_json/tests.rs
+++ b/src/wsgi_json/tests.rs
@@ -185,11 +185,18 @@ fn test_json_housenumbers_update_result() {
 #[test]
 fn test_json_housenumbers_update_result_error() {
     let mut test_wsgi = wsgi::tests::TestWsgi::new();
-    let routes = vec![context::tests::URLRoute::new(
-        /*url=*/ "https://overpass-api.de/api/interpreter",
-        /*data_path=*/ "",
-        /*result_path=*/ "",
-    )];
+    let routes = vec![
+        context::tests::URLRoute::new(
+            /*url=*/ "https://overpass-api.de/api/status",
+            /*data_path=*/ "",
+            /*result_path=*/ "src/fixtures/network/overpass-status-happy.txt",
+        ),
+        context::tests::URLRoute::new(
+            /*url=*/ "https://overpass-api.de/api/interpreter",
+            /*data_path=*/ "",
+            /*result_path=*/ "",
+        ),
+    ];
     let network = context::tests::TestNetwork::new(&routes);
     let network_rc: Rc<dyn context::Network> = Rc::new(network);
     test_wsgi.get_ctx().set_network(network_rc);


### PR DESCRIPTION
Instead of a copy&paste loop that naively sleeps for 1 second between
retry requests insead of asking the overpass API to find out the amount
of needed sleep.

This uncovered that overpass_query_with_retry() had a bug: if we really
fail 20 times in a row, then the return value was not an error, but a
success with an empty string. This is unlikely in practice, so change
this to return an actual error, which allows simplifying
update_stats_overpass() and update_settlement_stats_overpass().

Change-Id: I8fac1b95144387add2d59f982c4a2aac9f38ebd0
