### PR TITLE
missing-housenumbers: add a geojson endpoint for the streets

### DIFF
--- a/src/areas.rs
+++ b/src/areas.rs
@@ -1893,7 +1893,9 @@ fn normalize_housenumber_letters(
 }
 
 /// Creates an overpass query that shows all streets from a missing housenumbers table.
-pub fn make_turbo_query_for_streets(relation: &Relation<'_>, streets: &[String]) -> String {
+/// Creates an overpass query that shows the streets from a list, without the overpass-turbo
+/// specific MapCSS style block, so it can be sent to the raw overpass API.
+pub fn make_query_for_streets(relation: &Relation<'_>, streets: &[String]) -> String {
     let header = r#"[out:json][timeout:425];
 rel(@RELATION@)->.searchRelation;
 area(@AREA@)->.searchArea;
@@ -1908,7 +1910,13 @@ area(@AREA@)->.searchArea;
 out body;
 >;
 out skel qt;
-{{style:
+"#;
+    query
+}
+
+pub fn make_turbo_query_for_streets(relation: &Relation<'_>, streets: &[String]) -> String {
+    let mut query = make_query_for_streets(relation, streets);
+    query += r#"{{style:
 relation{width:3}
 way{color:blue; width:4;}
 }}"#;

--- a/src/fixtures/network/overpass-turbo-gazdagret.json
+++ b/src/fixtures/network/overpass-turbo-gazdagret.json
@@ -1,0 +1,31 @@
+{
+    "osm3s": {
+        "timestamp_osm_base": "2023-11-16T13:34:15Z",
+        "copyright": "The data included in this document is from www.openstreetmap.org. The data is made available under ODbL."
+    },
+    "elements": [
+        {
+            "type": "node",
+            "id": 1,
+            "lat": 47.5903109,
+            "lon": 19.0712456
+        },
+        {
+            "type": "node",
+            "id": 2,
+            "lat": 47.5905000,
+            "lon": 19.0715000
+        },
+        {
+            "type": "way",
+            "id": 100,
+            "nodes": [
+                1,
+                2
+            ],
+            "tags": {
+                "name": "Vöröskúti határsor"
+            }
+        }
+    ]
+}

--- a/src/wsgi_json.rs
+++ b/src/wsgi_json.rs
@@ -80,6 +80,140 @@ fn missing_housenumbers_view_result_json(
     cache::get_missing_housenumbers_json(&mut relation)
 }
 
+/// Expected request_uri: e.g. /osm/missing-housenumbers/ormezo/geojson.json.
+fn missing_housenumbers_geojson(
+    ctx: &context::Context,
+    relations: &mut areas::Relations<'_>,
+    request_uri: &str,
+) -> anyhow::Result<String> {
+    let mut tokens = request_uri.split('/');
+    tokens.next_back();
+    let relation_name = tokens.next_back().context("short tokens")?;
+    let mut relation = relations.get_relation(relation_name)?;
+    let ongoing_streets = relation.get_missing_housenumbers()?.ongoing_streets;
+    let mut streets: Vec<String> = Vec::new();
+    for result in ongoing_streets {
+        streets.push(result.street.get_osm_name().into());
+    }
+    let query = areas::make_query_for_streets(&relation, &streets);
+    let overpass = overpass_query::overpass_query_with_retry(ctx, &query)?;
+    overpass_to_geojson(&overpass)
+}
+
+/// Turns one overpass element into a geojson Feature, with the given resolved geometry.
+fn make_geojson_feature(
+    kind: &str,
+    id: i64,
+    tags: &serde_json::Value,
+    geometry: serde_json::Value,
+) -> serde_json::Value {
+    let full_id = format!("{kind}/{id}");
+    // properties is the tags, prefixed with an "@id" pointing to the source object.
+    let mut properties = serde_json::Map::new();
+    properties.insert("@id".into(), serde_json::json!(full_id));
+    if let Some(object) = tags.as_object() {
+        for (key, value) in object {
+            properties.insert(key.clone(), value.clone());
+        }
+    }
+    serde_json::json!({
+        "type": "Feature",
+        "properties": serde_json::Value::Object(properties),
+        "geometry": geometry,
+        "id": full_id,
+    })
+}
+
+/// Converts an overpass JSON response into a geojson FeatureCollection.
+fn overpass_to_geojson(overpass: &str) -> anyhow::Result<String> {
+    let root: serde_json::Value = serde_json::from_str(overpass)?;
+    let elements = root
+        .get("elements")
+        .and_then(|i| i.as_array())
+        .context("no elements array in overpass response")?;
+
+    // Collect node id -> [lon, lat], so way geometries can be resolved below.
+    let mut nodes: HashMap<i64, serde_json::Value> = HashMap::new();
+    for element in elements {
+        if element.get("type").and_then(|i| i.as_str()) != Some("node") {
+            continue;
+        }
+        let (Some(id), Some(lat), Some(lon)) = (
+            element.get("id").and_then(|i| i.as_i64()),
+            element.get("lat").and_then(|i| i.as_f64()),
+            element.get("lon").and_then(|i| i.as_f64()),
+        ) else {
+            continue;
+        };
+        nodes.insert(id, serde_json::json!([lon, lat]));
+    }
+
+    let mut features: Vec<serde_json::Value> = Vec::new();
+    for element in elements {
+        let element_type = element.get("type").and_then(|i| i.as_str()).unwrap_or("");
+        let Some(id) = element.get("id").and_then(|i| i.as_i64()) else {
+            continue;
+        };
+        let tags = element
+            .get("tags")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+        let has_tags = tags.as_object().map(|i| !i.is_empty()).unwrap_or(false);
+        match element_type {
+            "node" => {
+                // Untagged nodes only provide geometry for ways, they are not features.
+                if !has_tags {
+                    continue;
+                }
+                let Some(coordinates) = nodes.get(&id) else {
+                    continue;
+                };
+                let geometry = serde_json::json!({
+                    "type": "Point",
+                    "coordinates": coordinates.clone(),
+                });
+                features.push(make_geojson_feature("node", id, &tags, geometry));
+            }
+            "way" => {
+                // Untagged ways are just relation members / geometry fragments, skip them.
+                if !has_tags {
+                    continue;
+                }
+                let Some(way_nodes) = element.get("nodes").and_then(|i| i.as_array()) else {
+                    continue;
+                };
+                let coordinates: Vec<serde_json::Value> = way_nodes
+                    .iter()
+                    .filter_map(|node| node.as_i64())
+                    .filter_map(|node_id| nodes.get(&node_id).cloned())
+                    .collect();
+                let geometry = serde_json::json!({
+                    "type": "LineString",
+                    "coordinates": coordinates,
+                });
+                features.push(make_geojson_feature("way", id, &tags, geometry));
+            }
+            // Relations are not converted to geometry.
+            _ => {}
+        }
+    }
+
+    let osm3s = root.get("osm3s");
+    let field = |name: &str| -> serde_json::Value {
+        osm3s
+            .and_then(|i| i.get(name))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null)
+    };
+    let geojson = serde_json::json!({
+        "type": "FeatureCollection",
+        "copyright": field("copyright"),
+        "timestamp": field("timestamp_osm_base"),
+        "features": features,
+    });
+    Ok(serde_json::to_string(&geojson)?)
+}
+
 /// Expected request_uri: e.g. /osm/additional-housenumbers/ormezo/view-result.json.
 fn additional_housenumbers_view_result_json(
     relations: &mut areas::Relations<'_>,
@@ -106,8 +240,12 @@ pub fn our_application_json(
     } else if request_uri.starts_with(&format!("{prefix}/street-housenumbers/")) {
         output = street_housenumbers_update_result_json(ctx, relations, request_uri)?;
     } else if request_uri.starts_with(&format!("{prefix}/missing-housenumbers/")) {
-        // Assume request_uri ends with view-result.json.
-        output = missing_housenumbers_view_result_json(relations, request_uri)?;
+        if request_uri.ends_with("/geojson.json") {
+            output = missing_housenumbers_geojson(ctx, relations, request_uri)?;
+        } else {
+            // Assume request_uri ends with view-result.json.
+            output = missing_housenumbers_view_result_json(relations, request_uri)?;
+        }
     } else if request_uri
         == format!("{prefix}/lints/whole-country/invalid-addr-cities/update-result.json")
     {

--- a/src/wsgi_json/tests.rs
+++ b/src/wsgi_json/tests.rs
@@ -333,6 +333,179 @@ fn test_missing_housenumbers_view_result_json() {
     assert_eq!(ongoing_street.house_numbers.len(), 4);
 }
 
+/// Tests missing_housenumbers_geojson(): the geojson output from overpass.
+#[test]
+fn test_missing_housenumbers_geojson() {
+    let mut test_wsgi = wsgi::tests::TestWsgi::new();
+    let routes = vec![context::tests::URLRoute::new(
+        /*url=*/ "https://overpass-api.de/api/interpreter",
+        /*data_path=*/ "",
+        /*result_path=*/ "src/fixtures/network/overpass-turbo-gazdagret.json",
+    )];
+    let network = context::tests::TestNetwork::new(&routes);
+    let network_rc: Rc<dyn context::Network> = Rc::new(network);
+    test_wsgi.get_ctx().set_network(network_rc);
+    let mut file_system = context::tests::TestFileSystem::new();
+    let yamls_cache = serde_json::json!({
+        "relations.yaml": {
+            "budafok": {
+                "refcounty": "0",
+                "refsettlement": "0",
+                "osmrelation": 42,
+            },
+        },
+    });
+    let yamls_cache_value = context::tests::TestFileSystem::write_json_to_file(&yamls_cache);
+    let files = context::tests::TestFileSystem::make_files(
+        test_wsgi.get_ctx(),
+        &[("data/yamls.cache", &yamls_cache_value)],
+    );
+    file_system.set_files(&files);
+    let file_system_rc: Rc<dyn context::FileSystem> = Rc::new(file_system);
+    test_wsgi.get_ctx().set_file_system(&file_system_rc);
+    {
+        let conn = test_wsgi.get_ctx().get_database_connection().unwrap();
+        conn.execute_batch(
+            "insert into ref_housenumbers (county_code, settlement_code, street, housenumber, comment) values ('0', '0', 'Vöröskúti határsor', '34', '');
+             insert into osm_streets (relation, osm_id, name, highway, service, surface, leisure, osm_type) values ('budafok', '458338075', 'Vöröskúti határsor', '', '', '', '', '');"
+        )
+        .unwrap();
+    }
+
+    let result = test_wsgi.get_json_for_path("/missing-housenumbers/budafok/geojson.json");
+
+    // The overpass response is converted to a geojson FeatureCollection.
+    let root = result.as_object().unwrap();
+    assert_eq!(root["type"], "FeatureCollection");
+    let features = root["features"].as_array().unwrap();
+    // The single tagged way becomes one LineString feature.
+    assert_eq!(features.len(), 1);
+    let feature = features[0].as_object().unwrap();
+    assert_eq!(feature["id"], "way/100");
+    assert_eq!(feature["geometry"]["type"], "LineString");
+    assert_eq!(
+        feature["geometry"]["coordinates"].as_array().unwrap().len(),
+        2
+    );
+    assert_eq!(feature["properties"]["name"], "Vöröskúti határsor");
+}
+
+/// Tests make_geojson_feature(): the case when the tags are not a json object.
+#[test]
+fn test_make_geojson_feature_tags_not_object() {
+    // tags is not an object, so it contributes no properties.
+    let tags = serde_json::json!(null);
+    let geometry = serde_json::json!({"type": "Point", "coordinates": [19.0, 47.0]});
+
+    let feature = crate::wsgi_json::make_geojson_feature("node", 42, &tags, geometry);
+
+    let object = feature.as_object().unwrap();
+    assert_eq!(object["id"], "node/42");
+    // properties contains only the "@id" entry.
+    let properties = object["properties"].as_object().unwrap();
+    assert_eq!(properties.len(), 1);
+    assert_eq!(properties["@id"], "node/42");
+}
+
+/// Tests overpass_to_geojson(): a node without coordinates is skipped.
+#[test]
+fn test_overpass_to_geojson_node_without_coordinates() {
+    // The node has no lat/lon, so it can't provide geometry and is ignored.
+    let overpass = r#"{"elements": [{"type": "node", "id": 1}]}"#;
+
+    let geojson = crate::wsgi_json::overpass_to_geojson(overpass).unwrap();
+
+    let root: serde_json::Value = serde_json::from_str(&geojson).unwrap();
+    assert_eq!(root["type"], "FeatureCollection");
+    assert_eq!(root["features"].as_array().unwrap().is_empty(), true);
+}
+
+/// Tests overpass_to_geojson(): an element without an id is skipped.
+#[test]
+fn test_overpass_to_geojson_element_without_id() {
+    // The way has no id, so it can't be turned into a feature.
+    let overpass = r#"{"elements": [{"type": "way"}]}"#;
+
+    let geojson = crate::wsgi_json::overpass_to_geojson(overpass).unwrap();
+
+    let root: serde_json::Value = serde_json::from_str(&geojson).unwrap();
+    assert_eq!(root["type"], "FeatureCollection");
+    assert_eq!(root["features"].as_array().unwrap().is_empty(), true);
+}
+
+/// Tests overpass_to_geojson(): a tagged node becomes a Point feature.
+#[test]
+fn test_overpass_to_geojson_tagged_node() {
+    // The node has tags, so it is emitted as a standalone Point feature.
+    let overpass = r#"{"elements": [{"type": "node", "id": 1, "lat": 47.5, "lon": 19.0, "tags": {"name": "Foo"}}]}"#;
+
+    let geojson = crate::wsgi_json::overpass_to_geojson(overpass).unwrap();
+
+    let root: serde_json::Value = serde_json::from_str(&geojson).unwrap();
+    let features = root["features"].as_array().unwrap();
+    assert_eq!(features.len(), 1);
+    let feature = features[0].as_object().unwrap();
+    assert_eq!(feature["id"], "node/1");
+    assert_eq!(feature["geometry"]["type"], "Point");
+    assert_eq!(
+        feature["geometry"]["coordinates"].as_array().unwrap(),
+        &vec![serde_json::json!(19.0), serde_json::json!(47.5),]
+    );
+    assert_eq!(feature["properties"]["name"], "Foo");
+}
+
+/// Tests overpass_to_geojson(): a tagged node without coordinates is skipped.
+#[test]
+fn test_overpass_to_geojson_tagged_node_without_coordinates() {
+    // The node has tags but no lat/lon, so it never entered the node map and has no geometry.
+    let overpass = r#"{"elements": [{"type": "node", "id": 1, "tags": {"name": "Foo"}}]}"#;
+
+    let geojson = crate::wsgi_json::overpass_to_geojson(overpass).unwrap();
+
+    let root: serde_json::Value = serde_json::from_str(&geojson).unwrap();
+    assert_eq!(root["type"], "FeatureCollection");
+    assert_eq!(root["features"].as_array().unwrap().is_empty(), true);
+}
+
+/// Tests overpass_to_geojson(): an untagged way is skipped.
+#[test]
+fn test_overpass_to_geojson_way_without_tags() {
+    // The way has no tags, so it's just a geometry fragment and not emitted as a feature.
+    let overpass = r#"{"elements": [{"type": "way", "id": 100, "nodes": [1, 2]}]}"#;
+
+    let geojson = crate::wsgi_json::overpass_to_geojson(overpass).unwrap();
+
+    let root: serde_json::Value = serde_json::from_str(&geojson).unwrap();
+    assert_eq!(root["type"], "FeatureCollection");
+    assert_eq!(root["features"].as_array().unwrap().is_empty(), true);
+}
+
+/// Tests overpass_to_geojson(): a tagged way without a node list is skipped.
+#[test]
+fn test_overpass_to_geojson_way_without_nodes() {
+    // The way has tags but no "nodes" array, so its geometry can't be built.
+    let overpass = r#"{"elements": [{"type": "way", "id": 100, "tags": {"name": "Foo"}}]}"#;
+
+    let geojson = crate::wsgi_json::overpass_to_geojson(overpass).unwrap();
+
+    let root: serde_json::Value = serde_json::from_str(&geojson).unwrap();
+    assert_eq!(root["type"], "FeatureCollection");
+    assert_eq!(root["features"].as_array().unwrap().is_empty(), true);
+}
+
+/// Tests overpass_to_geojson(): a relation is not converted to geometry.
+#[test]
+fn test_overpass_to_geojson_relation() {
+    // Relations (and any non-node, non-way types) are ignored.
+    let overpass = r#"{"elements": [{"type": "relation", "id": 5, "tags": {"name": "Foo"}}]}"#;
+
+    let geojson = crate::wsgi_json::overpass_to_geojson(overpass).unwrap();
+
+    let root: serde_json::Value = serde_json::from_str(&geojson).unwrap();
+    assert_eq!(root["type"], "FeatureCollection");
+    assert_eq!(root["features"].as_array().unwrap().is_empty(), true);
+}
+
 /// Tests additional_housenumbers_view_result_json().
 #[test]
 fn test_additional_housenumbers_view_result_json() {


### PR DESCRIPTION
The /missing-housenumbers/RELATION/view-turbo endpoint already allowed
generating an overpass-turbo input, copying that there and asking for a
geojson output made it possible to visualize the result on a map, e.g.
to find a nearby street to survey for missing housenumbers.

What was missing is to see the result on a map with a single click: i.e.
need to cover the output from overpass to geojson + present it on a map.

Implement a new /missing-housenumbers/RELATION/geojson.json endpoint
which sends our generated overpass query to overpass, convert it to
geojson using the new overpass_to_geojson() function and return the
result. This should allow presenting the result on a site like
https://geojson.io/#data=data:text/x-url,<urlencoded url>, but
/missing-housenumbers/RELATION/view-result doesn't link this yet.

Related to <https://github.com/vmiklos/osm-gimmisn/issues/4464>.

Change-Id: I27a6cc04c6ed31f49c07b83f870bcfd832f5cfe7
