### PR TITLE
overpass: set User-Agent as a HTTP header

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -15,6 +15,7 @@ use once_cell::unsync::OnceCell;
 use std::cell::Ref;
 use std::cell::RefCell;
 use std::cell::RefMut;
+use std::collections::HashMap;
 use std::io::Read;
 use std::io::Write;
 use std::path::Path;
@@ -80,7 +81,12 @@ pub use system::StdDatabase;
 /// Network interface.
 pub trait Network {
     /// Opens an URL. Empty data means HTTP GET, otherwise it means a HTTP POST.
-    fn urlopen(&self, url: &str, data: &str) -> anyhow::Result<String>;
+    fn urlopen(
+        &self,
+        url: &str,
+        data: &str,
+        headers: &HashMap<String, String>,
+    ) -> anyhow::Result<String>;
 }
 
 pub use system::StdNetwork;

--- a/src/context/system.rs
+++ b/src/context/system.rs
@@ -93,9 +93,18 @@ pub struct StdNetwork {}
 
 // Real network is intentionally mocked.
 impl Network for StdNetwork {
-    fn urlopen(&self, url: &str, data: &str) -> anyhow::Result<String> {
+    fn urlopen(
+        &self,
+        url: &str,
+        data: &str,
+        headers: &HashMap<String, String>,
+    ) -> anyhow::Result<String> {
         if !data.is_empty() {
-            let mut response = isahc::Request::post(url)
+            let mut builder = isahc::Request::post(url);
+            for (key, value) in headers {
+                builder = builder.header(key, value);
+            }
+            let mut response = builder
                 .redirect_policy(isahc::config::RedirectPolicy::Limit(1))
                 .timeout(Duration::from_secs(425))
                 .body(data)?
@@ -108,7 +117,11 @@ impl Network for StdNetwork {
             return Ok(ret);
         }
 
-        let mut response = isahc::Request::get(url)
+        let mut builder = isahc::Request::get(url);
+        for (key, value) in headers {
+            builder = builder.header(key, value);
+        }
+        let mut response = builder
             .redirect_policy(isahc::config::RedirectPolicy::Limit(1))
             .timeout(Duration::from_secs(425))
             .body(())?

--- a/src/context/tests.rs
+++ b/src/context/tests.rs
@@ -288,7 +288,12 @@ impl TestNetwork {
 
 impl Network for TestNetwork {
     /// Opens an URL. Empty data means HTTP GET, otherwise it means a HTTP POST.
-    fn urlopen(&self, url: &str, data: &str) -> anyhow::Result<String> {
+    fn urlopen(
+        &self,
+        url: &str,
+        data: &str,
+        _headers: &HashMap<String, String>,
+    ) -> anyhow::Result<String> {
         let mut ret: String = "".into();
         let mut remove: Option<usize> = None;
         let mut locked_routes = self.routes.borrow_mut();

--- a/src/overpass_query.rs
+++ b/src/overpass_query.rs
@@ -11,6 +11,16 @@
 //! The overpass_query module allows getting data out of the OSM DB without a full download.
 
 use crate::context;
+use crate::util;
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+
+lazy_static! {
+    static ref USER_AGENT: String = format!(
+        "osm-gimmisn/{} (GitHub: vmiklos/osm-gimmisn)",
+        util::VERSION
+    );
+}
 
 #[cfg(not(test))]
 use log::info;
@@ -21,14 +31,18 @@ use std::println as info;
 /// Posts the query string to the overpass API and returns the result string.
 pub fn overpass_query(ctx: &context::Context, query: &str) -> anyhow::Result<String> {
     let url = ctx.get_ini().get_overpass_uri() + "/api/interpreter";
+    let mut headers = HashMap::new();
+    headers.insert("User-Agent".to_string(), USER_AGENT.to_string());
 
-    ctx.get_network().urlopen(&url, query)
+    ctx.get_network().urlopen(&url, query, &headers)
 }
 
 /// Checks if we need to sleep before executing an overpass query.
 pub fn overpass_query_need_sleep(ctx: &context::Context) -> i32 {
     let url = ctx.get_ini().get_overpass_uri() + "/api/status";
-    let status = match ctx.get_network().urlopen(&url, "") {
+    let mut headers = HashMap::new();
+    headers.insert("User-Agent".to_string(), USER_AGENT.to_string());
+    let status = match ctx.get_network().urlopen(&url, "", &headers) {
         Ok(value) => value,
         _ => {
             return 0;

--- a/src/sync_ref.rs
+++ b/src/sync_ref.rs
@@ -54,7 +54,9 @@ pub fn download(
             }
 
             stream.write_all(format!("sync-ref: downloading '{url}'...\n").as_bytes())?;
-            let buf = ctx.get_network().urlopen(&url, "")?;
+            let buf = ctx
+                .get_network()
+                .urlopen(&url, "", &std::collections::HashMap::new())?;
             ctx.get_file_system().write_from_string(&buf, &dest)?;
         }
         for path in ctx
@@ -128,7 +130,9 @@ pub fn our_main(
 
     // Download HTML.
     let url = url.context("missing url")?;
-    let mut html = ctx.get_network().urlopen(url, "")?;
+    let mut html = ctx
+        .get_network()
+        .urlopen(url, "", &std::collections::HashMap::new())?;
     // Work around 'expected attribute key' failure.
     html = html.replace(
         r#"<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">"#,

--- a/src/util.rs
+++ b/src/util.rs
@@ -39,6 +39,9 @@ lazy_static! {
     static ref GIT_HASH: regex::Regex = regex::Regex::new(r".*-g([0-9a-f]+)(-modified)?").unwrap();
 }
 
+/// The version of the application, from git.
+pub const VERSION: &str = git_version::git_version!(args = ["--always", "--long"]);
+
 /// A house number range is a string that may expand to one or more HouseNumber instances in the
 /// future. It can also have a comment.
 #[derive(Clone, Debug)]

--- a/src/webframe.rs
+++ b/src/webframe.rs
@@ -33,7 +33,7 @@ pub fn get_footer(last_updated: &str) -> yattag::Doc {
         doc.text(&tr("Version: "));
         doc.append_value(
             util::git_link(
-                git_version::git_version!(args = ["--always", "--long"]),
+                util::VERSION,
                 "https://github.com/vmiklos/osm-gimmisn/commit/",
             )
             .get_value(),


### PR DESCRIPTION
Run e.g. 'cargo run -- cron --mode relations --refcounty 01
--refsettlement 011', it results in '406 Not Acceptable' HTTP errors.

It seems not setting the User-Agent is no longer accepted by the
overpass server.

Fix this by setting it to 'osm-gimmisn/<VERSION> (GitHub: user/repo)'.

Addresses <https://github.com/vmiklos/osm-gimmisn/issues/4956>.

Change-Id: Icd14b472da0f0a5744bf58bcf393de5a57ffb2c6
