### PR TITLE
validator: roundtrip relation-foo.yaml via json before manual validation

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -45,18 +45,6 @@ pub struct RelationFiltersDict {
     show_refstreet: Option<bool>,
 }
 
-impl RelationFiltersDict {
-    /// Determines if at least one Option is Some.
-    pub fn is_some(&self) -> bool {
-        self.interpolation.is_some()
-            || self.invalid.is_some()
-            || self.ranges.is_some()
-            || self.valid.is_some()
-            || self.refsettlement.is_some()
-            || self.show_refstreet.is_some()
-    }
-}
-
 /// A relation from data/relation-<name>.yaml.
 #[derive(Clone, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]


### PR DESCRIPTION
This does a lot of type checking for us, some of that was missing
previously and some of that can be now dropped.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/4846>.

Change-Id: I80d458a2b9c397ba9b6e44305205a1b80baa9447
