### PR TITLE
about: add CDLA-Permissive-2.0 to the list of allowed licenses

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -8,4 +8,5 @@ accepted = [
     "BSD-2-Clause",
     "CC0-1.0",
     "Zlib",
+    "CDLA-Permissive-2.0",
 ]


### PR DESCRIPTION
No problem with this permissive license, but breaks the license bundle
that is linked from the website to comply with copyright notices.

Change-Id: Ifaf2a7a7b5270a1be52084a342a77da9d4466d60
