### PR TITLE
missing-housenumbers: add a leaflet endpoint to show the geojson

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ YAML_TEST_OBJECTS = \
 TS_OBJECTS = \
 	src/browser/config.ts \
 	src/browser/main.ts \
+	src/browser/map.ts \
 	src/browser/stats.ts \
 	src/browser/types.d.ts \
 
@@ -128,11 +129,16 @@ package-lock.json: package.json
 	npm install
 	touch $@
 
-css: target/browser/osm.min.css
+css: target/browser/osm.min.css target/browser/leaflet.css
 
 target/browser/osm.min.css: static/osm.css package-lock.json
 	mkdir -p workdir
 	[ -x "./node_modules/.bin/cleancss" ] && npx cleancss -o $@ $< || cp -a $< $@
+
+# Leaflet's own CSS is shipped as-is (not minified/inlined), the map page links to it.
+target/browser/leaflet.css: package-lock.json
+	mkdir -p target/browser
+	cp -a node_modules/leaflet/dist/leaflet.css $@
 
 # Intentionally don't update this when the source changes.
 workdir/wsgi.ini:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "license": "MIT",
   "dependencies": {
     "@eslint/js": "10.0.1",
+    "@types/geojson": "7946.0.16",
+    "@types/leaflet": "1.9.22",
     "@types/node": "26.1.2",
     "chart.js": "4.5.1",
     "chartjs-plugin-datalabels": "2.2.0",
@@ -9,6 +11,7 @@
     "clean-css-cli": "5.6.3",
     "eslint": "10.8.0",
     "globals": "17.8.0",
+    "leaflet": "1.9.4",
     "sorttable": "1.0.2",
     "ts-loader": "9.6.2",
     "typescript": "6.0.3",

--- a/src/browser/main.ts
+++ b/src/browser/main.ts
@@ -7,6 +7,7 @@
 import * as config from './config';
 import 'sorttable'; // only for its side-effects
 import * as stats from './stats';
+import * as map from './map';
 
 /**
  * Creates a loading indicator element.
@@ -352,6 +353,7 @@ document.addEventListener("DOMContentLoaded", async function() {
     initRedirects();
     initTriggerUpdate();
     stats.initStats();
+    map.initMap();
 });
 
 // vim: shiftwidth=4 softtabstop=4 expandtab:

--- a/src/browser/map.ts
+++ b/src/browser/map.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import * as geojson from "geojson";
+import * as L from "leaflet";
+
+// The property of a feature we show as a popup.
+interface NameSupplier {
+    name: string | null;
+}
+
+// Shows a progress indicator at the center of the screen, till the fetch is in progress.
+function createLoader(): Element
+{
+    const loader = document.createElement("div");
+    loader.className = "loader";
+    // osm.css styles the loader for inline, in-page use; center it above the fullscreen map here.
+    loader.style.position = "absolute";
+    loader.style.top = "50%";
+    loader.style.left = "50%";
+    loader.style.transform = "translate(-50%, -50%)";
+    loader.style.zIndex = "1000";
+    for (let i = 0; i < 3; i += 1)
+    {
+        const loaderBox = document.createElement("span");
+        loaderBox.className = "loader-box";
+        loader.appendChild(loaderBox);
+    }
+    document.body.appendChild(loader);
+    return loader;
+}
+
+// Binds the name of a feature as its popup, if any.
+function onEachFeature(
+    feature: geojson.Feature<geojson.GeometryObject, NameSupplier>,
+    layer: L.Layer
+)
+{
+    if (feature.properties == null || feature.properties.name == null)
+    {
+        return;
+    }
+
+    layer.bindPopup(feature.properties.name);
+}
+
+// Shows the geojson referenced by the "geojson" query parameter on a fullscreen leaflet map.
+async function initMap(): Promise<void>
+{
+    if (!document.getElementById("map"))
+    {
+        // Not on the map page.
+        return;
+    }
+
+    const map = L.map("map");
+    map.attributionControl.setPrefix(
+        '<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">Leaflet</a>'
+    );
+
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+        attribution:
+            '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors.',
+    }).addTo(map);
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const geojsonURL = urlParams.get("geojson");
+    if (geojsonURL == null)
+    {
+        return;
+    }
+
+    const loader = createLoader();
+    try
+    {
+        const response = await window.fetch(geojsonURL);
+        const featureCollection = await response.json();
+        const geoJSON = L.geoJSON(featureCollection, {
+            onEachFeature: (feature, layer) => onEachFeature(feature, layer),
+        }).addTo(map);
+        map.fitBounds(geoJSON.getBounds());
+    }
+    finally
+    {
+        loader.remove();
+    }
+}
+
+export { initMap };
+
+// vim: shiftwidth=4 softtabstop=4 expandtab:

--- a/src/wsgi.rs
+++ b/src/wsgi.rs
@@ -1450,6 +1450,36 @@ fn write_html_head(ctx: &context::Context, doc: &yattag::Tag, title: &str) -> an
     Ok(())
 }
 
+/// Expected request_uri: e.g. /osm/map. Shows a fullscreen leaflet map.
+fn handle_map(
+    ctx: &context::Context,
+    _relations: &mut areas::Relations<'_>,
+    _request_uri: &str,
+) -> anyhow::Result<yattag::Doc> {
+    let prefix = ctx.get_ini().get_uri_prefix();
+    let doc = yattag::Doc::new();
+    // Leaflet's own stylesheet, shipped as-is and only needed on this page.
+    doc.tag(
+        "link",
+        &[
+            ("rel", "stylesheet"),
+            ("href", &format!("{prefix}/static/leaflet.css")),
+        ],
+    );
+    // The map fills the whole viewport, browser/map.ts renders the geojson into it.
+    doc.tag(
+        "div",
+        &[
+            ("id", "map"),
+            (
+                "style",
+                "position: absolute; top: 0; bottom: 0; left: 0; right: 0;",
+            ),
+        ],
+    );
+    Ok(doc)
+}
+
 /// Dispatches GPX requests based on their URIs.
 fn our_application_gpx(
     ctx: &context::Context,
@@ -1551,6 +1581,7 @@ lazy_static! {
         ret.insert("/missing-housenumbers/".into(), handle_missing_housenumbers);
         ret.insert("/housenumber-stats/".into(), webframe::handle_stats);
         ret.insert("/lints/".into(), webframe::handle_lints);
+        ret.insert("/map".into(), handle_map);
         ret
     };
 }

--- a/src/wsgi/tests.rs
+++ b/src/wsgi/tests.rs
@@ -2628,3 +2628,15 @@ fn test_handle_main_filters_refcounty_filter_no_settlements() {
         "<a href=\"/osm/filter-for/refcounty/01/whole-county\">Budapest</a>"
     );
 }
+
+/// Tests handle_map(): the fullscreen leaflet map page.
+#[test]
+fn test_map() {
+    let mut test_wsgi = TestWsgi::new();
+
+    let root = test_wsgi.get_dom_for_path("/map");
+
+    // The page has a single div with the "map" id, browser/map.ts renders into it.
+    let results = TestWsgi::find_all(&root, "body/div[@id='map']");
+    assert_eq!(results.len(), 1);
+}


### PR DESCRIPTION
We already have a geojson endpoint for this, but only an external viewer
could present it.

Leaflet is exactly for this, so add a new /osm/map endpoint and use
leaflet there to show the geosjon.

Sample URL:
<http://127.0.0.1:8000/osm/map?geojson=%2Fosm%2Fmissing-housenumbers%2FRELATION%2Fgeojson.json>

Related to <https://github.com/vmiklos/osm-gimmisn/issues/4464>.

Change-Id: Ifdbf3f5b01e58f1c0404336a6b7013ca98cd61dc
